### PR TITLE
Support Vite 7

### DIFF
--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -31,10 +31,10 @@
     "devDependencies": {
         "@types/node": "^18.11.17",
         "typescript": "^5.3.3",
-        "vite": "^4.0.0||^5.0.0||^6.0.0"
+        "vite": "^4.0.0||^5.0.0||^6.0.0||^7.0.0"
     },
     "peerDependencies": {
-        "vite": "^4.0.0||^5.0.0||^6.0.0"
+        "vite": "^4.0.0||^5.0.0||^6.0.0||^7.0.0"
     },
     "publishConfig": {
         "access": "public"


### PR DESCRIPTION
Vite 7 is out: https://vite.dev/blog/announcing-vite7.html

There's [very few breaking changes](https://vite.dev/guide/migration.html), and with a quick look at [the changelog](https://github.com/vitejs/vite/blob/main/packages/vite/CHANGELOG.md) I'm fairly certain that nothing will break with Vite 7. Though feel free to prove me wrong :)