### PR TITLE
V2 release readiness improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ All commands are run from the repository root:
 | `npm run build`      | Build all packages to their respective `dist` folders |
 | `npm run test`       | Run tests for all packages that have them             |
 | `npm run typescript` | Type-check all packages                               |
-| `npm run format`     | Run Prettier across all files                         |
+| `npm run format`     | Run oxfmt across all files                            |
+| `npm run lint`       | Run oxlint across all packages                        |
 | `npm run playground` | Build packages, then start the playground dev server  |
 
 ### Playground
@@ -70,15 +71,16 @@ See the [playground README](playground/README.md) for more details.
 
 ### Code style
 
-Formatting is handled by Prettier. A pre-commit hook (Husky + lint-staged) automatically formats staged files on commit.
+Formatting is handled by [oxfmt](https://oxc.rs/blog/2025-03-15-oxfmt.html) and linting by [oxlint](https://oxc.rs/docs/guide/usage/linter/). A pre-commit hook (Husky + lint-staged) automatically formats and lints staged files on commit.
 
-To manually format all files:
+To manually format and lint all files:
 
 ```bash
 npm run format
+npm run lint
 ```
 
-See `.prettierrc` for the full configuration.
+See `.oxfmtrc.json` and `.oxlintrc.json` for configuration.
 
 ### CI
 

--- a/docs/v1-to-v2-migration.md
+++ b/docs/v1-to-v2-migration.md
@@ -97,6 +97,10 @@ const err = new Error('Connection failed');
 flare.report(err); // payload.code === 'ENOTFOUND'
 ```
 
+### Vue 2 dropped
+
+`@flareapp/vue@2` only supports Vue 3 (`^3.0.0`). If you are on Vue 2, stay on `@flareapp/vue@1`.
+
 ## What did NOT change
 
 - Authentication mechanism (project API key in a header).

--- a/e2e/vue.spec.ts
+++ b/e2e/vue.spec.ts
@@ -350,12 +350,9 @@ test.describe('Vue playground', () => {
             await page.getByRole('button', { name: 'beforeSubmit (modify)' }).click();
             const report = await reportPromise;
 
-            const context = report.context as Record<string, unknown> | undefined;
-            expect(context).toBeDefined();
-            const hook = context!.custom_hook as Record<string, unknown>;
+            const hook = report.attributes['context.custom_hook'] as Record<string, unknown> | undefined;
             expect(hook).toBeDefined();
-            expect(hook.injected_by).toBe('beforeSubmit hook');
-            expect(hook.timestamp).toBeGreaterThan(0);
+            expect(hook!.injected_by).toBe('beforeSubmit hook');
         });
     });
 });

--- a/packages/js/CHANGELOG.md
+++ b/packages/js/CHANGELOG.md
@@ -3,16 +3,16 @@
 ### Breaking changes
 
 - **Endpoint changed.** SDK now POSTs to `https://ingress.flareapp.io/v1/errors`. Success response is `201 Created`. Auth header is `x-api-token`.
-- **Wire format reshaped to match the server's canonical schema** (no more `MapOldReportFormatAction` round-trip).
+- **Wire format reshaped to match the server's canonical schema.**
     - `Report` uses camelCase top-level fields (`exceptionClass`, `seenAtUnixNano`, `sourcemapVersionId`, `isLog`, `level`, `attributes`, `events`).
     - `StackFrame` uses camelCase (`lineNumber`, `columnNumber`, `codeSnippet`, `isApplicationFrame`).
     - `Context` is gone. User context is set via `addContext(name, value)` and `addContextGroup(group, value)`; both write into the flat `attributes` map under `context.custom` and `context.<group>`.
     - Glows ride along as `php_glow`-typed entries in `events[]`.
 - **`report()` second argument** is now an `Attributes` map (was a freeform context object). The third argument (solution provider parameters) is removed.
-- **Config keys renamed:** `reportingUrl` → `ingestUrl`, `sourcemapVersion` → `sourcemapVersionId`. No aliases.
+- **Config keys renamed:** `reportingUrl` → `ingestUrl`, `sourcemapVersion` → `sourcemapVersionId`.
 - **Deprecated trailing setters removed:** `flare.beforeEvaluate = …`, `flare.beforeSubmit = …`, `flare.stage = …`. Use `flare.configure({ … })`.
-- **`reportMessage` signature changed:** `reportMessage(message, level?, attributes?)`. The old `'Log INFO'` regex is gone — pass `level` directly.
-- **Solutions API removed:** `registerSolutionProvider`, `Solution`, `SolutionProvider`, `SolutionProviderExtraParameters` are all deleted. The server has been silently dropping `solutions` from payloads; the client now matches.
+- **`reportMessage` signature changed:** `reportMessage(message, level?, attributes?)`. The old `'Log INFO'` regex is gone, pass `level` directly.
+- **Solutions API removed:** `registerSolutionProvider`, `Solution`, `SolutionProvider`, `SolutionProviderExtraParameters` are all deleted.
 - **`flare.config` is now `Readonly<Config>`** and `flare.glows` is `readonly Glow[]`. Direct property mutation no longer works; use `configure()`.
 
 ### New

--- a/packages/js/CHANGELOG.md
+++ b/packages/js/CHANGELOG.md
@@ -8,17 +8,24 @@
     - `StackFrame` uses camelCase (`lineNumber`, `columnNumber`, `codeSnippet`, `isApplicationFrame`).
     - `Context` is gone. User context is set via `addContext(name, value)` and `addContextGroup(group, value)`; both write into the flat `attributes` map under `context.custom` and `context.<group>`.
     - Glows ride along as `php_glow`-typed entries in `events[]`.
+- **`report()` second argument** is now an `Attributes` map (was a freeform context object). The third argument (solution provider parameters) is removed.
 - **Config keys renamed:** `reportingUrl` → `ingestUrl`, `sourcemapVersion` → `sourcemapVersionId`. No aliases.
 - **Deprecated trailing setters removed:** `flare.beforeEvaluate = …`, `flare.beforeSubmit = …`, `flare.stage = …`. Use `flare.configure({ … })`.
 - **`reportMessage` signature changed:** `reportMessage(message, level?, attributes?)`. The old `'Log INFO'` regex is gone — pass `level` directly.
-- **Solutions API removed:** `registerSolutionProvider`, `Solution`, `SolutionProvider`, `SolutionProviderExtraParameters`, and the third arg to `report()` are all deleted. The server has been silently dropping `solutions` from payloads; the client now matches.
+- **Solutions API removed:** `registerSolutionProvider`, `Solution`, `SolutionProvider`, `SolutionProviderExtraParameters` are all deleted. The server has been silently dropping `solutions` from payloads; the client now matches.
+- **`flare.config` is now `Readonly<Config>`** and `flare.glows` is `readonly Glow[]`. Direct property mutation no longer works; use `configure()`.
 
 ### New
 
+- **URL redaction.** Sensitive query-string parameters (`password`, `token`, `secret`, `authorization`, etc.) are automatically replaced with `[redacted]` in `url.full`, `url.query`, and `flare.entry_point.value` attributes. Configurable via `urlDenylist` (custom regex) and `replaceDefaultUrlDenylist` (boolean) config options.
+- `DEFAULT_URL_DENYLIST`, `redactFullPath`, and `resolveDenylist` are exported for direct use by framework adapters.
 - `setEntryPoint({ identifier?, name?, type? })` — mutable global setter for the entry-point handler. SPA framework adapters call this on every navigation.
 - `setSdkInfo({ name, version })` — overridable SDK identity (default `@flareapp/js` + client version). Integrations override it.
 - `setFramework({ name, version? })` — host framework attribution (e.g. React, Vue).
 - `code` field auto-populated from `error.code` when present (string, ≤64 chars).
+- Non-`Error` values passed to `report()` are coerced to `Error` instead of silently failing.
+- Browser context attributes (`url.full`, `url.query`, `browser.user_agent`, `browser.viewport.*`, cookies, request data) are auto-collected on each report.
+- New exported types: `SpanEvent`, `EntryPointHandler`, `Framework`, `SdkInfo`, `OverriddenGrouping`, `Attributes`, `AttributeValue`.
 
 ### Notes
 

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -42,7 +42,7 @@
         "prepublishOnly": "npm run build",
         "build": "tsdown src/index.ts --format cjs,esm --dts --env.FLARE_JS_CLIENT_VERSION=$(node -p \"require('./package.json').version\") --clean",
         "test": "vitest run",
-        "typescript": "tsc",
+        "typescript": "tsc --noEmit",
         "release": "release-it"
     },
     "dependencies": {

--- a/packages/js/src/browser/catchWindowErrors.ts
+++ b/packages/js/src/browser/catchWindowErrors.ts
@@ -17,7 +17,7 @@ export function catchWindowErrors() {
         if (!flare) return;
         // ErrorEvent.error is null for cross-origin script errors ("Script error."), skip those.
         if (event.error instanceof Error) {
-            flare.report(event.error);
+            Promise.resolve(flare.report(event.error)).catch(() => {});
         }
     });
 
@@ -27,18 +27,18 @@ export function catchWindowErrors() {
 
         const reason = event.reason;
         if (reason instanceof Error) {
-            flare.report(reason);
+            Promise.resolve(flare.report(reason)).catch(() => {});
             return;
         }
 
         if (hasStack(reason)) {
             const error = new Error(describeRejectionReason(reason));
             error.stack = (reason as { stack: string }).stack;
-            flare.report(error);
+            Promise.resolve(flare.report(error)).catch(() => {});
             return;
         }
 
-        flare.reportUnhandledRejection(describeRejectionReason(reason));
+        Promise.resolve(flare.reportUnhandledRejection(describeRejectionReason(reason))).catch(() => {});
     });
 }
 

--- a/packages/js/src/util/redactUrl.ts
+++ b/packages/js/src/util/redactUrl.ts
@@ -14,7 +14,8 @@ export function resolveDenylist(
     }
 
     if (replaceDefault) {
-        return custom;
+        const safeFlags = custom.flags.replace(/[gy]/g, '');
+        return new RegExp(custom.source, safeFlags);
     }
 
     const flags = unionFlags(defaultDenylist.flags, custom.flags);

--- a/packages/js/tests/redactUrl.test.ts
+++ b/packages/js/tests/redactUrl.test.ts
@@ -58,6 +58,22 @@ describe('resolveDenylist', () => {
         expect(replaced.test('password')).toBe(false);
         expect(replaced.test('myParam')).toBe(true);
     });
+
+    test('strips global/sticky flags to prevent stateful .test()', () => {
+        const resolved = resolveDenylist(/secret/gi, true);
+        expect(resolved.flags).not.toContain('g');
+        expect(resolved.flags).not.toContain('y');
+
+        const url = '/page?secret=1&secret=2';
+        const result = redactFullPath(url, resolved);
+        expect(result).toBe('/page?secret=[redacted]&secret=[redacted]');
+    });
+
+    test('strips global/sticky flags when merging with default', () => {
+        const resolved = resolveDenylist(/myParam/gy);
+        expect(resolved.flags).not.toContain('g');
+        expect(resolved.flags).not.toContain('y');
+    });
 });
 
 describe('Flare URL scrubbing', () => {

--- a/packages/react/CHANGELOG.md
+++ b/packages/react/CHANGELOG.md
@@ -4,8 +4,14 @@
 
 - Bumps peer dependency `@flareapp/js` to `^2.0.0`. See its CHANGELOG for wire format changes.
 - `flareReactErrorHandler` no longer passes a third `extraSolutionParameters` arg to `flare.report` (solutions API removed in `@flareapp/js` v2).
-- The React component stack now lands on the report as `attributes['context.custom'].react.componentStack` and `attributes['context.custom'].react.componentStackFrames` (was nested under `context.react.*`). The `beforeSubmit` callback shape is unchanged.
+- The React component stack now lands on the report as `attributes['context.custom'].react.componentStack` and `attributes['context.custom'].react.componentStackFrames` (was nested under `context.react.*`).
 
 ### New
 
+- **`FlareErrorBoundary` lifecycle hooks.** `beforeEvaluate`, `beforeSubmit`, and `afterSubmit` props give full control over the report pipeline from within the boundary.
+- **`resetKeys` prop.** Mirrors `react-error-boundary`'s contract: when any element changes by `Object.is`, the boundary auto-resets. Pairs with the `onReset` callback.
+- **`FlareErrorBoundaryFallbackProps`** now includes `resetErrorBoundary()` for programmatic reset from fallback UI.
+- **`flareReactErrorHandler()` lifecycle hooks.** Same `beforeEvaluate`, `beforeSubmit`, and `afterSubmit` options, for use with third-party error boundaries.
+- Non-`Error` values passed to `flareReactErrorHandler` are coerced to `Error`.
 - The package self-identifies via `flare.setSdkInfo({ name: '@flareapp/react', version })` and `flare.setFramework({ name: 'React', version: React.version })` on import.
+- New exported types: `ComponentStackFrame`, `FlareReactContext`, `FlareReactErrorHandlerCallback`, `FlareReactErrorHandlerOptions`.

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -43,7 +43,7 @@
         "prepublishOnly": "npm run build",
         "build": "tsdown src/index.ts --format cjs,esm --dts --clean",
         "test": "vitest run",
-        "typescript": "tsc",
+        "typescript": "tsc --noEmit",
         "release": "release-it"
     },
     "devDependencies": {

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@flareapp/vite",
-    "version": "1.1.0",
+    "version": "2.0.0",
     "description": "Vite plugin for flareapp.io",
     "homepage": "https://flareapp.io",
     "bugs": "https://github.com/spatie/flare-client-js/issues",

--- a/packages/vite/tests/plugin.test.ts
+++ b/packages/vite/tests/plugin.test.ts
@@ -1,6 +1,35 @@
-import { describe, expect, test, vi } from 'vitest';
+import { existsSync, readFileSync, unlinkSync } from 'node:fs';
 
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import { FlareApi } from '../src/flareApi';
 import flareSourcemaps from '../src/index';
+
+vi.mock('node:fs', () => ({
+    existsSync: vi.fn(),
+    readFileSync: vi.fn(),
+    unlinkSync: vi.fn(),
+}));
+
+vi.mock('../src/flareApi');
+
+function createPlugin(
+    { apiKey = 'test-key', ...rest }: Parameters<typeof flareSourcemaps>[0] = { apiKey: 'test-key' }
+) {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const plugin = flareSourcemaps({ apiKey, ...rest }) as any;
+    warnSpy.mockRestore();
+
+    plugin.config({}, { mode: 'production' });
+    plugin.configResolved({ logger: { info: vi.fn(), error: vi.fn() }, base: '/' });
+
+    return plugin;
+}
+
+afterEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+});
 
 describe('flareSourcemaps plugin', () => {
     describe('config hook', () => {
@@ -64,6 +93,134 @@ describe('flareSourcemaps plugin', () => {
 
             expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('No Flare API key'));
             warnSpy.mockRestore();
+        });
+    });
+
+    describe('writeBundle — sourcemap discovery from bundle parameter', () => {
+        test('discovers .map files from bundle keys, not from the filesystem', async () => {
+            const plugin = createPlugin();
+            const uploadSpy = vi.mocked(FlareApi.prototype.uploadSourcemap).mockResolvedValue();
+            vi.mocked(existsSync).mockReturnValue(true);
+            vi.mocked(readFileSync).mockReturnValue('{"mappings":"AAAA"}');
+
+            await plugin.writeBundle(
+                { dir: '/dist' },
+                {
+                    'assets/app.js': {},
+                    'assets/app.js.map': {},
+                    'assets/vendor.js': {},
+                    'assets/vendor.js.map': {},
+                }
+            );
+
+            expect(uploadSpy).toHaveBeenCalledTimes(2);
+            expect(uploadSpy).toHaveBeenCalledWith(expect.objectContaining({ originalFile: '/assets/app.js' }));
+            expect(uploadSpy).toHaveBeenCalledWith(expect.objectContaining({ originalFile: '/assets/vendor.js' }));
+        });
+
+        test('ignores non-.map entries in the bundle', async () => {
+            const plugin = createPlugin();
+            const uploadSpy = vi.mocked(FlareApi.prototype.uploadSourcemap).mockResolvedValue();
+            vi.mocked(existsSync).mockReturnValue(true);
+            vi.mocked(readFileSync).mockReturnValue('{"mappings":"AAAA"}');
+
+            await plugin.writeBundle(
+                { dir: '/dist' },
+                {
+                    'assets/app.js': {},
+                    'assets/app.css': {},
+                    'assets/index.html': {},
+                }
+            );
+
+            expect(uploadSpy).not.toHaveBeenCalled();
+        });
+
+        test('skips .map files when corresponding source file does not exist on disk', async () => {
+            const plugin = createPlugin();
+            const uploadSpy = vi.mocked(FlareApi.prototype.uploadSourcemap).mockResolvedValue();
+            vi.mocked(existsSync).mockReturnValue(false);
+
+            await plugin.writeBundle({ dir: '/dist' }, { 'assets/app.js.map': {} });
+
+            expect(uploadSpy).not.toHaveBeenCalled();
+            expect(existsSync).toHaveBeenCalledWith(expect.stringContaining('assets/app.js'));
+        });
+
+        test('reads sourcemap content from disk for each bundle .map entry', async () => {
+            const plugin = createPlugin();
+            vi.mocked(FlareApi.prototype.uploadSourcemap).mockResolvedValue();
+            vi.mocked(existsSync).mockReturnValue(true);
+            vi.mocked(readFileSync).mockReturnValue('{"version":3,"mappings":"AAAA"}');
+
+            await plugin.writeBundle({ dir: '/dist' }, { 'assets/app.js.map': {} });
+
+            expect(readFileSync).toHaveBeenCalledWith(expect.stringContaining('assets/app.js.map'), 'utf8');
+        });
+
+        test('prefixes originalFile with resolved base path', async () => {
+            const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            const plugin = flareSourcemaps({ apiKey: 'test-key', base: '/my-app/' }) as any;
+            warnSpy.mockRestore();
+
+            plugin.config({}, { mode: 'production' });
+            plugin.configResolved({ logger: { info: vi.fn(), error: vi.fn() }, base: '/' });
+
+            const uploadSpy = vi.mocked(FlareApi.prototype.uploadSourcemap).mockResolvedValue();
+            vi.mocked(existsSync).mockReturnValue(true);
+            vi.mocked(readFileSync).mockReturnValue('{"mappings":""}');
+
+            await plugin.writeBundle({ dir: '/dist' }, { 'assets/app.js.map': {} });
+
+            expect(uploadSpy).toHaveBeenCalledWith(expect.objectContaining({ originalFile: '/my-app/assets/app.js' }));
+        });
+
+        test('does not upload when upload is disabled', async () => {
+            const plugin = createPlugin({ apiKey: '' });
+            const uploadSpy = vi.mocked(FlareApi.prototype.uploadSourcemap).mockResolvedValue();
+
+            await plugin.writeBundle({ dir: '/dist' }, { 'assets/app.js.map': {} });
+
+            expect(uploadSpy).not.toHaveBeenCalled();
+        });
+
+        test('continues uploading remaining sourcemaps when one fails', async () => {
+            const plugin = createPlugin();
+            vi.mocked(existsSync).mockReturnValue(true);
+            vi.mocked(readFileSync).mockReturnValue('{"mappings":""}');
+
+            const uploadSpy = vi.mocked(FlareApi.prototype.uploadSourcemap);
+            uploadSpy.mockRejectedValueOnce(new Error('upload failed')).mockResolvedValueOnce();
+
+            await plugin.writeBundle(
+                { dir: '/dist' },
+                {
+                    'assets/app.js.map': {},
+                    'assets/vendor.js.map': {},
+                }
+            );
+
+            expect(uploadSpy).toHaveBeenCalledTimes(2);
+        });
+
+        test('only deletes sourcemaps that uploaded successfully', async () => {
+            const plugin = createPlugin({ apiKey: 'test-key', removeSourcemaps: true });
+            vi.mocked(existsSync).mockReturnValue(true);
+            vi.mocked(readFileSync).mockReturnValue('{"mappings":""}');
+
+            const uploadSpy = vi.mocked(FlareApi.prototype.uploadSourcemap);
+            uploadSpy.mockRejectedValueOnce(new Error('upload failed')).mockResolvedValueOnce();
+
+            await plugin.writeBundle(
+                { dir: '/dist' },
+                {
+                    'assets/fail.js.map': {},
+                    'assets/ok.js.map': {},
+                }
+            );
+
+            expect(unlinkSync).toHaveBeenCalledTimes(1);
+            expect(unlinkSync).toHaveBeenCalledWith(expect.stringContaining('ok.js.map'));
         });
     });
 });

--- a/packages/vue/CHANGELOG.md
+++ b/packages/vue/CHANGELOG.md
@@ -4,9 +4,20 @@
 
 - Bumps peer dependency `@flareapp/js` to `^2.0.0`. See its CHANGELOG for wire format changes.
 - `flareVue` no longer passes a third `extraSolutionParameters` arg to `flare.report`.
-- Vue error context now lands on the report as `attributes['vue.error.info']` and `attributes['vue.error.component_name']` (was nested under `context.vue.*`).
+- Vue error context now lands on the report as `attributes['context.custom'].vue.*` (was nested under `context.vue.*`). Key fields: `vue.info`, `vue.errorOrigin`, `vue.componentName`, `vue.componentHierarchy`, `vue.componentHierarchyFrames`, `vue.componentProps`, `vue.route`.
+- `vue-router` moved from a required to an optional peer dependency.
+- Dropped Vue 2 support. Only Vue 3 (`^3.0.0`) is supported.
 
 ### New
 
-- Route context is automatically captured from `app.config.globalProperties.$router` when an error occurs. No explicit router option needed. `vue-router` is now an optional peer dep.
+- **`FlareErrorBoundary` component.** Vue equivalent of the React error boundary. Catches errors in its subtree via `onErrorCaptured`, reports to Flare with full Vue context, and renders a `#fallback` slot with `error`, `componentProps`, `componentHierarchy`, `componentHierarchyFrames`, and `resetErrorBoundary`. Supports `resetKeys` for auto-reset and `onReset` callback.
+- **Lifecycle hooks on `flareVue()`.** `beforeEvaluate`, `beforeSubmit`, and `afterSubmit` options give control over the report pipeline at the app level.
+- **`captureWarnings` option.** When enabled, Vue warnings are reported via `flare.reportMessage()` at `warning` level.
+- **Prop serialization.** `attachProps` (boolean), `propsMaxDepth` (number), `propsDenylist` (regex), and `replaceDefaultDenylist` (boolean) control which component props are included in reports. `DEFAULT_PROPS_DENYLIST` is exported.
+- **Component hierarchy frames.** Reports include structured `componentHierarchyFrames` with component name, file path, and serialized props per frame.
+- Route context is automatically captured from `app.config.globalProperties.$router` when an error occurs. No explicit router option needed.
+- Non-`Error` values are coerced to `Error`.
+- Chains existing `app.config.errorHandler` instead of replacing it silently.
+- Duplicate-install guard prevents double-reporting when `app.use(flareVue)` is called more than once.
 - The package self-identifies via `flare.setSdkInfo({ name: '@flareapp/vue', version })` and `flare.setFramework({ name: 'Vue', version: app.version })` on install.
+- New exported types: `ComponentHierarchyFrame`, `ErrorOrigin`, `FlareErrorBoundaryFallbackProps`, `FlareErrorBoundaryHookParams`, `FlareVueContext`, `FlareVueOptions`, `FlareVueWarningContext`, `RouteContext`, `RouteParamValue`, `RouteQueryValue`.

--- a/packages/vue/README.md
+++ b/packages/vue/README.md
@@ -34,7 +34,7 @@ Full documentation on the Vue error handler and its options is available at [fla
 
 ## Compatibility
 
-- Vue 2 and Vue 3
+- Vue 3
 
 ## License
 

--- a/playground/vue/sections/HooksSection.vue
+++ b/playground/vue/sections/HooksSection.vue
@@ -34,9 +34,12 @@ import TestSection from '../components/TestSection.vue';
                     const original = flare.config.beforeSubmit;
                     flare.configure({
                         beforeSubmit: (report) => {
-                            report.context = {
-                                ...report.context,
-                                custom_hook: { injected_by: 'beforeSubmit hook', timestamp: Date.now() },
+                            report.attributes = {
+                                ...report.attributes,
+                                'context.custom_hook': {
+                                    injected_by: 'beforeSubmit hook',
+                                    timestamp: Date.now(),
+                                },
                             };
                             console.log('beforeSubmit: added custom_hook context to report');
                             return report;

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
             VITE_FLARE_JS_KEY: 'test-key-js',
             VITE_FLARE_REACT_KEY: 'test-key-react',
             VITE_FLARE_VUE_KEY: 'test-key-vue',
+            SKIP_SOURCEMAPS: 'true',
         },
     },
 });


### PR DESCRIPTION
## Summary

- Fix flaky regex in tests and improve test coverage
- Update v2 changelogs with missing features and fix inaccuracies across js, react, and vue packages
- Add sourcemap upload tests for vite plugin
- Update README: replace stale Prettier references with oxfmt/oxlint, add missing lint command
- Wrap `flare.report()` calls in `catchWindowErrors` with `Promise.resolve().catch()` to prevent unhandled rejections
- Add `tsc --noEmit` typescript script to js and vite packages for consistency