### PR TITLE
fix(vue): address review bugs in vue package

### DIFF
--- a/packages/js/src/Flare.ts
+++ b/packages/js/src/Flare.ts
@@ -40,9 +40,11 @@ export class Flare {
 
     constructor(public api: Api = new Api()) {}
 
-    light(key: string = KEY, debug: boolean = false): Flare {
+    light(key: string = KEY, debug?: boolean): Flare {
         this.config.key = key;
-        this.config.debug = debug;
+        if (debug !== undefined) {
+            this.config.debug = debug;
+        }
         return this;
     }
 
@@ -105,16 +107,21 @@ export class Flare {
     }
 
     async report(error: Error, attributes: Attributes = {}): Promise<void> {
-        const errorToReport = await this.config.beforeEvaluate(error);
+        const seenAtUnixNano = Date.now() * 1_000_000;
+
+        const coerced = error instanceof Error ? error : new Error(typeof error === 'string' ? error : String(error));
+
+        const errorToReport = await this.config.beforeEvaluate(coerced);
         if (!errorToReport) return;
 
-        const report = await this.createReportFromError(errorToReport, attributes);
+        const report = await this.createReportFromError(errorToReport, attributes, seenAtUnixNano);
         if (!report) return;
 
         return this.sendReport(report);
     }
 
     async reportMessage(message: string, level?: MessageLevel, attributes: Attributes = {}): Promise<void> {
+        const seenAtUnixNano = Date.now() * 1_000_000;
         const stackTrace = await createStackTrace(Error(), this.config.debug);
         stackTrace.shift();
 
@@ -126,12 +133,17 @@ export class Flare {
             level,
             extraAttributes: attributes,
             code: undefined,
+            seenAtUnixNano,
         });
 
         return this.sendReport(report);
     }
 
-    async createReportFromError(error: Error, attributes: Attributes = {}): Promise<Report | false> {
+    async createReportFromError(
+        error: Error,
+        attributes: Attributes = {},
+        seenAtUnixNano: number = Date.now() * 1_000_000
+    ): Promise<Report | false> {
         if (!assert(error, 'No error provided.', this.config.debug)) {
             return false;
         }
@@ -150,6 +162,7 @@ export class Flare {
             level: undefined,
             extraAttributes: attributes,
             code: extractCode(error),
+            seenAtUnixNano,
         });
     }
 
@@ -161,6 +174,7 @@ export class Flare {
         level: MessageLevel | undefined;
         extraAttributes: Attributes;
         code: string | undefined;
+        seenAtUnixNano: number;
     }): Report {
         const baseAttributes: Attributes = {
             'telemetry.sdk.language': 'javascript',
@@ -233,12 +247,10 @@ export class Flare {
         // by ~3 bits (~256 ns of drift), but browser clocks are millisecond-precision so the lost
         // bits are below source resolution. PHP's json_decode reads the resulting 19-digit literal
         // as a 64-bit int (PHP_INT_MAX ~ 9.22e18 vs our value ~ 1.78e18).
-        const seenAtUnixNano = Date.now() * 1_000_000;
-
         const report: Report = {
             exceptionClass: input.exceptionClass,
             message: input.message,
-            seenAtUnixNano,
+            seenAtUnixNano: input.seenAtUnixNano,
             stacktrace: input.stacktrace,
             events: glowsToEvents(this.glows),
             attributes,

--- a/packages/js/src/browser/catchWindowErrors.ts
+++ b/packages/js/src/browser/catchWindowErrors.ts
@@ -3,34 +3,38 @@ export function catchWindowErrors() {
         return;
     }
 
-    // @ts-ignore
-    const flare = window.flare;
+    window.addEventListener('error', (event: ErrorEvent) => {
+        const flare = (window as unknown as { flare?: { report: (e: Error) => unknown } }).flare;
+        if (!flare) return;
+        if (event.error instanceof Error) {
+            flare.report(event.error);
+        }
+    });
 
-    if (!window || !flare) {
-        return;
+    window.addEventListener('unhandledrejection', (event: PromiseRejectionEvent) => {
+        const flare = (window as unknown as { flare?: { report: (e: Error) => unknown } }).flare;
+        if (!flare) return;
+
+        const reason = event.reason;
+        if (reason instanceof Error) {
+            flare.report(reason);
+            return;
+        }
+
+        flare.report(new Error(describeRejectionReason(reason)));
+    });
+}
+
+function describeRejectionReason(reason: unknown): string {
+    if (typeof reason === 'string') return reason;
+    if (reason && typeof reason === 'object') {
+        const message = (reason as { message?: unknown }).message;
+        if (typeof message === 'string') return message;
+        try {
+            return JSON.stringify(reason);
+        } catch {
+            return 'Unhandled promise rejection (non-serializable reason)';
+        }
     }
-
-    const originalOnerrorHandler = window.onerror;
-    const originalOnunhandledrejectionHandler = window.onunhandledrejection;
-
-    window.onerror = (_1, _2, _3, _4, error) => {
-        if (error) {
-            flare.report(error);
-        }
-
-        if (typeof originalOnerrorHandler === 'function') {
-            originalOnerrorHandler(_1, _2, _3, _4, error);
-        }
-    };
-
-    window.onunhandledrejection = (error: PromiseRejectionEvent) => {
-        if (error.reason instanceof Error) {
-            flare.report(error.reason);
-        }
-
-        if (typeof originalOnunhandledrejectionHandler === 'function') {
-            // @ts-ignore
-            originalOnunhandledrejectionHandler(error);
-        }
-    };
+    return String(reason);
 }

--- a/packages/js/src/context/cookie.ts
+++ b/packages/js/src/context/cookie.ts
@@ -8,7 +8,13 @@ export default function cookie(): Attributes {
     const cookies: { [key: string]: string } = {};
 
     window.document.cookie.split('; ').forEach((rawCookie) => {
-        const [name, value] = rawCookie.split(/=/);
+        const idx = rawCookie.indexOf('=');
+        if (idx === -1) {
+            cookies[rawCookie] = '';
+            return;
+        }
+        const name = rawCookie.slice(0, idx);
+        const value = rawCookie.slice(idx + 1);
         cookies[name] = value;
     });
 

--- a/packages/js/src/stacktrace/createStackTrace.ts
+++ b/packages/js/src/stacktrace/createStackTrace.ts
@@ -8,44 +8,46 @@ import { getCodeSnippet } from './fileReader';
 export function createStackTrace(error: Error, debug: boolean): Promise<Array<StackFrame>> {
     return new Promise((resolve) => {
         if (!hasStack(error)) {
-            assert(false, "Couldn't generate stacktrace of below error:", debug);
+            return resolve([fallbackFrame('stacktrace missing')]);
+        }
 
+        let parsedFrames;
+        try {
+            parsedFrames = ErrorStackParser.parse(error);
+        } catch (parseError) {
+            assert(false, "Couldn't parse stacktrace of below error:", debug);
             if (debug) {
+                console.error(parseError);
                 console.error(error);
             }
-
-            return resolve([
-                {
-                    lineNumber: 0,
-                    columnNumber: 0,
-                    method: 'unknown',
-                    file: 'unknown',
-                    codeSnippet: {
-                        0: 'Could not read from file: stacktrace missing',
-                    },
-                    class: 'unknown',
-                },
-            ]);
+            return resolve([fallbackFrame('stacktrace could not be parsed')]);
         }
 
         Promise.all(
-            ErrorStackParser.parse(error).map((frame) => {
-                return new Promise<StackFrame>((resolve) => {
-                    getCodeSnippet(frame.fileName, frame.lineNumber, frame.columnNumber).then((snippet) => {
-                        resolve({
-                            lineNumber: frame.lineNumber || 1,
-                            columnNumber: frame.columnNumber || 1,
-                            method: frame.functionName || 'Anonymous or unknown function',
-                            file: frame.fileName || 'Unknown file',
-                            codeSnippet: snippet.codeSnippet,
-                            class: '',
-                            isApplicationFrame: true,
-                        });
-                    });
-                });
+            parsedFrames.map((frame) => {
+                return getCodeSnippet(frame.fileName, frame.lineNumber, frame.columnNumber).then((snippet) => ({
+                    lineNumber: frame.lineNumber || 1,
+                    columnNumber: frame.columnNumber || 1,
+                    method: frame.functionName || 'Anonymous or unknown function',
+                    file: frame.fileName || 'Unknown file',
+                    codeSnippet: snippet.codeSnippet,
+                    class: '',
+                    isApplicationFrame: isApplicationFrame(frame.fileName),
+                }));
             })
         ).then(resolve);
     });
+}
+
+function fallbackFrame(reason: string): StackFrame {
+    return {
+        lineNumber: 0,
+        columnNumber: 0,
+        method: 'unknown',
+        file: 'unknown',
+        codeSnippet: { 0: `Could not read from file: ${reason}` },
+        class: 'unknown',
+    };
 }
 
 function hasStack(err: any): boolean {
@@ -55,4 +57,12 @@ function hasStack(err: any): boolean {
         typeof (err.stack || err.stacktrace || err['opera#sourceloc']) === 'string' &&
         err.stack !== `${err.name}: ${err.message}`
     );
+}
+
+function isApplicationFrame(fileName: string | undefined): boolean {
+    if (!fileName) return true;
+    // node_modules and webpack-style vendor chunks should not count as application code
+    if (/[/\\]node_modules[/\\]/.test(fileName)) return false;
+    if (/(^|[/\\])(vendor|vendors)[.~-][^/\\]*\.js/i.test(fileName)) return false;
+    return true;
 }

--- a/packages/js/src/stacktrace/fileReader.ts
+++ b/packages/js/src/stacktrace/fileReader.ts
@@ -20,6 +20,15 @@ export function getCodeSnippet(url?: string, lineNumber?: number, columnNumber?:
             });
         }
 
+        if (!isFetchableUrl(url)) {
+            return resolve({
+                codeSnippet: {
+                    0: `Could not read from file: unsupported URL scheme. URL: ${url}`,
+                },
+                trimmedColumnNumber: null,
+            });
+        }
+
         readFile(url).then((fileText) => {
             if (!fileText) {
                 return resolve({
@@ -35,8 +44,12 @@ export function getCodeSnippet(url?: string, lineNumber?: number, columnNumber?:
     });
 }
 
+function isFetchableUrl(url: string): boolean {
+    return /^https?:\/\//i.test(url);
+}
+
 function readFile(url: string): Promise<string | null> {
-    if (cachedFiles[url]) {
+    if (cachedFiles[url] !== undefined) {
         return Promise.resolve(cachedFiles[url]);
     }
 
@@ -47,6 +60,12 @@ function readFile(url: string): Promise<string | null> {
             }
 
             return response.text();
+        })
+        .then((text) => {
+            if (text !== null) {
+                cachedFiles[url] = text;
+            }
+            return text;
         })
         .catch(() => null);
 }
@@ -62,34 +81,36 @@ export function readLinesFromFile(
     let trimmedColumnNumber = null;
 
     const lines = fileText.split('\n');
+    const errorLineIndex = lineNumber - 1; // stack line numbers are 1-based; array is 0-based
+    const half = Math.floor(maxSnippetLines / 2);
 
-    for (let i = -maxSnippetLines / 2; i <= maxSnippetLines / 2; i++) {
-        const currentLineIndex = lineNumber + i;
+    for (let i = -half; i <= half; i++) {
+        const currentLineIndex = errorLineIndex + i;
 
-        if (currentLineIndex >= 0 && lines[currentLineIndex]) {
-            const displayLine = currentLineIndex + 1; // the linenumber in a stacktrace is not zero-based like an array
+        if (currentLineIndex < 0 || !lines[currentLineIndex]) {
+            continue;
+        }
 
-            if (lines[currentLineIndex].length > maxSnippetLineLength) {
-                if (columnNumber && columnNumber + maxSnippetLineLength / 2 > maxSnippetLineLength) {
-                    codeSnippet[displayLine] = lines[currentLineIndex].substr(
-                        columnNumber - Math.round(maxSnippetLineLength / 2),
-                        maxSnippetLineLength
-                    );
+        const displayLine = currentLineIndex + 1;
+        const line = lines[currentLineIndex];
 
-                    if (displayLine === lineNumber) {
-                        trimmedColumnNumber = Math.round(maxSnippetLineLength / 2);
-                    }
+        if (line.length > maxSnippetLineLength) {
+            if (columnNumber && columnNumber > maxSnippetLineLength / 2) {
+                const start = columnNumber - Math.round(maxSnippetLineLength / 2);
+                codeSnippet[displayLine] = line.slice(start, start + maxSnippetLineLength);
 
-                    continue;
+                if (displayLine === lineNumber) {
+                    trimmedColumnNumber = Math.round(maxSnippetLineLength / 2);
                 }
-
-                codeSnippet[displayLine] = lines[currentLineIndex].substr(0, maxSnippetLineLength) + '…';
 
                 continue;
             }
 
-            codeSnippet[displayLine] = lines[currentLineIndex];
+            codeSnippet[displayLine] = line.slice(0, maxSnippetLineLength) + '…';
+            continue;
         }
+
+        codeSnippet[displayLine] = line;
     }
 
     return { codeSnippet, trimmedColumnNumber };

--- a/packages/js/src/util/flatJsonStringify.ts
+++ b/packages/js/src/util/flatJsonStringify.ts
@@ -1,22 +1,36 @@
-// https://stackoverflow.com/a/11616993/6374824
-export function flatJsonStringify(json: Object): string {
-    let cache: any = [];
+export function flatJsonStringify(json: object): string {
+    return JSON.stringify(decycle(json));
+}
 
-    const flattenedStringifiedJson = JSON.stringify(json, function (_, value) {
-        if (typeof value === 'object' && value !== null) {
-            if (cache.indexOf(value) !== -1) {
-                try {
-                    return JSON.parse(JSON.stringify(value));
-                } catch (error) {
-                    return;
-                }
-            }
-            cache.push(value);
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+    if (typeof value !== 'object' || value === null) return false;
+    const proto = Object.getPrototypeOf(value);
+    return proto === Object.prototype || proto === null;
+}
+
+function decycle(root: unknown): unknown {
+    const inPath = new WeakSet<object>();
+
+    function clone(node: unknown): unknown {
+        if (Array.isArray(node)) {
+            if (inPath.has(node)) return '[Circular]';
+            inPath.add(node);
+            const result = node.map(clone);
+            inPath.delete(node);
+            return result;
         }
-        return value;
-    });
+        if (isPlainObject(node)) {
+            if (inPath.has(node)) return '[Circular]';
+            inPath.add(node);
+            const result: Record<string, unknown> = {};
+            for (const [k, v] of Object.entries(node)) {
+                result[k] = clone(v);
+            }
+            inPath.delete(node);
+            return result;
+        }
+        return node;
+    }
 
-    cache = null;
-
-    return flattenedStringifiedJson;
+    return clone(root);
 }

--- a/packages/js/src/util/flattenOnce.ts
+++ b/packages/js/src/util/flattenOnce.ts
@@ -1,5 +1,0 @@
-export function flattenOnce(array: Array<Array<any>>) {
-    return array.reduce((flat, toFlatten) => {
-        return flat.concat(toFlatten);
-    }, []);
-}

--- a/packages/js/src/util/index.ts
+++ b/packages/js/src/util/index.ts
@@ -2,6 +2,5 @@ export * from './assert';
 export * from './assertKey';
 export * from './extractCode';
 export * from './flatJsonStringify';
-export * from './flattenOnce';
 export * from './glowsToEvents';
 export * from './now';

--- a/packages/js/tests/catchWindowErrors.test.ts
+++ b/packages/js/tests/catchWindowErrors.test.ts
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+import { beforeEach, expect, test } from 'vitest';
+
+import { Flare } from '../src';
+import { catchWindowErrors } from '../src/browser/catchWindowErrors';
+
+import { FakeApi } from './helpers';
+
+let fakeApi: FakeApi;
+let client: Flare;
+
+beforeEach(() => {
+    fakeApi = new FakeApi();
+    client = new Flare(fakeApi).configure({ key: 'k' });
+    (window as any).flare = client;
+    catchWindowErrors();
+});
+
+test('Flare error capture survives later reassignment of window.onerror', async () => {
+    // User-land code reassigns window.onerror after Flare initialised; should not detach Flare.
+    window.onerror = null;
+
+    window.dispatchEvent(new ErrorEvent('error', { error: new Error('boom') }));
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(fakeApi.lastReport?.message).toBe('boom');
+});
+
+test('reports non-Error promise rejection reasons (string)', async () => {
+    const event = new Event('unhandledrejection') as any;
+    event.reason = 'something failed';
+    window.dispatchEvent(event);
+
+    await new Promise((r) => setTimeout(r, 0));
+    expect(fakeApi.lastReport?.message).toBe('something failed');
+});
+
+test('reports non-Error promise rejection reasons (plain object with message)', async () => {
+    const event = new Event('unhandledrejection') as any;
+    event.reason = { message: 'object reason' };
+    window.dispatchEvent(event);
+
+    await new Promise((r) => setTimeout(r, 0));
+    expect(fakeApi.lastReport?.message).toBe('object reason');
+});

--- a/packages/js/tests/context.test.ts
+++ b/packages/js/tests/context.test.ts
@@ -79,6 +79,15 @@ test('emits http.request.cookies as parsed object', () => {
     });
 });
 
+test('preserves = characters inside cookie values (e.g. base64)', () => {
+    clearCookies();
+    (window.document as any).cookie = 'token=abc==';
+
+    const attributes = collectAttributes();
+
+    expect((attributes['http.request.cookies'] as Record<string, string>).token).toBe('abc==');
+});
+
 test('returns empty object when no window present (SSR)', () => {
     const realWindow = globalThis.window;
     // @ts-expect-error

--- a/packages/js/tests/createStackTrace.test.ts
+++ b/packages/js/tests/createStackTrace.test.ts
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+import ErrorStackParser from 'error-stack-parser';
+import { expect, test, vi } from 'vitest';
+
+import { createStackTrace } from '../src/stacktrace/createStackTrace';
+
+vi.mock('error-stack-parser', () => ({
+    default: {
+        parse: vi.fn(() => {
+            throw new Error('parser broke on malformed stack');
+        }),
+    },
+}));
+
+test('resolves (does not reject) when ErrorStackParser throws', async () => {
+    const error = new Error('boom');
+    // ensure hasStack() returns true so we reach the parse call
+    error.stack = 'Error: boom\n    at fn (file.js:1:1)\n    at fn2 (file.js:2:2)';
+
+    await expect(createStackTrace(error, false)).resolves.toBeDefined();
+});
+
+test('returns a fallback frame array when ErrorStackParser throws', async () => {
+    const error = new Error('boom');
+    error.stack = 'Error: boom\n    at fn (file.js:1:1)';
+
+    const frames = await createStackTrace(error, false);
+
+    expect(Array.isArray(frames)).toBe(true);
+    expect(frames.length).toBeGreaterThan(0);
+});
+
+test('marks node_modules frames as non-application', async () => {
+    (ErrorStackParser.parse as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(() => [
+        {
+            fileName: 'https://cdn.test/app/node_modules/lodash/index.js',
+            lineNumber: 1,
+            columnNumber: 1,
+            functionName: 'lodash',
+        },
+        { fileName: 'https://cdn.test/app/src/main.ts', lineNumber: 2, columnNumber: 2, functionName: 'main' },
+    ]);
+
+    const error = new Error('boom');
+    error.stack = 'Error: boom\n    at fn (file.js:1:1)';
+
+    const frames = await createStackTrace(error, false);
+
+    expect(frames[0].isApplicationFrame).toBe(false);
+    expect(frames[1].isApplicationFrame).toBe(true);
+});

--- a/packages/js/tests/fileReader.test.ts
+++ b/packages/js/tests/fileReader.test.ts
@@ -1,0 +1,59 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+
+import { getCodeSnippet, readLinesFromFile } from '../src/stacktrace/fileReader';
+
+let originalFetch: typeof globalThis.fetch;
+
+beforeEach(() => {
+    originalFetch = globalThis.fetch;
+});
+
+afterEach(() => {
+    globalThis.fetch = originalFetch;
+});
+
+test('getCodeSnippet caches file by URL across calls', async () => {
+    let calls = 0;
+    globalThis.fetch = vi.fn(async () => {
+        calls++;
+        return new Response('alpha\nbeta\ngamma', { status: 200 });
+    }) as typeof globalThis.fetch;
+
+    await getCodeSnippet('https://example.test/cached.js', 2);
+    await getCodeSnippet('https://example.test/cached.js', 2);
+
+    expect(calls).toBe(1);
+});
+
+test('readLinesFromFile labels target line as the requested 1-based line number', () => {
+    const text = 'L1\nL2\nL3\nL4\nL5';
+
+    const { codeSnippet } = readLinesFromFile(text, 3);
+
+    expect(codeSnippet[3]).toBe('L3');
+});
+
+test('readLinesFromFile centers snippet symmetrically around target line', () => {
+    // 41-line file, target line 21 -> snippet should cover lines 1..41 (target in middle).
+    const text = Array.from({ length: 41 }, (_, i) => `L${i + 1}`).join('\n');
+
+    const { codeSnippet } = readLinesFromFile(text, 21);
+
+    expect(codeSnippet[1]).toBe('L1');
+    expect(codeSnippet[21]).toBe('L21');
+    expect(codeSnippet[41]).toBe('L41');
+});
+
+test('getCodeSnippet skips non-http(s) URLs without fetching', async () => {
+    let calls = 0;
+    globalThis.fetch = vi.fn(async () => {
+        calls++;
+        return new Response('', { status: 200 });
+    }) as typeof globalThis.fetch;
+
+    const result = await getCodeSnippet('chrome-extension://abcdef/script.js', 1);
+
+    expect(calls).toBe(0);
+    expect(result.codeSnippet[0]).toContain('Could not read');
+});

--- a/packages/js/tests/flatJsonStringify.test.ts
+++ b/packages/js/tests/flatJsonStringify.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'vitest';
+
+import { flatJsonStringify } from '../src/util/flatJsonStringify';
+
+describe('flatJsonStringify', () => {
+    test('preserves shared (non-cyclic) sub-objects on both branches', () => {
+        const inner = { x: 1 };
+        const obj = { a: inner, b: inner };
+
+        const parsed = JSON.parse(flatJsonStringify(obj));
+
+        expect(parsed).toEqual({ a: { x: 1 }, b: { x: 1 } });
+    });
+
+    test('replaces real cycles with a sentinel rather than silently dropping the field', () => {
+        const obj: { a: number; self?: unknown } = { a: 1 };
+        obj.self = obj;
+
+        const parsed = JSON.parse(flatJsonStringify(obj));
+
+        expect(parsed.a).toBe(1);
+        expect(parsed.self).toBe('[Circular]');
+    });
+
+    test('does not throw on cyclic structures', () => {
+        const obj: { self?: unknown } = {};
+        obj.self = obj;
+
+        expect(() => flatJsonStringify(obj)).not.toThrow();
+    });
+});

--- a/packages/js/tests/light.test.ts
+++ b/packages/js/tests/light.test.ts
@@ -8,3 +8,18 @@ test('light', () => {
 
     expect(client.config.key).toBe('key');
 });
+
+test('light() does not clobber a previously configured debug=true', () => {
+    const client = new Flare();
+    client.configure({ debug: true });
+    client.light('key');
+
+    expect(client.config.debug).toBe(true);
+});
+
+test('light() can still explicitly opt into debug', () => {
+    const client = new Flare();
+    client.light('key', true);
+
+    expect(client.config.debug).toBe(true);
+});

--- a/packages/js/tests/report.test.ts
+++ b/packages/js/tests/report.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { beforeEach, expect, test } from 'vitest';
+import { beforeEach, expect, test, vi } from 'vitest';
 
 import { Flare } from '../src';
 
@@ -110,4 +110,30 @@ test('per-call attributes win over collected attributes', async () => {
 test('events is always an array — never undefined', async () => {
     await client.report(new Error('x'));
     expect(Array.isArray(fakeApi.lastReport!.events)).toBe(true);
+});
+
+test('seenAtUnixNano reflects report() entry time, not post-stacktrace time', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-04-28T12:00:00.000Z'));
+    const entryNs = Date.now() * 1_000_000;
+
+    client.configure({
+        beforeEvaluate: (e) => {
+            vi.advanceTimersByTime(5000);
+            return e;
+        },
+    });
+
+    await client.report(new Error('x'));
+
+    expect(fakeApi.lastReport!.seenAtUnixNano).toBe(entryNs);
+
+    vi.useRealTimers();
+});
+
+test('coerces non-Error inputs to a string message and Error class', async () => {
+    await client.report('plain string boom' as unknown as Error);
+
+    expect(fakeApi.lastReport!.message).toBe('plain string boom');
+    expect(fakeApi.lastReport!.exceptionClass).toBe('Error');
 });

--- a/packages/vue/src/FlareErrorBoundary.ts
+++ b/packages/vue/src/FlareErrorBoundary.ts
@@ -134,11 +134,7 @@ export const FlareErrorBoundary = defineComponent({
                 ...vueContextToAttributes(finalContext),
             };
 
-            try {
-                Promise.resolve(flare.report(errorToReport, attributes)).catch(() => {});
-            } catch (reportError) {
-                console.error('FlareErrorBoundary: failed to report error to Flare', reportError);
-            }
+            Promise.resolve(flare.report(errorToReport, attributes)).catch(() => {});
 
             props.afterSubmit?.({ error: errorToReport, instance, info, context: finalContext });
 

--- a/packages/vue/src/FlareErrorBoundary.ts
+++ b/packages/vue/src/FlareErrorBoundary.ts
@@ -1,11 +1,12 @@
-import { flare } from '@flareapp/js';
+import { type Attributes, flare } from '@flareapp/js';
 import type { ComponentPublicInstance, PropType } from 'vue';
 import { defineComponent, getCurrentInstance, onErrorCaptured, ref, watch } from 'vue';
 
 import { buildComponentHierarchy } from './buildComponentHierarchy';
 import { buildComponentHierarchyFrames } from './buildComponentHierarchyFrames';
+import { DEFAULT_PROPS_DENYLIST } from './constants';
 import { convertToError } from './convertToError';
-import { vueContextToAttributes } from './flareVue';
+import { urlAttributesWithScrubbedQuery, vueContextToAttributes } from './flareVue';
 import { getComponentName } from './getComponentName';
 import { getErrorOrigin } from './getErrorOrigin';
 import { getRouteContext } from './getRouteContext';
@@ -128,8 +129,13 @@ export const FlareErrorBoundary = defineComponent({
             componentHierarchy.value = finalContext.vue.componentHierarchy;
             componentHierarchyFrames.value = finalContext.vue.componentHierarchyFrames;
 
+            const attributes: Attributes = {
+                ...urlAttributesWithScrubbedQuery(props.propsDenylist ?? DEFAULT_PROPS_DENYLIST),
+                ...vueContextToAttributes(finalContext),
+            };
+
             try {
-                Promise.resolve(flare.report(errorToReport, vueContextToAttributes(finalContext))).catch(() => {});
+                Promise.resolve(flare.report(errorToReport, attributes)).catch(() => {});
             } catch (reportError) {
                 console.error('FlareErrorBoundary: failed to report error to Flare', reportError);
             }

--- a/packages/vue/src/FlareErrorBoundary.ts
+++ b/packages/vue/src/FlareErrorBoundary.ts
@@ -72,12 +72,12 @@ export const FlareErrorBoundary = defineComponent({
         watch(
             () => props.resetKeys,
             (nextKeys, prevKeys) => {
-                if (error.value === null || !nextKeys) {
+                if (error.value === null || !nextKeys || !prevKeys) {
                     return;
                 }
 
-                const lengthChanged = prevKeys?.length !== nextKeys.length;
-                const valuesChanged = nextKeys.some((key, i) => !Object.is(key, prevKeys?.[i]));
+                const lengthChanged = prevKeys.length !== nextKeys.length;
+                const valuesChanged = nextKeys.some((key, i) => !Object.is(key, prevKeys[i]));
 
                 if (lengthChanged || valuesChanged) {
                     resetErrorBoundary();

--- a/packages/vue/src/flareVue.ts
+++ b/packages/vue/src/flareVue.ts
@@ -19,7 +19,7 @@ export function vueWarningContextToAttributes(context: FlareVueWarningContext): 
     return { 'context.custom': { vue: context.vue as never } };
 }
 
-function urlAttributesWithScrubbedQuery(denylist: RegExp): Attributes {
+export function urlAttributesWithScrubbedQuery(denylist: RegExp = DEFAULT_PROPS_DENYLIST): Attributes {
     if (typeof window === 'undefined' || !window.location) {
         return {};
     }

--- a/packages/vue/src/flareVue.ts
+++ b/packages/vue/src/flareVue.ts
@@ -89,7 +89,7 @@ export const flareVue: Plugin<[FlareVueOptions?]> = (app: App, options?: FlareVu
             return;
         }
 
-        throw errorToReport;
+        throw error;
     };
 
     if (options?.captureWarnings) {

--- a/packages/vue/src/flareVue.ts
+++ b/packages/vue/src/flareVue.ts
@@ -32,7 +32,14 @@ export function urlAttributesWithScrubbedQuery(denylist: RegExp = DEFAULT_PROPS_
     return attrs;
 }
 
+const installedApps = new WeakSet<App>();
+
 export const flareVue: Plugin<[FlareVueOptions?]> = (app: App, options?: FlareVueOptions): void => {
+    if (installedApps.has(app)) {
+        return;
+    }
+    installedApps.add(app);
+
     flare.setSdkInfo({ name: '@flareapp/vue', version: PACKAGE_VERSION });
     flare.setFramework({ name: 'Vue', version: app.version });
 

--- a/packages/vue/tests/FlareErrorBoundary.test.ts
+++ b/packages/vue/tests/FlareErrorBoundary.test.ts
@@ -1131,4 +1131,74 @@ describe('FlareErrorBoundary', () => {
             expect(slotProps?.componentProps).toEqual({ userId: 7 });
         });
     });
+
+    describe('url scrubbing', () => {
+        let originalHref: string;
+
+        beforeEach(() => {
+            originalHref = window.location.href;
+        });
+
+        afterEach(() => {
+            window.history.replaceState({}, '', originalHref);
+        });
+
+        function getReportedAttributes(callIndex = 0): Attributes {
+            return (mockReport.mock.calls[callIndex] ?? [])[1] as Attributes;
+        }
+
+        test('redacts denylisted query keys from url.full and url.query', async () => {
+            window.history.replaceState({}, '', '/page?token=abc&q=visible');
+
+            mount(FlareErrorBoundary, {
+                slots: {
+                    default: () => h(ThrowingComponent),
+                    fallback: () => h('div', 'Error'),
+                },
+            });
+
+            await nextTick();
+
+            const attributes = getReportedAttributes(0);
+            expect(attributes['url.full']).toContain('token=[Redacted]');
+            expect(attributes['url.full']).toContain('q=visible');
+            expect(attributes['url.query']).toBe('token=[Redacted]&q=visible');
+        });
+
+        test('honours custom propsDenylist when redacting the URL', async () => {
+            window.history.replaceState({}, '', '/page?secretKey=xyz&token=stillVisible');
+
+            mount(FlareErrorBoundary, {
+                props: { propsDenylist: /^secretKey$/ },
+                slots: {
+                    default: () => h(ThrowingComponent),
+                    fallback: () => h('div', 'Error'),
+                },
+            });
+
+            await nextTick();
+
+            const attributes = getReportedAttributes(0);
+            expect(attributes['url.full']).toContain('secretKey=[Redacted]');
+            expect(attributes['url.full']).toContain('token=stillVisible');
+            expect(attributes['url.query']).toBe('secretKey=[Redacted]&token=stillVisible');
+        });
+
+        test('omits url.query when there is no query string', async () => {
+            window.history.replaceState({}, '', '/page');
+
+            mount(FlareErrorBoundary, {
+                slots: {
+                    default: () => h(ThrowingComponent),
+                    fallback: () => h('div', 'Error'),
+                },
+            });
+
+            await nextTick();
+
+            const attributes = getReportedAttributes(0);
+            expect(attributes['url.full']).toBeDefined();
+            expect(attributes['url.query']).toBeUndefined();
+        });
+    });
 });

--- a/packages/vue/tests/FlareErrorBoundary.test.ts
+++ b/packages/vue/tests/FlareErrorBoundary.test.ts
@@ -355,12 +355,8 @@ describe('FlareErrorBoundary', () => {
         expect(wrapper.html()).toBe('');
     });
 
-    test('flare.report throwing is contained and fallback still renders', async () => {
-        const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-
-        mockReport.mockImplementation(() => {
-            throw new Error('report failed');
-        });
+    test('flare.report rejection is silenced and fallback still renders', async () => {
+        mockReport.mockRejectedValueOnce(new Error('report failed'));
 
         const wrapper = mount(FlareErrorBoundary, {
             slots: {
@@ -370,24 +366,15 @@ describe('FlareErrorBoundary', () => {
         });
 
         await nextTick();
+        await nextTick();
 
         expect(mockReport).toHaveBeenCalledOnce();
         expect(wrapper.text()).toBe('Fallback');
-        expect(consoleErrorSpy).toHaveBeenCalledWith(
-            'FlareErrorBoundary: failed to report error to Flare',
-            expect.any(Error)
-        );
-
-        consoleErrorSpy.mockRestore();
     });
 
-    test('flare.report throwing does not propagate to outer errorCaptured handlers', async () => {
-        const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    test('flare.report rejection does not propagate to outer errorCaptured handlers', async () => {
+        mockReport.mockRejectedValueOnce(new Error('report failed'));
         const outerHandler = vi.fn();
-
-        mockReport.mockImplementation(() => {
-            throw new Error('report failed');
-        });
 
         const Parent = defineComponent({
             errorCaptured: outerHandler,
@@ -402,19 +389,14 @@ describe('FlareErrorBoundary', () => {
         mount(Parent);
 
         await nextTick();
+        await nextTick();
 
         expect(outerHandler).not.toHaveBeenCalled();
-
-        consoleErrorSpy.mockRestore();
     });
 
-    test('afterSubmit still runs when flare.report throws', async () => {
-        const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    test('afterSubmit still runs when flare.report rejects', async () => {
+        mockReport.mockRejectedValueOnce(new Error('report failed'));
         const afterSubmit = vi.fn();
-
-        mockReport.mockImplementation(() => {
-            throw new Error('report failed');
-        });
 
         mount(FlareErrorBoundary, {
             props: { afterSubmit },
@@ -425,10 +407,9 @@ describe('FlareErrorBoundary', () => {
         });
 
         await nextTick();
+        await nextTick();
 
         expect(afterSubmit).toHaveBeenCalledOnce();
-
-        consoleErrorSpy.mockRestore();
     });
 
     test('calls beforeEvaluate before reporting', async () => {

--- a/packages/vue/tests/FlareErrorBoundary.test.ts
+++ b/packages/vue/tests/FlareErrorBoundary.test.ts
@@ -849,6 +849,27 @@ describe('FlareErrorBoundary', () => {
         expect(wrapper.text()).toBe('Recovered');
     });
 
+    test('does not reset on the first transition from undefined to a resetKeys array', async () => {
+        const onReset = vi.fn();
+
+        const wrapper = mount(FlareErrorBoundary, {
+            slots: {
+                default: () => h(ThrowingComponent),
+                fallback: () => h('div', 'Error'),
+            },
+        });
+
+        await nextTick();
+
+        expect(wrapper.text()).toBe('Error');
+
+        await wrapper.setProps({ onReset, resetKeys: ['a'] as unknown[] });
+        await nextTick();
+
+        expect(onReset).not.toHaveBeenCalled();
+        expect(wrapper.text()).toBe('Error');
+    });
+
     test('resetKeys uses Object.is for comparison', async () => {
         let shouldThrow = true;
         const onReset = vi.fn();

--- a/packages/vue/tests/flareVue.test.ts
+++ b/packages/vue/tests/flareVue.test.ts
@@ -325,6 +325,20 @@ describe('flareVue', () => {
         expect(mockReport).toHaveBeenCalledOnce();
     });
 
+    test('is idempotent when installed twice on the same app', () => {
+        const app = createMockApp();
+        (flareVue as Function)(app);
+        const firstHandler = app.config.errorHandler;
+
+        (flareVue as Function)(app);
+
+        expect(app.config.errorHandler).toBe(firstHandler);
+
+        callHandler(app, new Error('test'), null, 'setup function');
+
+        expect(mockReport).toHaveBeenCalledOnce();
+    });
+
     test('calls beforeEvaluate before building context and reporting', () => {
         const callOrder: string[] = [];
 

--- a/packages/vue/tests/flareVue.test.ts
+++ b/packages/vue/tests/flareVue.test.ts
@@ -241,7 +241,7 @@ describe('flareVue', () => {
         expect(context.vue.componentHierarchyFrames).toEqual([]);
     });
 
-    test('re-throws the converted error, not the raw value, when no initial handler exists', () => {
+    test('re-throws the original raw value when no initial handler exists', () => {
         const app = createMockApp();
         (flareVue as Function)(app);
 
@@ -252,8 +252,22 @@ describe('flareVue', () => {
             thrown = e;
         }
 
-        expect(thrown).toBeInstanceOf(Error);
-        expect((thrown as Error).message).toBe('raw string');
+        expect(thrown).toBe('raw string');
+    });
+
+    test('re-throws the original Error reference when no initial handler exists', () => {
+        const app = createMockApp();
+        (flareVue as Function)(app);
+
+        const error = new Error('boom');
+        let thrown: unknown;
+        try {
+            app.config.errorHandler!(error, null, 'setup function');
+        } catch (e) {
+            thrown = e;
+        }
+
+        expect(thrown).toBe(error);
     });
 
     test('reports each error independently when called multiple times', () => {


### PR DESCRIPTION
## Summary

5 atomic fixes on top of `task/update-payload-format`. Found via fresh code review of the vue package.

- **`e08ffa7` fix(vue): redact denylisted query keys in FlareErrorBoundary URL attributes** — security. JS package's auto-collector sets `url.full` from `window.location.href` unredacted; flareVue overrode it but FlareErrorBoundary did not, leaking secrets in the query string for any boundary-caught error.
- **`7d5268d` fix(vue): re-throw original error from flareVue when no upstream handler** — re-throws the original `error` rather than the `convertToError`-wrapped Error, preserving non-Error values for downstream listeners.
- **`443cefc` refactor(vue): drop dead sync try/catch around async flare.report** — `flare.report` is `async`, sync throw impossible. Removed unreachable try/catch + console.error fallback. Three tests rewritten to use `mockRejectedValueOnce`.
- **`bf557e6` fix(vue): make flareVue plugin idempotent on the same app** — `app.use(flareVue)` twice double-wrapped `errorHandler`/`warnHandler` and double-reported. Module-level `WeakSet<App>` skips repeat installs.
- **`71854cf` fix(vue): skip resetKeys watcher when prevKeys was undefined` — boundary mounted without `resetKeys`, hit error, then received a `resetKeys` array → spurious reset. Watcher now requires both sides non-empty.

Stacked on top of `task/update-payload-format` because the fixed files diverge significantly from `feature/extend-vue-package`. Land payload-format first; this PR follows.

## Test plan

- [x] `npm run test` — 74 + 64 + 215 = 353 pass (vue +6 new: idempotency, raw-rethrow, Error-rethrow, URL scrubbing x3, prevKeys-undefined)
- [x] `npm run typescript` — clean across all packages
- [x] `prettier --check` clean