### PR TITLE
v1.2.0 — payload migration to Flare v2 wire format

### DIFF
--- a/packages/js/CHANGELOG.md
+++ b/packages/js/CHANGELOG.md
@@ -9,9 +9,8 @@ This is the **final v1 release**. Subsequent work ships under v2.
 
 ### Changed
 - Default `reportingUrl` now points to the new ingestion endpoint: `https://ingress.flareapp.io/v1/errors`. Consumers with allowlist firewall rules on outbound HTTP must add this host to their allowlist. Consumers passing a custom `reportingUrl` to `flare.configure({...})` are unaffected.
-- HTTP success status changed from `204` to `201`.
-- Headers updated: `Accept: application/json` and `X-Flare-Client-Version: 2` added; `X-Requested-With` and `X-Report-Browser-Extension-Errors` removed.
-- `Config.reportBrowserExtensionErrors` is now a no-op. The v2 ingestion endpoint does not consume the corresponding header. The field is preserved on `Config` for backward compatibility.
+- HTTP response is now treated as success on status `200`, `201`, or `204` (previously only `204`).
+- Headers updated: `Accept: application/json` and `X-Flare-Client-Version: 1` added; `X-Requested-With` removed. `X-Api-Token` and `X-Report-Browser-Extension-Errors` retained.
 - Stack frames omit the `class` field when empty (previously emitted as `""`). The field is still emitted when populated.
 
 ### Fixed

--- a/packages/js/CHANGELOG.md
+++ b/packages/js/CHANGELOG.md
@@ -1,0 +1,31 @@
+# @flareapp/js
+
+## 1.2.0
+
+This is the **final v1 release**. Subsequent work ships under v2.
+
+### Added
+- Reports are now mapped to the Flare v2 wire format on egress. The mapper sits at the `Api.report()` boundary; the public API and the `beforeSubmit` hook still see the v1 `Report` shape.
+
+### Changed
+- Default `reportingUrl` now points to the new ingestion endpoint: `https://ingress.flareapp.io/v1/errors`. Consumers with allowlist firewall rules on outbound HTTP must add this host to their allowlist. Consumers passing a custom `reportingUrl` to `flare.configure({...})` are unaffected.
+- HTTP success status changed from `204` to `201`.
+- Headers updated: `Accept: application/json` and `X-Flare-Client-Version: 2` added; `X-Requested-With` and `X-Report-Browser-Extension-Errors` removed.
+- `Config.reportBrowserExtensionErrors` is now a no-op. The v2 ingestion endpoint does not consume the corresponding header. The field is preserved on `Config` for backward compatibility.
+- Stack frames omit the `class` field when empty (previously emitted as `""`). The field is still emitted when populated.
+
+### Fixed
+- `cookie` context collector preserves `=` characters inside cookie values (previously truncated base64-padded values at the first `=`).
+- Global error and unhandled-rejection handlers attach via `addEventListener`, so user code reassigning `window.onerror` no longer detaches Flare's handlers.
+- Non-Error rejection reasons (strings, plain objects, Symbols) now produce reports instead of being silently dropped.
+- `flatJsonStringify` decycles via a `WeakSet` of ancestor objects: real cycles become the literal `'[Circular]'`; non-cyclic shared sub-objects are preserved without recursion blowup.
+- `createStackTrace` wraps `ErrorStackParser.parse` in `try/catch`. Parser failures resolve to a single fallback frame instead of dropping the report.
+
+### Internal
+- New `mapToV2Wire(report, config)` pure function in `src/api/mapToV2Wire.ts`.
+- New `glowsToEvents(glows)` helper in `src/util/glowsToEvents.ts`.
+- `Api.report()` signature changed from `(report, url, key, reportBrowserExtensionErrors)` to `(report, config)`. This is internal — it is not part of the package's public exports.
+
+## 1.1.0
+
+Prior history is in git.

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@flareapp/js",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "description": "JavaScript client for flareapp.io",
     "homepage": "https://flareapp.io",
     "bugs": {

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -31,7 +31,7 @@
         "error-stack-parser": "^2.0.2"
     },
     "devDependencies": {
-        "jsdom": "^29.1.0",
+        "jsdom": "^25.0.0",
         "tsup": "^8.0.1",
         "typescript": "^5.3.3",
         "vitest": "^1.0.4"

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -31,6 +31,7 @@
         "error-stack-parser": "^2.0.2"
     },
     "devDependencies": {
+        "jsdom": "^29.1.0",
         "tsup": "^8.0.1",
         "typescript": "^5.3.3",
         "vitest": "^1.0.4"

--- a/packages/js/src/Flare.ts
+++ b/packages/js/src/Flare.ts
@@ -21,7 +21,7 @@ export class Flare {
         sourcemapVersion: SOURCEMAP_VERSION,
         stage: '',
         maxGlowsPerReport: 30,
-        reportingUrl: 'https://reporting.flareapp.io/api/reports',
+        reportingUrl: 'https://ingress.flareapp.io/v1/errors',
         reportBrowserExtensionErrors: false,
         debug: false,
         beforeEvaluate: (error) => error,
@@ -184,12 +184,7 @@ export class Flare {
             return;
         }
 
-        return this.api.report(
-            reportToSubmit,
-            this.config.reportingUrl,
-            this.config.key,
-            this.config.reportBrowserExtensionErrors
-        );
+        return this.api.report(reportToSubmit, this.config);
     }
 
     // Deprecated, the following methods exist for backwards compatibility.

--- a/packages/js/src/api/Api.ts
+++ b/packages/js/src/api/Api.ts
@@ -1,23 +1,22 @@
-import { Report } from '../types';
+import { Config, Report } from '../types';
 import { flatJsonStringify } from '../util';
 
+import { mapToV2Wire } from './mapToV2Wire';
+
 export class Api {
-    report(report: Report, url: string, key: string | null, reportBrowserExtensionErrors: boolean): Promise<void> {
-        return fetch(url, {
+    report(report: Report, config: Config): Promise<void> {
+        return fetch(config.reportingUrl, {
             method: 'POST',
             headers: {
+                'Accept': 'application/json',
                 'Content-Type': 'application/json',
-                'X-Api-Token': key ?? '',
-                'X-Requested-With': 'XMLHttpRequest',
-                'X-Report-Browser-Extension-Errors': JSON.stringify(reportBrowserExtensionErrors),
+                'X-Api-Token': config.key ?? '',
+                'X-Flare-Client-Version': '2',
             },
-            body: flatJsonStringify({
-                ...report,
-                key: key,
-            }),
+            body: flatJsonStringify(mapToV2Wire(report, config)),
         }).then(
             (response) => {
-                if (response.status !== 204) {
+                if (response.status !== 201) {
                     console.error(`Received response with status ${response.status} from Flare`);
                 }
             },

--- a/packages/js/src/api/Api.ts
+++ b/packages/js/src/api/Api.ts
@@ -11,12 +11,13 @@ export class Api {
                 'Accept': 'application/json',
                 'Content-Type': 'application/json',
                 'X-Api-Token': config.key ?? '',
-                'X-Flare-Client-Version': '2',
+                'X-Report-Browser-Extension-Errors': JSON.stringify(config.reportBrowserExtensionErrors),
+                'X-Flare-Client-Version': '1',
             },
             body: flatJsonStringify(mapToV2Wire(report, config)),
         }).then(
             (response) => {
-                if (response.status !== 201) {
+                if (response.status !== 200 && response.status !== 201 && response.status !== 204) {
                     console.error(`Received response with status ${response.status} from Flare`);
                 }
             },

--- a/packages/js/src/api/index.ts
+++ b/packages/js/src/api/index.ts
@@ -1,1 +1,2 @@
 export * from './Api';
+export * from './mapToV2Wire';

--- a/packages/js/src/api/mapToV2Wire.ts
+++ b/packages/js/src/api/mapToV2Wire.ts
@@ -1,0 +1,116 @@
+import { CLIENT_VERSION } from '../env';
+import { Config, Context, Report, StackFrame } from '../types';
+import { glowsToEvents } from '../util/glowsToEvents';
+
+import { V2AttributeValue, V2Attributes, V2StackFrame, V2WirePayload } from './v2WireTypes';
+
+const KNOWN_CONTEXT_BUCKETS = new Set(['request', 'request_data', 'cookies', 'context']);
+
+const NON_APPLICATION_FRAME_PATTERN = /node_modules|vendor|chunk-/;
+
+export function mapToV2Wire(report: Report, config: Config): V2WirePayload {
+    const wire: V2WirePayload = {
+        seenAtUnixNano: Math.round(report.seen_at * 1_000_000_000),
+        stacktrace: report.stacktrace.map(mapStackFrame),
+        events: glowsToEvents(report.glows),
+        attributes: buildAttributes(report, config),
+    };
+
+    if (report.exception_class) {
+        wire.exceptionClass = report.exception_class;
+    }
+    if (report.message != null) {
+        wire.message = report.message;
+    }
+    if (report.sourcemap_version_id) {
+        wire.sourcemapVersionId = report.sourcemap_version_id;
+    }
+
+    return wire;
+}
+
+function mapStackFrame(frame: StackFrame): V2StackFrame {
+    const out: V2StackFrame = {
+        file: frame.file,
+        lineNumber: frame.line_number,
+        isApplicationFrame: !NON_APPLICATION_FRAME_PATTERN.test(frame.file),
+    };
+
+    if (frame.column_number != null) {
+        out.columnNumber = frame.column_number;
+    }
+    if (frame.method) {
+        out.method = frame.method;
+    }
+    if (frame.class != null) {
+        out.class = frame.class;
+    }
+    if (frame.code_snippet) {
+        out.codeSnippet = frame.code_snippet;
+    }
+
+    return out;
+}
+
+function buildAttributes(report: Report, config: Config): V2Attributes {
+    const attrs: V2Attributes = {
+        'telemetry.sdk.language': 'javascript',
+        'telemetry.sdk.name': '@flareapp/js',
+        'telemetry.sdk.version': CLIENT_VERSION,
+        'flare.language.name': 'javascript',
+        'flare.entry_point.type': 'web',
+    };
+
+    if (typeof window !== 'undefined' && window.location && window.location.href) {
+        attrs['flare.entry_point.value'] = window.location.href;
+    }
+
+    if (config.stage) {
+        attrs['service.stage'] = config.stage;
+    }
+    if (config.version) {
+        attrs['service.version'] = config.version;
+    }
+
+    const context: Context = report.context ?? {};
+
+    if (context.request?.url) attrs['url.full'] = String(context.request.url);
+    if (context.request?.useragent) attrs['user_agent.original'] = String(context.request.useragent);
+    if (context.request?.referrer) attrs['http.request.referrer'] = String(context.request.referrer);
+    if (context.request?.readyState) attrs['document.ready_state'] = String(context.request.readyState);
+
+    if (context.request_data?.queryString) {
+        attrs['url.query'] = context.request_data.queryString as V2AttributeValue;
+    }
+    if (context.cookies) {
+        attrs['http.request.cookies'] = context.cookies as V2AttributeValue;
+    }
+
+    const custom = buildCustomContext(context);
+    if (Object.keys(custom).length > 0) {
+        attrs['context.custom'] = custom;
+    }
+
+    return attrs;
+}
+
+function buildCustomContext(context: Context): { [k: string]: V2AttributeValue } {
+    const custom: { [k: string]: V2AttributeValue } = {};
+
+    // Passed-context: any top-level key not in known buckets.
+    for (const key of Object.keys(context)) {
+        if (KNOWN_CONTEXT_BUCKETS.has(key)) continue;
+        custom[key] = context[key] as V2AttributeValue;
+    }
+
+    // addContext bucket: context.context.* — flattened into custom siblings.
+    // addContext wins on collision (matches the spread precedence in Flare.report).
+    const added = (context as any).context;
+    if (added && typeof added === 'object') {
+        for (const key of Object.keys(added)) {
+            custom[key] = added[key] as V2AttributeValue;
+        }
+    }
+
+    return custom;
+}

--- a/packages/js/src/api/mapToV2Wire.ts
+++ b/packages/js/src/api/mapToV2Wire.ts
@@ -42,7 +42,7 @@ function mapStackFrame(frame: StackFrame): V2StackFrame {
     if (frame.method) {
         out.method = frame.method;
     }
-    if (frame.class != null) {
+    if (frame.class) {
         out.class = frame.class;
     }
     if (frame.code_snippet) {
@@ -103,8 +103,12 @@ function buildCustomContext(context: Context): { [k: string]: V2AttributeValue }
         custom[key] = context[key] as V2AttributeValue;
     }
 
-    // addContext bucket: context.context.* — flattened into custom siblings.
-    // addContext wins on collision (matches the spread precedence in Flare.report).
+    // addContext('foo', value) populates context.context.foo. Flatten its
+    // children into siblings under context.custom. We process this AFTER the
+    // passed-context loop above so that on a collision (e.g. user calls both
+    // addContext('vue', X) and flare.report(err, {vue: Y})), the addContext
+    // value wins — same outcome as the {...passed, ...this.context} merge in
+    // Flare.report's createReportFromError.
     const added = (context as any).context;
     if (added && typeof added === 'object') {
         for (const key of Object.keys(added)) {

--- a/packages/js/src/api/v2WireTypes.ts
+++ b/packages/js/src/api/v2WireTypes.ts
@@ -1,0 +1,39 @@
+// Internal types — NOT re-exported from packages/js/src/index.ts.
+// These describe the v2 wire shape posted to https://ingress.flareapp.io/v1/errors.
+
+export type V2AttributeValue =
+    | string
+    | number
+    | boolean
+    | null
+    | V2AttributeValue[]
+    | { [key: string]: V2AttributeValue };
+
+export type V2Attributes = Record<string, V2AttributeValue>;
+
+export type V2StackFrame = {
+    file: string;
+    lineNumber: number;
+    columnNumber?: number;
+    method?: string;
+    class?: string;
+    codeSnippet?: { [line: number]: string };
+    isApplicationFrame?: boolean;
+};
+
+export type V2SpanEvent = {
+    type: string;
+    startTimeUnixNano: number;
+    endTimeUnixNano: number | null;
+    attributes: V2Attributes;
+};
+
+export type V2WirePayload = {
+    exceptionClass?: string;
+    message?: string;
+    seenAtUnixNano: number;
+    sourcemapVersionId?: string;
+    stacktrace: V2StackFrame[];
+    events: V2SpanEvent[];
+    attributes: V2Attributes;
+};

--- a/packages/js/src/browser/catchWindowErrors.ts
+++ b/packages/js/src/browser/catchWindowErrors.ts
@@ -10,27 +10,29 @@ export function catchWindowErrors() {
         return;
     }
 
-    const originalOnerrorHandler = window.onerror;
-    const originalOnunhandledrejectionHandler = window.onunhandledrejection;
+    window.addEventListener('error', (event: ErrorEvent) => {
+        if (event.error) {
+            flare.report(event.error);
+        }
+    });
 
-    window.onerror = (_1, _2, _3, _4, error) => {
-        if (error) {
-            flare.report(error);
+    window.addEventListener('unhandledrejection', (event: PromiseRejectionEvent) => {
+        const reason = event.reason;
+
+        if (reason instanceof Error) {
+            flare.report(reason);
+            return;
         }
 
-        if (typeof originalOnerrorHandler === 'function') {
-            originalOnerrorHandler(_1, _2, _3, _4, error);
-        }
-    };
+        const message = typeof reason === 'string' ? reason : safeStringify(reason);
+        flare.report(new Error(message));
+    });
+}
 
-    window.onunhandledrejection = (error: PromiseRejectionEvent) => {
-        if (error.reason instanceof Error) {
-            flare.report(error.reason);
-        }
-
-        if (typeof originalOnunhandledrejectionHandler === 'function') {
-            // @ts-ignore
-            originalOnunhandledrejectionHandler(error);
-        }
-    };
+function safeStringify(value: unknown): string {
+    try {
+        return JSON.stringify(value);
+    } catch {
+        return String(value);
+    }
 }

--- a/packages/js/src/browser/catchWindowErrors.ts
+++ b/packages/js/src/browser/catchWindowErrors.ts
@@ -31,7 +31,7 @@ export function catchWindowErrors() {
 
 function safeStringify(value: unknown): string {
     try {
-        return JSON.stringify(value);
+        return JSON.stringify(value) ?? String(value);
     } catch {
         return String(value);
     }

--- a/packages/js/src/context/cookie.ts
+++ b/packages/js/src/context/cookie.ts
@@ -3,15 +3,22 @@ export default function cookie() {
         return {};
     }
 
-    return {
-        cookies: window.document.cookie.split('; ').reduce(
-            (cookies, cookie) => {
-                const [cookieName, cookieValue] = cookie.split(/=/);
-                cookies[cookieName] = cookieValue;
+    const cookies: { [key: string]: string } = {};
 
-                return cookies;
-            },
-            {} as { [key: string]: string }
-        ),
-    };
+    for (const raw of window.document.cookie.split('; ')) {
+        const eq = raw.indexOf('=');
+        if (eq === -1) {
+            continue;
+        }
+
+        const name = raw.slice(0, eq);
+        const value = raw.slice(eq + 1);
+        cookies[name] = value;
+    }
+
+    if (Object.keys(cookies).length === 0) {
+        return {};
+    }
+
+    return { cookies };
 }

--- a/packages/js/src/stacktrace/createStackTrace.ts
+++ b/packages/js/src/stacktrace/createStackTrace.ts
@@ -14,23 +14,21 @@ export function createStackTrace(error: Error, debug: boolean): Promise<Array<St
                 console.error(error);
             }
 
-            return resolve([
-                {
-                    line_number: 0,
-                    column_number: 0,
-                    method: 'unknown',
-                    file: 'unknown',
-                    code_snippet: {
-                        0: 'Could not read from file: stacktrace missing',
-                    },
-                    trimmed_column_number: null,
-                    class: 'unknown',
-                },
-            ]);
+            return resolve([fallbackFrame('stacktrace missing')]);
+        }
+
+        let parsed: ReturnType<typeof ErrorStackParser.parse>;
+        try {
+            parsed = ErrorStackParser.parse(error);
+        } catch (parseError) {
+            if (debug) {
+                console.error('Flare: failed to parse stacktrace', parseError);
+            }
+            return resolve([fallbackFrame('Could not parse stacktrace')]);
         }
 
         Promise.all(
-            ErrorStackParser.parse(error).map((frame) => {
+            parsed.map((frame) => {
                 return new Promise<StackFrame>((resolve) => {
                     getCodeSnippet(frame.fileName, frame.lineNumber, frame.columnNumber).then((snippet) => {
                         resolve({
@@ -47,6 +45,18 @@ export function createStackTrace(error: Error, debug: boolean): Promise<Array<St
             })
         ).then(resolve);
     });
+}
+
+function fallbackFrame(message: string): StackFrame {
+    return {
+        line_number: 0,
+        column_number: 0,
+        method: 'unknown',
+        file: 'unknown',
+        code_snippet: { 0: message },
+        trimmed_column_number: null,
+        class: 'unknown',
+    };
 }
 
 function hasStack(err: any): boolean {

--- a/packages/js/src/types.ts
+++ b/packages/js/src/types.ts
@@ -4,11 +4,6 @@ export type Config = {
     sourcemapVersion: string;
     stage: string;
     maxGlowsPerReport: number;
-    /**
-     * No-op since v1.2.0. The v2 ingestion endpoint does not consume the
-     * X-Report-Browser-Extension-Errors header. The field is preserved
-     * on `Config` for backward compatibility with v1.x consumers.
-     */
     reportBrowserExtensionErrors: boolean;
     reportingUrl: string;
     debug: boolean;

--- a/packages/js/src/types.ts
+++ b/packages/js/src/types.ts
@@ -4,6 +4,11 @@ export type Config = {
     sourcemapVersion: string;
     stage: string;
     maxGlowsPerReport: number;
+    /**
+     * No-op since v1.2.0. The v2 ingestion endpoint does not consume the
+     * X-Report-Browser-Extension-Errors header. The field is preserved
+     * on `Config` for backward compatibility with v1.x consumers.
+     */
     reportBrowserExtensionErrors: boolean;
     reportingUrl: string;
     debug: boolean;

--- a/packages/js/src/util/flatJsonStringify.ts
+++ b/packages/js/src/util/flatJsonStringify.ts
@@ -1,22 +1,25 @@
-// https://stackoverflow.com/a/11616993/6374824
-export function flatJsonStringify(json: Object): string {
-    let cache: any = [];
+export function flatJsonStringify(json: object): string {
+    const ancestors = new WeakSet<object>();
+    const path: object[] = [];
 
-    const flattenedStringifiedJson = JSON.stringify(json, function (_, value) {
-        if (typeof value === 'object' && value !== null) {
-            if (cache.indexOf(value) !== -1) {
-                try {
-                    return JSON.parse(JSON.stringify(value));
-                } catch (error) {
-                    return;
-                }
-            }
-            cache.push(value);
+    return JSON.stringify(json, function (this: object, _key, value) {
+        if (typeof value !== 'object' || value === null) {
+            return value;
         }
+
+        // Pop ancestors that are no longer on the path to `this`.
+        while (path.length > 0 && path[path.length - 1] !== this) {
+            const popped = path.pop()!;
+            ancestors.delete(popped);
+        }
+
+        if (ancestors.has(value)) {
+            return '[Circular]';
+        }
+
+        ancestors.add(value);
+        path.push(value);
+
         return value;
     });
-
-    cache = null;
-
-    return flattenedStringifiedJson;
 }

--- a/packages/js/src/util/glowsToEvents.ts
+++ b/packages/js/src/util/glowsToEvents.ts
@@ -1,0 +1,17 @@
+import { V2AttributeValue, V2SpanEvent } from '../api/v2WireTypes';
+import { Glow } from '../types';
+
+// glow.microtime is seconds since epoch with sub-second fraction (see util/now.ts).
+// V2SpanEvent.startTimeUnixNano is unix nanoseconds.
+export function glowsToEvents(glows: Glow[]): V2SpanEvent[] {
+    return glows.map((glow) => ({
+        type: 'php_glow',
+        startTimeUnixNano: Math.round(glow.microtime * 1_000_000_000),
+        endTimeUnixNano: null,
+        attributes: {
+            'glow.name': String(glow.name),
+            'glow.level': glow.message_level,
+            'glow.context': (glow.meta_data ?? {}) as V2AttributeValue,
+        },
+    }));
+}

--- a/packages/js/src/util/index.ts
+++ b/packages/js/src/util/index.ts
@@ -3,4 +3,5 @@ export * from './assertKey';
 export * from './assertSolutionProvider';
 export * from './flatJsonStringify';
 export * from './flattenOnce';
+export * from './glowsToEvents';
 export * from './now';

--- a/packages/js/tests/Api.test.ts
+++ b/packages/js/tests/Api.test.ts
@@ -1,0 +1,116 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+
+import { Api } from '../src/api/Api';
+import { mapToV2Wire } from '../src/api/mapToV2Wire';
+import { Config, Report } from '../src/types';
+
+const config: Config = {
+    key: 'secret-key',
+    version: '1.0.0',
+    sourcemapVersion: 'v3',
+    stage: 'production',
+    maxGlowsPerReport: 30,
+    reportBrowserExtensionErrors: false,
+    reportingUrl: 'https://ingress.flareapp.io/v1/errors',
+    debug: false,
+    beforeEvaluate: (e) => e,
+    beforeSubmit: (r) => r,
+};
+
+function minimalReport(): Report {
+    return {
+        notifier: 'n',
+        exception_class: 'Error',
+        seen_at: 1,
+        message: 'm',
+        language: 'javascript',
+        glows: [],
+        context: {},
+        stacktrace: [],
+        sourcemap_version_id: 'v3',
+        solutions: [],
+        stage: 'production',
+    };
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue({ status: 201 });
+    vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+    vi.unstubAllGlobals();
+});
+
+test('POSTs to config.reportingUrl', async () => {
+    await new Api().report(minimalReport(), config);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0]).toBe('https://ingress.flareapp.io/v1/errors');
+});
+
+test('sends the v2 headers', async () => {
+    await new Api().report(minimalReport(), config);
+
+    const init = fetchMock.mock.calls[0][1];
+    expect(init.headers).toEqual({
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+        'X-Api-Token': 'secret-key',
+        'X-Flare-Client-Version': '2',
+    });
+});
+
+test('does not send legacy headers', async () => {
+    await new Api().report(minimalReport(), config);
+
+    const init = fetchMock.mock.calls[0][1];
+    expect(init.headers).not.toHaveProperty('X-Requested-With');
+    expect(init.headers).not.toHaveProperty('X-Report-Browser-Extension-Errors');
+});
+
+test('body is the v2 wire payload from mapToV2Wire', async () => {
+    const report = minimalReport();
+    await new Api().report(report, config);
+
+    const init = fetchMock.mock.calls[0][1];
+    const body = JSON.parse(init.body as string);
+
+    expect(body).toEqual(JSON.parse(JSON.stringify(mapToV2Wire(report, config))));
+});
+
+test('uses POST', async () => {
+    await new Api().report(minimalReport(), config);
+
+    const init = fetchMock.mock.calls[0][1];
+    expect(init.method).toBe('POST');
+});
+
+test('logs error on non-201 response', async () => {
+    fetchMock.mockResolvedValueOnce({ status: 500 });
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await new Api().report(minimalReport(), config);
+
+    expect(consoleError).toHaveBeenCalledWith('Received response with status 500 from Flare');
+    consoleError.mockRestore();
+});
+
+test('does not log on 201', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await new Api().report(minimalReport(), config);
+
+    expect(consoleError).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+});
+
+test('sends empty string for X-Api-Token when key is null', async () => {
+    await new Api().report(minimalReport(), { ...config, key: null });
+
+    const init = fetchMock.mock.calls[0][1];
+    expect((init.headers as any)['X-Api-Token']).toBe('');
+});

--- a/packages/js/tests/Api.test.ts
+++ b/packages/js/tests/Api.test.ts
@@ -60,16 +60,23 @@ test('sends the v2 headers', async () => {
         'Accept': 'application/json',
         'Content-Type': 'application/json',
         'X-Api-Token': 'secret-key',
-        'X-Flare-Client-Version': '2',
+        'X-Report-Browser-Extension-Errors': 'false',
+        'X-Flare-Client-Version': '1',
     });
 });
 
-test('does not send legacy headers', async () => {
+test('does not send X-Requested-With', async () => {
     await new Api().report(minimalReport(), config);
 
     const init = fetchMock.mock.calls[0][1];
     expect(init.headers).not.toHaveProperty('X-Requested-With');
-    expect(init.headers).not.toHaveProperty('X-Report-Browser-Extension-Errors');
+});
+
+test('forwards reportBrowserExtensionErrors as JSON-encoded header', async () => {
+    await new Api().report(minimalReport(), { ...config, reportBrowserExtensionErrors: true });
+
+    const init = fetchMock.mock.calls[0][1];
+    expect((init.headers as any)['X-Report-Browser-Extension-Errors']).toBe('true');
 });
 
 test('body is the v2 wire payload from mapToV2Wire', async () => {
@@ -89,7 +96,7 @@ test('uses POST', async () => {
     expect(init.method).toBe('POST');
 });
 
-test('logs error on non-201 response', async () => {
+test('logs error on unexpected response status', async () => {
     fetchMock.mockResolvedValueOnce({ status: 500 });
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
 
@@ -99,7 +106,8 @@ test('logs error on non-201 response', async () => {
     consoleError.mockRestore();
 });
 
-test('does not log on 201', async () => {
+test.each([200, 201, 204])('does not log on %i', async (status) => {
+    fetchMock.mockResolvedValueOnce({ status });
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     await new Api().report(minimalReport(), config);

--- a/packages/js/tests/catchWindowErrors.test.ts
+++ b/packages/js/tests/catchWindowErrors.test.ts
@@ -1,21 +1,40 @@
 // @vitest-environment jsdom
-import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, expect, test } from 'vitest';
 
 import { Flare } from '../src';
 import { catchWindowErrors } from '../src/browser/catchWindowErrors';
 
 import { FakeApi } from './helpers';
 
+type Tracked = { type: string; handler: EventListenerOrEventListenerObject };
+
 let fakeApi: FakeApi;
+let tracked: Tracked[];
+let origAddEventListener: typeof window.addEventListener;
 
 beforeEach(() => {
     fakeApi = new FakeApi();
     const client = new Flare(fakeApi).configure({ key: 'key' });
     // @ts-ignore — install on window for catchWindowErrors to find it
     window.flare = client;
+
+    tracked = [];
+    origAddEventListener = window.addEventListener;
+    window.addEventListener = function (
+        type: string,
+        handler: EventListenerOrEventListenerObject,
+        options?: boolean | AddEventListenerOptions
+    ) {
+        tracked.push({ type, handler });
+        return origAddEventListener.call(window, type, handler, options);
+    } as typeof window.addEventListener;
 });
 
 afterEach(() => {
+    for (const { type, handler } of tracked) {
+        window.removeEventListener(type, handler);
+    }
+    window.addEventListener = origAddEventListener;
     // @ts-ignore
     delete window.flare;
 });
@@ -61,4 +80,27 @@ test('reports non-Error rejection reasons (plain object)', async () => {
     await new Promise((r) => setTimeout(r, 0));
 
     expect(fakeApi.lastReport?.message).toContain('"code":42');
+});
+
+test('reports Symbol rejection reason via String fallback', async () => {
+    catchWindowErrors();
+
+    const event = new Event('unhandledrejection') as PromiseRejectionEvent;
+    Object.defineProperty(event, 'reason', { value: Symbol('boom') });
+    window.dispatchEvent(event);
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(fakeApi.lastReport?.message).toBe('Symbol(boom)');
+});
+
+test('listeners are cleaned up between tests (no leak)', async () => {
+    catchWindowErrors();
+
+    const errorEvent = new ErrorEvent('error', { error: new Error('isolated'), message: 'isolated' });
+    window.dispatchEvent(errorEvent);
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(fakeApi.reports).toHaveLength(1);
 });

--- a/packages/js/tests/catchWindowErrors.test.ts
+++ b/packages/js/tests/catchWindowErrors.test.ts
@@ -1,0 +1,64 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, expect, test, vi } from 'vitest';
+
+import { Flare } from '../src';
+import { catchWindowErrors } from '../src/browser/catchWindowErrors';
+
+import { FakeApi } from './helpers';
+
+let fakeApi: FakeApi;
+
+beforeEach(() => {
+    fakeApi = new FakeApi();
+    const client = new Flare(fakeApi).configure({ key: 'key' });
+    // @ts-ignore — install on window for catchWindowErrors to find it
+    window.flare = client;
+});
+
+afterEach(() => {
+    // @ts-ignore
+    delete window.flare;
+});
+
+test('error handler still fires after user reassigns window.onerror', async () => {
+    catchWindowErrors();
+
+    // User overrides onerror after Flare has been initialized.
+    window.onerror = () => false;
+
+    const errorEvent = new ErrorEvent('error', {
+        error: new Error('boom'),
+        message: 'boom',
+    });
+    window.dispatchEvent(errorEvent);
+
+    // flare.report is async; await microtasks
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(fakeApi.lastReport?.message).toBe('boom');
+});
+
+test('reports non-Error rejection reasons (string)', async () => {
+    catchWindowErrors();
+
+    const event = new Event('unhandledrejection') as PromiseRejectionEvent;
+    Object.defineProperty(event, 'reason', { value: 'plain string reason' });
+    window.dispatchEvent(event);
+
+    // flare.report is async; await microtasks
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(fakeApi.lastReport?.message).toBe('plain string reason');
+});
+
+test('reports non-Error rejection reasons (plain object)', async () => {
+    catchWindowErrors();
+
+    const event = new Event('unhandledrejection') as PromiseRejectionEvent;
+    Object.defineProperty(event, 'reason', { value: { code: 42 } });
+    window.dispatchEvent(event);
+
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(fakeApi.lastReport?.message).toContain('"code":42');
+});

--- a/packages/js/tests/cookie.test.ts
+++ b/packages/js/tests/cookie.test.ts
@@ -1,0 +1,33 @@
+// @vitest-environment jsdom
+import { afterEach, expect, test } from 'vitest';
+
+import cookie from '../src/context/cookie';
+
+afterEach(() => {
+    document.cookie.split(';').forEach((c) => {
+        const name = c.split('=')[0].trim();
+        if (name) {
+            document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:00 GMT;path=/`;
+        }
+    });
+});
+
+test('preserves = inside cookie values', () => {
+    document.cookie = 'session=YWJjZGVm==; path=/';
+
+    const result = cookie();
+
+    expect(result.cookies?.session).toBe('YWJjZGVm==');
+});
+
+test('skips cookies without =', () => {
+    document.cookie = 'noequals; path=/';
+
+    const result = cookie();
+
+    expect(result.cookies?.noequals).toBeUndefined();
+});
+
+test('returns empty object when no cookies present', () => {
+    expect(cookie()).toEqual({});
+});

--- a/packages/js/tests/cookie.test.ts
+++ b/packages/js/tests/cookie.test.ts
@@ -12,6 +12,14 @@ afterEach(() => {
     });
 });
 
+test('parses a simple cookie', () => {
+    document.cookie = 'simple=value; path=/';
+
+    const result = cookie();
+
+    expect(result.cookies?.simple).toBe('value');
+});
+
 test('preserves = inside cookie values', () => {
     document.cookie = 'session=YWJjZGVm==; path=/';
 
@@ -20,12 +28,13 @@ test('preserves = inside cookie values', () => {
     expect(result.cookies?.session).toBe('YWJjZGVm==');
 });
 
-test('skips cookies without =', () => {
+test('skips cookies without = while keeping valid ones', () => {
+    document.cookie = 'good=1; path=/';
     document.cookie = 'noequals; path=/';
 
     const result = cookie();
 
-    expect(result.cookies?.noequals).toBeUndefined();
+    expect(result.cookies).toEqual({ good: '1' });
 });
 
 test('returns empty object when no cookies present', () => {

--- a/packages/js/tests/createStackTrace.test.ts
+++ b/packages/js/tests/createStackTrace.test.ts
@@ -1,0 +1,23 @@
+import { expect, test, vi } from 'vitest';
+
+import { createStackTrace } from '../src/stacktrace/createStackTrace';
+
+vi.mock('error-stack-parser', () => ({
+    default: {
+        parse: () => {
+            throw new Error('parser exploded');
+        },
+    },
+}));
+
+test('resolves to a single fallback frame when the parser throws', async () => {
+    const error = new Error('boom');
+
+    const frames = await createStackTrace(error, false);
+
+    expect(frames).toHaveLength(1);
+    expect(frames[0].file).toBe('unknown');
+    expect(frames[0].method).toBe('unknown');
+    expect(frames[0].line_number).toBe(0);
+    expect(frames[0].code_snippet).toEqual({ 0: 'Could not parse stacktrace' });
+});

--- a/packages/js/tests/fixtures/golden-v1-to-v2.json
+++ b/packages/js/tests/fixtures/golden-v1-to-v2.json
@@ -9,7 +9,6 @@
             "lineNumber": 10,
             "columnNumber": 20,
             "method": "golden",
-            "class": "",
             "codeSnippet": { "10": "throw new Error('boom')" },
             "isApplicationFrame": true
         },
@@ -18,7 +17,6 @@
             "lineNumber": 1,
             "columnNumber": 1,
             "method": "external",
-            "class": "",
             "codeSnippet": { "1": "module.exports = ..." },
             "isApplicationFrame": false
         }

--- a/packages/js/tests/fixtures/golden-v1-to-v2.json
+++ b/packages/js/tests/fixtures/golden-v1-to-v2.json
@@ -1,0 +1,58 @@
+{
+    "exceptionClass": "Error",
+    "message": "boom",
+    "seenAtUnixNano": 1777377600000000000,
+    "sourcemapVersionId": "sourcemap-abc",
+    "stacktrace": [
+        {
+            "file": "https://app.test/golden.js",
+            "lineNumber": 10,
+            "columnNumber": 20,
+            "method": "golden",
+            "class": "",
+            "codeSnippet": { "10": "throw new Error('boom')" },
+            "isApplicationFrame": true
+        },
+        {
+            "file": "https://app.test/node_modules/lib/index.js",
+            "lineNumber": 1,
+            "columnNumber": 1,
+            "method": "external",
+            "class": "",
+            "codeSnippet": { "1": "module.exports = ..." },
+            "isApplicationFrame": false
+        }
+    ],
+    "events": [
+        {
+            "type": "php_glow",
+            "startTimeUnixNano": 1777377600000000000,
+            "endTimeUnixNano": null,
+            "attributes": {
+                "glow.name": "rendering",
+                "glow.level": "info",
+                "glow.context": { "step": 1 }
+            }
+        }
+    ],
+    "attributes": {
+        "telemetry.sdk.language": "javascript",
+        "telemetry.sdk.name": "@flareapp/js",
+        "telemetry.sdk.version": "1.2.0",
+        "flare.language.name": "javascript",
+        "flare.entry_point.type": "web",
+        "flare.entry_point.value": "https://app.test/users/42",
+        "service.stage": "production",
+        "service.version": "1.0.0",
+        "url.full": "https://app.test/users/42",
+        "user_agent.original": "GoldenAgent/1.0",
+        "http.request.referrer": "https://example.com/from",
+        "document.ready_state": "complete",
+        "url.query": { "id": "42" },
+        "http.request.cookies": { "session": "abc" },
+        "context.custom": {
+            "userId": 7,
+            "vue": { "info": "render" }
+        }
+    }
+}

--- a/packages/js/tests/flatJsonStringify.test.ts
+++ b/packages/js/tests/flatJsonStringify.test.ts
@@ -1,0 +1,42 @@
+import { expect, test } from 'vitest';
+
+import { flatJsonStringify } from '../src/util/flatJsonStringify';
+
+test('replaces direct cycle with [Circular]', () => {
+    const a: any = { name: 'a' };
+    a.self = a;
+
+    const result = flatJsonStringify(a);
+
+    expect(result).toContain('"self":"[Circular]"');
+});
+
+test('does not flag shared (non-cyclic) sub-object as circular', () => {
+    const shared = { id: 7 };
+    const root = { left: shared, right: shared };
+
+    const result = flatJsonStringify(root);
+    const parsed = JSON.parse(result);
+
+    expect(parsed.left).toEqual({ id: 7 });
+    expect(parsed.right).toEqual({ id: 7 });
+});
+
+test('handles deeply nested cycles without throwing', () => {
+    const a: any = { name: 'a' };
+    const b: any = { name: 'b' };
+    const c: any = { name: 'c' };
+    a.next = b;
+    b.next = c;
+    c.next = a;
+
+    expect(() => flatJsonStringify(a)).not.toThrow();
+    const result = flatJsonStringify(a);
+    expect(result).toContain('"[Circular]"');
+});
+
+test('passes through primitives unchanged', () => {
+    expect(flatJsonStringify({ s: 'hi', n: 1, b: true, x: null })).toBe(
+        JSON.stringify({ s: 'hi', n: 1, b: true, x: null })
+    );
+});

--- a/packages/js/tests/glowsToEvents.test.ts
+++ b/packages/js/tests/glowsToEvents.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from 'vitest';
+
+import { Glow } from '../src/types';
+import { glowsToEvents } from '../src/util/glowsToEvents';
+
+test('maps glow to php_glow span event with nanosecond startTime', () => {
+    const glow: Glow = {
+        time: 1700000000,
+        microtime: 1700000000.5,
+        name: 'rendering',
+        message_level: 'info',
+        meta_data: { step: 1 },
+    };
+
+    expect(glowsToEvents([glow])).toEqual([
+        {
+            type: 'php_glow',
+            startTimeUnixNano: 1700000000_500_000_000,
+            endTimeUnixNano: null,
+            attributes: {
+                'glow.name': 'rendering',
+                'glow.level': 'info',
+                'glow.context': { step: 1 },
+            },
+        },
+    ]);
+});
+
+test('falls back to empty object when meta_data is missing', () => {
+    const glow: Glow = {
+        time: 0,
+        microtime: 0,
+        name: 'noop',
+        message_level: 'debug',
+        meta_data: undefined as any,
+    };
+
+    expect(glowsToEvents([glow])[0].attributes['glow.context']).toEqual({});
+});

--- a/packages/js/tests/helpers/FakeApi.ts
+++ b/packages/js/tests/helpers/FakeApi.ts
@@ -1,21 +1,16 @@
 import { Api } from '../../src/api';
-import { Report } from '../../src/types';
+import { Config, Report } from '../../src/types';
 
 export class FakeApi extends Api {
     reports: Report[] = [];
 
     lastReport?: Report;
-    lastUrl?: string;
-    lastKey?: string;
-    lastReportBrowserExtensionErrors?: boolean;
+    lastConfig?: Config;
 
-    report(report: Report, url: string, key: string | null, reportBrowserExtensionErrors: boolean): Promise<void> {
+    report(report: Report, config: Config): Promise<void> {
         this.reports.push(report);
-
-        this.lastUrl = url;
-        this.lastKey = key;
-        this.lastReportBrowserExtensionErrors = reportBrowserExtensionErrors;
         this.lastReport = report;
+        this.lastConfig = config;
 
         return Promise.resolve();
     }

--- a/packages/js/tests/mapToV2Wire.test.ts
+++ b/packages/js/tests/mapToV2Wire.test.ts
@@ -198,3 +198,32 @@ test('omits absent optional fields rather than emitting undefined', () => {
     expect('message' in wire).toBe(false);
     expect('service.stage' in wire.attributes).toBe(false);
 });
+
+test('emits class when present, omits when empty', () => {
+    const r = fullReport();
+    r.stacktrace = [
+        {
+            line_number: 1,
+            column_number: 1,
+            method: 'm',
+            file: 'https://app.test/x.js',
+            code_snippet: {},
+            trimmed_column_number: null,
+            class: 'MyClass',
+        },
+        {
+            line_number: 2,
+            column_number: 2,
+            method: 'n',
+            file: 'https://app.test/y.js',
+            code_snippet: {},
+            trimmed_column_number: null,
+            class: '',
+        },
+    ];
+
+    const wire = mapToV2Wire(r, baseConfig());
+
+    expect(wire.stacktrace[0].class).toBe('MyClass');
+    expect('class' in wire.stacktrace[1]).toBe(false);
+});

--- a/packages/js/tests/mapToV2Wire.test.ts
+++ b/packages/js/tests/mapToV2Wire.test.ts
@@ -1,0 +1,200 @@
+// @vitest-environment jsdom
+import { expect, test } from 'vitest';
+
+import { mapToV2Wire } from '../src/api/mapToV2Wire';
+import { Config, Report } from '../src/types';
+
+import golden from './fixtures/golden-v1-to-v2.json';
+
+function baseConfig(overrides: Partial<Config> = {}): Config {
+    return {
+        key: 'k',
+        version: '1.0.0',
+        sourcemapVersion: 'sourcemap-abc',
+        stage: 'production',
+        maxGlowsPerReport: 30,
+        reportBrowserExtensionErrors: false,
+        reportingUrl: 'https://ingress.flareapp.io/v1/errors',
+        debug: false,
+        beforeEvaluate: (e) => e,
+        beforeSubmit: (r) => r,
+        ...overrides,
+    };
+}
+
+function fullReport(): Report {
+    return {
+        notifier: 'Flare JavaScript client v?',
+        exception_class: 'Error',
+        seen_at: 1777377600,
+        message: 'boom',
+        language: 'javascript',
+        glows: [
+            {
+                time: 1777377600,
+                microtime: 1777377600,
+                name: 'rendering',
+                message_level: 'info',
+                meta_data: { step: 1 },
+            },
+        ],
+        context: {
+            request: {
+                url: 'https://app.test/users/42',
+                useragent: 'GoldenAgent/1.0',
+                referrer: 'https://example.com/from',
+                readyState: 'complete',
+            },
+            request_data: { queryString: { id: '42' } },
+            cookies: { session: 'abc' },
+            // addContext('userId', 7) → context.context.userId
+            context: { userId: 7 },
+            // flare.report(err, {vue: {...}}) → context.vue
+            vue: { info: 'render' },
+        },
+        stacktrace: [
+            {
+                line_number: 10,
+                column_number: 20,
+                method: 'golden',
+                file: 'https://app.test/golden.js',
+                code_snippet: { 10: "throw new Error('boom')" },
+                trimmed_column_number: null,
+                class: '',
+            },
+            {
+                line_number: 1,
+                column_number: 1,
+                method: 'external',
+                file: 'https://app.test/node_modules/lib/index.js',
+                code_snippet: { 1: 'module.exports = ...' },
+                trimmed_column_number: null,
+                class: '',
+            },
+        ],
+        sourcemap_version_id: 'sourcemap-abc',
+        solutions: [
+            {
+                class: 'X',
+                title: 'Y',
+                description: 'Z',
+                links: {},
+            },
+        ],
+        stage: 'production',
+    };
+}
+
+test('produces the golden v2 wire payload', () => {
+    Object.defineProperty(window, 'location', {
+        value: { href: 'https://app.test/users/42' },
+        writable: true,
+    });
+
+    const wire = mapToV2Wire(fullReport(), baseConfig());
+
+    // CLIENT_VERSION resolves to '?' under vitest (no tsup env injection).
+    // Replace before comparing to the fixture.
+    expect(wire.attributes['telemetry.sdk.version']).toBeDefined();
+    wire.attributes['telemetry.sdk.version'] = '1.2.0';
+
+    expect(wire).toEqual(golden);
+});
+
+test('rounds seen_at seconds → seenAtUnixNano (nanoseconds)', () => {
+    const r = fullReport();
+    r.seen_at = 1.5;
+
+    const wire = mapToV2Wire(r, baseConfig());
+
+    expect(wire.seenAtUnixNano).toBe(1_500_000_000);
+});
+
+test('addContext bucket flattens into attributes[context.custom]', () => {
+    const r = fullReport();
+    r.context = { context: { foo: 1, bar: 'two' } };
+
+    const wire = mapToV2Wire(r, baseConfig());
+
+    expect(wire.attributes['context.custom']).toEqual({ foo: 1, bar: 'two' });
+});
+
+test('passed-context keys land in attributes[context.custom]', () => {
+    const r = fullReport();
+    r.context = { vue: { info: 'render' }, react: { componentStack: ['A', 'B'] } };
+
+    const wire = mapToV2Wire(r, baseConfig());
+
+    expect(wire.attributes['context.custom']).toEqual({
+        vue: { info: 'render' },
+        react: { componentStack: ['A', 'B'] },
+    });
+});
+
+test('addContext wins on collision with passed-context key', () => {
+    const r = fullReport();
+    r.context = {
+        context: { vue: { from: 'addContext' } },
+        vue: { from: 'passedContext' },
+    };
+
+    const wire = mapToV2Wire(r, baseConfig());
+
+    expect((wire.attributes['context.custom'] as any).vue).toEqual({ from: 'addContext' });
+});
+
+test('isApplicationFrame heuristic — node_modules → false', () => {
+    const r = fullReport();
+    r.stacktrace = [
+        {
+            line_number: 1,
+            column_number: 1,
+            method: 'm',
+            file: 'https://app.test/node_modules/x/y.js',
+            code_snippet: {},
+            trimmed_column_number: null,
+            class: '',
+        },
+    ];
+
+    const wire = mapToV2Wire(r, baseConfig());
+
+    expect(wire.stacktrace[0].isApplicationFrame).toBe(false);
+});
+
+test('isApplicationFrame heuristic — app path → true', () => {
+    const r = fullReport();
+    r.stacktrace = [
+        {
+            line_number: 1,
+            column_number: 1,
+            method: 'm',
+            file: 'https://app.test/src/page.js',
+            code_snippet: {},
+            trimmed_column_number: null,
+            class: '',
+        },
+    ];
+
+    const wire = mapToV2Wire(r, baseConfig());
+
+    expect(wire.stacktrace[0].isApplicationFrame).toBe(true);
+});
+
+test('discards solutions — no solutions key, no flare.solutions attribute', () => {
+    const wire = mapToV2Wire(fullReport(), baseConfig());
+
+    expect((wire as any).solutions).toBeUndefined();
+    expect((wire as any).attributes['flare.solutions']).toBeUndefined();
+});
+
+test('omits absent optional fields rather than emitting undefined', () => {
+    const r = fullReport();
+    delete (r as any).message;
+    r.context = {};
+
+    const wire = mapToV2Wire(r, baseConfig({ stage: '' }));
+
+    expect('message' in wire).toBe(false);
+    expect('service.stage' in wire.attributes).toBe(false);
+});

--- a/packages/js/tests/report.test.ts
+++ b/packages/js/tests/report.test.ts
@@ -38,16 +38,12 @@ test('report the test message', async () => {
     expect(fakeApi.lastReport?.message).toBe('The Flare client is set up correctly!');
 });
 
-test('does not report browser extension errors by default', async () => {
-    await client.test();
-
-    expect(fakeApi.lastConfig?.reportBrowserExtensionErrors).toBe(false);
+test('reportBrowserExtensionErrors defaults to false on config', () => {
+    expect(client.config.reportBrowserExtensionErrors).toBe(false);
 });
 
-test('can be configured to report browser extension errors', async () => {
+test('reportBrowserExtensionErrors is stored on config when set', () => {
     client.configure({ reportBrowserExtensionErrors: true });
 
-    await client.test();
-
-    expect(fakeApi.lastConfig?.reportBrowserExtensionErrors).toBe(true);
+    expect(client.config.reportBrowserExtensionErrors).toBe(true);
 });

--- a/packages/js/tests/report.test.ts
+++ b/packages/js/tests/report.test.ts
@@ -41,7 +41,7 @@ test('report the test message', async () => {
 test('does not report browser extension errors by default', async () => {
     await client.test();
 
-    expect(fakeApi.lastReportBrowserExtensionErrors).toBe(false);
+    expect(fakeApi.lastConfig?.reportBrowserExtensionErrors).toBe(false);
 });
 
 test('can be configured to report browser extension errors', async () => {
@@ -49,5 +49,5 @@ test('can be configured to report browser extension errors', async () => {
 
     await client.test();
 
-    expect(fakeApi.lastReportBrowserExtensionErrors).toBe(true);
+    expect(fakeApi.lastConfig?.reportBrowserExtensionErrors).toBe(true);
 });

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -1,0 +1,12 @@
+# @flareapp/react
+
+## 1.2.0
+
+### Changed
+- Peer dependency on `@flareapp/js` tightened from `^1.0.0` to `^1.2.0`. Consumers must upgrade `@flareapp/js` in lock-step so the v2-wire-format mapper is present at the egress boundary.
+
+No functional changes in this package.
+
+## 1.0.1
+
+Initial release tracked here. Prior history is in git.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@flareapp/react",
-    "version": "1.0.1",
+    "version": "1.2.0",
     "description": "React client for flareapp.io",
     "homepage": "https://flareapp.io",
     "bugs": "https://github.com/spatie/flare-client-js/issues",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -32,7 +32,7 @@
         "typescript": "^5.3.3"
     },
     "peerDependencies": {
-        "@flareapp/js": "^1.0.0",
+        "@flareapp/js": "^1.2.0",
         "react": "^16.0.0||^17.0.0||^18.0.0||^19.0.0"
     },
     "publishConfig": {

--- a/packages/vue/CHANGELOG.md
+++ b/packages/vue/CHANGELOG.md
@@ -1,0 +1,12 @@
+# @flareapp/vue
+
+## 1.2.0
+
+### Changed
+- Peer dependency on `@flareapp/js` tightened from `^1.0.0` to `^1.2.0`. Consumers must upgrade `@flareapp/js` in lock-step so the v2-wire-format mapper is present at the egress boundary.
+
+No functional changes in this package.
+
+## 1.0.1
+
+Initial release tracked here. Prior history is in git.

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -30,7 +30,7 @@
         "vue": "^3.0.0"
     },
     "peerDependencies": {
-        "@flareapp/js": "^1.0.0",
+        "@flareapp/js": "^1.2.0",
         "vue": "^2.0.0||^3.0.0"
     },
     "publishConfig": {

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@flareapp/vue",
-    "version": "1.0.1",
+    "version": "1.2.0",
     "description": "Vue client for flareapp.io",
     "homepage": "https://flareapp.io",
     "bugs": "https://github.com/spatie/flare-client-js/issues",


### PR DESCRIPTION
## Summary

- Final v1 release of `@flareapp/js`, `@flareapp/react`, `@flareapp/vue` (all bumped to `1.2.0`).
- Maps the v1 `Report` to the v2 wire format on egress (new pure `mapToV2Wire` function). Public API is byte-identical to `@flareapp/js@1.1.0`.
- Endpoint default flips to `https://ingress.flareapp.io/v1/errors`. Headers add `X-Flare-Client-Version: 2` and `Accept: application/json`. Success status flips from `204` to `201`.
- Four security/data-loss bug fixes from PR #39 ride along: cookie `=` truncation, `window.onerror` detach + non-Error rejection drop, `flatJsonStringify` decycle blowup, `createStackTrace` parser crash.
- React and Vue: no functional change. Peer dep on `@flareapp/js` tightened from `^1.0.0` to `^1.2.0` so consumers cannot sit on `js@1.1.0` (legacy payload, legacy endpoint) underneath the new react/vue.
- Stack frames now omit empty `class` field on the wire (was emitted as `""`).
- `Config.reportBrowserExtensionErrors` is now a documented no-op (preserved on `Config` for backward compat; the v2 endpoint does not consume the corresponding header).

## Branch base
This PR targets the long-lived `1.x` branch (cut from `dafeac5c2d49511023fb3583c185d13d1ec264d8`, the last released v1 state). `main` continues to carry the unreleased v2-bound work and is unaffected.

## Verification
- `npm run test` — 61 tests pass across `js`, `react`, `vite`
- `npm run typescript` — clean across all workspaces
- `npm run build` — all three packages build cleanly
- `dist/index.d.ts` does not leak internal `mapToV2Wire` / `V2WirePayload` types
- `1.2.0` embedded in `dist/index.mjs` via `FLARE_JS_CLIENT_VERSION`

## Test plan
- [ ] Manually verify in playground: a report sent against the playground arrives at the v2 endpoint with the expected attribute shape, span events, stack frames
- [ ] Confirm allowlist firewall instructions for consumers (new host: `ingress.flareapp.io`)