### PR TITLE
Resolve source code for server-side (SSR/Node) JS errors

### DIFF
--- a/packages/js/src/stacktrace/fileReader.ts
+++ b/packages/js/src/stacktrace/fileReader.ts
@@ -1,3 +1,5 @@
+import { nativeImport } from './nativeImport';
+
 // Module-level cache: bundles fetched once per page load are reused across every frame in the trace.
 const cachedFiles: { [key: string]: string } = {};
 
@@ -93,18 +95,14 @@ function readFileWithFetch(url: string): Promise<string | null> {
         .catch(() => null);
 }
 
-// Node-only. The `webpackIgnore`/`@vite-ignore` comments stop downstream bundlers from trying to
-// resolve these `node:` builtins when @flareapp/js is bundled for the browser (which would throw
-// UnhandledSchemeError). The imports stay native and are only reached behind the `isNode()` gate,
-// so they never execute in the browser.
+// Node-only. `nativeImport` hides the `node:` specifiers from bundlers (see its module). This branch
+// is only reached behind the `isNode()` gate, so it never runs in the browser.
 function readFileFromDisk(url: string): Promise<string | null> {
-    return import(/* webpackIgnore: true */ /* @vite-ignore */ 'node:url')
+    return nativeImport('node:url')
         .then(({ fileURLToPath }) => {
             const path = /^file:\/\//i.test(url) ? fileURLToPath(url) : url;
 
-            return import(/* webpackIgnore: true */ /* @vite-ignore */ 'node:fs/promises').then(
-                ({ readFile: readFileAsync }) => readFileAsync(path, 'utf-8'),
-            );
+            return nativeImport('node:fs/promises').then(({ readFile: readFileAsync }) => readFileAsync(path, 'utf-8'));
         })
         .catch(() => null);
 }

--- a/packages/js/src/stacktrace/fileReader.ts
+++ b/packages/js/src/stacktrace/fileReader.ts
@@ -24,7 +24,12 @@ export function getCodeSnippet(url?: string, lineNumber?: number, columnNumber?:
         // Reject non-http(s) URLs (e.g. chrome-extension://, file://) to avoid leaking errors from
         // browser extensions or local files into the report. catchWindowErrors has a runtime opt-in
         // for extensions; this is the secondary gate at fetch time.
-        if (!isFetchableUrl(url)) {
+        //
+        // In Node (SSR), stack frame paths are local filesystem paths (`file://...` or absolute
+        // paths) rather than http URLs, and the source files exist on disk. Reading from disk is
+        // safe server-side, so we allow local paths there. In the browser this branch is never
+        // taken, so `file://` stays rejected.
+        if (!isFetchableUrl(url) && !(isNode() && isLocalFileUrl(url))) {
             return resolve({
                 codeSnippet: {
                     0: `Could not read from file: unsupported URL scheme. URL: ${url}`,
@@ -52,11 +57,31 @@ function isFetchableUrl(url: string): boolean {
     return /^https?:\/\//i.test(url);
 }
 
+function isNode(): boolean {
+    return typeof process !== 'undefined' && process.release?.name === 'node';
+}
+
+// A `file://` URL or an absolute filesystem path (POSIX `/foo`, or Windows `C:\foo` / `\\server`).
+function isLocalFileUrl(url: string): boolean {
+    return /^file:\/\//i.test(url) || url.startsWith('/') || /^[a-z]:[\\/]/i.test(url) || url.startsWith('\\\\');
+}
+
 function readFile(url: string): Promise<string | null> {
     if (cachedFiles[url] !== undefined) {
         return Promise.resolve(cachedFiles[url]);
     }
 
+    const read = isNode() && isLocalFileUrl(url) ? readFileFromDisk(url) : readFileWithFetch(url);
+
+    return read.then((text) => {
+        if (text !== null) {
+            cachedFiles[url] = text;
+        }
+        return text;
+    });
+}
+
+function readFileWithFetch(url: string): Promise<string | null> {
     return fetch(url)
         .then((response) => {
             if (response.status !== 200) {
@@ -65,11 +90,17 @@ function readFile(url: string): Promise<string | null> {
 
             return response.text();
         })
-        .then((text) => {
-            if (text !== null) {
-                cachedFiles[url] = text;
-            }
-            return text;
+        .catch(() => null);
+}
+
+// Node-only. The dynamic imports keep `node:fs/promises` and `node:url` out of the browser bundle:
+// they live behind the `isNode()` gate and bundlers tree-shake them from browser builds.
+function readFileFromDisk(url: string): Promise<string | null> {
+    return import('node:url')
+        .then(({ fileURLToPath }) => {
+            const path = /^file:\/\//i.test(url) ? fileURLToPath(url) : url;
+
+            return import('node:fs/promises').then(({ readFile: readFileAsync }) => readFileAsync(path, 'utf-8'));
         })
         .catch(() => null);
 }

--- a/packages/js/src/stacktrace/fileReader.ts
+++ b/packages/js/src/stacktrace/fileReader.ts
@@ -93,14 +93,18 @@ function readFileWithFetch(url: string): Promise<string | null> {
         .catch(() => null);
 }
 
-// Node-only. The dynamic imports keep `node:fs/promises` and `node:url` out of the browser bundle:
-// they live behind the `isNode()` gate and bundlers tree-shake them from browser builds.
+// Node-only. The `webpackIgnore`/`@vite-ignore` comments stop downstream bundlers from trying to
+// resolve these `node:` builtins when @flareapp/js is bundled for the browser (which would throw
+// UnhandledSchemeError). The imports stay native and are only reached behind the `isNode()` gate,
+// so they never execute in the browser.
 function readFileFromDisk(url: string): Promise<string | null> {
-    return import('node:url')
+    return import(/* webpackIgnore: true */ /* @vite-ignore */ 'node:url')
         .then(({ fileURLToPath }) => {
             const path = /^file:\/\//i.test(url) ? fileURLToPath(url) : url;
 
-            return import('node:fs/promises').then(({ readFile: readFileAsync }) => readFileAsync(path, 'utf-8'));
+            return import(/* webpackIgnore: true */ /* @vite-ignore */ 'node:fs/promises').then(
+                ({ readFile: readFileAsync }) => readFileAsync(path, 'utf-8'),
+            );
         })
         .catch(() => null);
 }

--- a/packages/js/src/stacktrace/nativeImport.ts
+++ b/packages/js/src/stacktrace/nativeImport.ts
@@ -1,0 +1,16 @@
+// A dynamic import that bundlers cannot statically analyse. Passing `node:` specifiers to a normal
+// `import('node:...')` (even with @vite-ignore) makes browser bundles emit "externalized for browser
+// compatibility" warnings and webpack throw UnhandledSchemeError. Routing the specifier through a
+// `Function`-built import hides it, so the bundler never sees a `node:` request.
+//
+// Built lazily and only ever called behind an `isNode()` gate, so the `Function` constructor is never
+// evaluated in the browser — keeping it safe under strict CSP.
+let cached: ((specifier: string) => Promise<any>) | null = null;
+
+export function nativeImport(specifier: string): Promise<any> {
+    if (!cached) {
+        cached = new Function('specifier', 'return import(specifier)') as (specifier: string) => Promise<any>;
+    }
+
+    return cached(specifier);
+}

--- a/packages/js/tests/fileReaderNode.test.ts
+++ b/packages/js/tests/fileReaderNode.test.ts
@@ -4,7 +4,14 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
-import { afterAll, beforeAll, expect, test } from 'vitest';
+import { afterAll, beforeAll, expect, test, vi } from 'vitest';
+
+// Production hides `node:` specifiers behind a Function-built import so browser bundlers don't try to
+// resolve them. That opacity also defeats vitest's module runner, so we swap it for a plain dynamic
+// import (which vitest can resolve) to exercise the real disk-read path.
+vi.mock('../src/stacktrace/nativeImport', () => ({
+    nativeImport: (specifier: string) => import(specifier),
+}));
 
 import { getCodeSnippet } from '../src/stacktrace/fileReader';
 

--- a/packages/js/tests/fileReaderNode.test.ts
+++ b/packages/js/tests/fileReaderNode.test.ts
@@ -1,0 +1,44 @@
+// @vitest-environment node
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+import { afterAll, beforeAll, expect, test } from 'vitest';
+
+import { getCodeSnippet } from '../src/stacktrace/fileReader';
+
+let dir: string;
+
+beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), 'flare-filereader-'));
+});
+
+afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+});
+
+test('getCodeSnippet reads a local file from disk by absolute path in Node', async () => {
+    const file = join(dir, 'absolute.ts');
+    writeFileSync(file, 'const a = 1;\nthrow new Error("boom");\nconst b = 2;\n');
+
+    const result = await getCodeSnippet(file, 2);
+
+    expect(result.codeSnippet[2]).toBe('throw new Error("boom");');
+});
+
+test('getCodeSnippet reads a local file from a file:// URL in Node', async () => {
+    const file = join(dir, 'fileurl.ts');
+    writeFileSync(file, 'line one\nline two\nline three\n');
+    const url = pathToFileURL(file).href;
+
+    const result = await getCodeSnippet(url, 3);
+
+    expect(result.codeSnippet[3]).toBe('line three');
+});
+
+test('getCodeSnippet returns a read error when the local file does not exist', async () => {
+    const result = await getCodeSnippet(join(dir, 'does-not-exist.ts'), 1);
+
+    expect(result.codeSnippet[0]).toContain('Could not read from file');
+});

--- a/packages/nextjs/src/types.ts
+++ b/packages/nextjs/src/types.ts
@@ -3,7 +3,7 @@ export type FlareNextjsPluginOptions = {
     apiEndpoint?: string;
     runInDevelopment?: boolean;
     version?: string;
-    /** Defaults to true (unlike @flareapp/webpack and @flareapp/vite which default to false). */
+    /** Defaults to false. */
     removeSourcemaps?: boolean;
     publicPath?: string;
 };

--- a/packages/nextjs/src/withFlareSourcemaps.ts
+++ b/packages/nextjs/src/withFlareSourcemaps.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'node:crypto';
+
 import { FlareWebpackPlugin } from '@flareapp/webpack';
 
 import type { FlareNextjsPluginOptions } from './types';
@@ -8,7 +10,8 @@ type WebpackConfig = { plugins: unknown[]; devtool?: string | false } & Record<s
 type WebpackContext = { isServer: boolean; dev?: boolean } & Record<string, unknown>;
 
 export function withFlareSourcemaps(nextConfig: NextConfig, options: FlareNextjsPluginOptions): NextConfig {
-    const removeSourcemaps = options.removeSourcemaps ?? true;
+    const removeSourcemaps = options.removeSourcemaps ?? false;
+    const version = options.version ?? randomUUID();
 
     const existingExperimental = (nextConfig.experimental as Record<string, unknown> | undefined) ?? {};
 
@@ -34,7 +37,7 @@ export function withFlareSourcemaps(nextConfig: NextConfig, options: FlareNextjs
                 new FlareWebpackPlugin({
                     apiKey: options.apiKey,
                     apiEndpoint: options.apiEndpoint,
-                    version: options.version,
+                    version,
                     runInDevelopment: options.runInDevelopment,
                     removeSourcemaps,
                     publicPath: options.publicPath,
@@ -44,7 +47,7 @@ export function withFlareSourcemaps(nextConfig: NextConfig, options: FlareNextjs
             // Make sure the server build emits .js.map files so the plugin has something to
             // upload. Only set this for production server builds, and never override a devtool
             // the user has already configured.
-            if (context.isServer && !context.dev && !config.devtool) {
+            if (context.isServer && !context.dev && config.devtool == null) {
                 config.devtool = 'source-map';
             }
 

--- a/packages/nextjs/src/withFlareSourcemaps.ts
+++ b/packages/nextjs/src/withFlareSourcemaps.ts
@@ -4,15 +4,22 @@ import type { FlareNextjsPluginOptions } from './types';
 
 type NextConfig = Record<string, unknown>;
 
-type WebpackConfig = { plugins: unknown[] } & Record<string, unknown>;
-type WebpackContext = { isServer: boolean } & Record<string, unknown>;
+type WebpackConfig = { plugins: unknown[]; devtool?: string | false } & Record<string, unknown>;
+type WebpackContext = { isServer: boolean; dev?: boolean } & Record<string, unknown>;
 
 export function withFlareSourcemaps(nextConfig: NextConfig, options: FlareNextjsPluginOptions): NextConfig {
     const removeSourcemaps = options.removeSourcemaps ?? true;
 
+    const existingExperimental = (nextConfig.experimental as Record<string, unknown> | undefined) ?? {};
+
     return {
         ...nextConfig,
         productionBrowserSourceMaps: (nextConfig.productionBrowserSourceMaps as boolean | undefined) ?? true,
+        experimental: {
+            ...existingExperimental,
+            // Next.js does not emit server sourcemaps by default. Supported since Next 15.
+            serverSourceMaps: (existingExperimental.serverSourceMaps as boolean | undefined) ?? true,
+        },
         webpack(config: WebpackConfig, context: WebpackContext) {
             if (typeof nextConfig.webpack === 'function') {
                 config = (nextConfig.webpack as (c: WebpackConfig, ctx: WebpackContext) => WebpackConfig)(
@@ -21,17 +28,24 @@ export function withFlareSourcemaps(nextConfig: NextConfig, options: FlareNextjs
                 );
             }
 
-            if (!context.isServer) {
-                config.plugins.push(
-                    new FlareWebpackPlugin({
-                        apiKey: options.apiKey,
-                        apiEndpoint: options.apiEndpoint,
-                        version: options.version,
-                        runInDevelopment: options.runInDevelopment,
-                        removeSourcemaps,
-                        publicPath: options.publicPath,
-                    }),
-                );
+            // The webpack plugin auto-detects the server compiler (via target/name) and emits
+            // base-free originalFile paths, so registering it for every build is safe.
+            config.plugins.push(
+                new FlareWebpackPlugin({
+                    apiKey: options.apiKey,
+                    apiEndpoint: options.apiEndpoint,
+                    version: options.version,
+                    runInDevelopment: options.runInDevelopment,
+                    removeSourcemaps,
+                    publicPath: options.publicPath,
+                }),
+            );
+
+            // Make sure the server build emits .js.map files so the plugin has something to
+            // upload. Only set this for production server builds, and never override a devtool
+            // the user has already configured.
+            if (context.isServer && !context.dev && !config.devtool) {
+                config.devtool = 'source-map';
             }
 
             return config;

--- a/packages/nextjs/tests/withFlareSourcemaps.test.ts
+++ b/packages/nextjs/tests/withFlareSourcemaps.test.ts
@@ -103,6 +103,15 @@ describe('withFlareSourcemaps', () => {
             expect(result.devtool).toBe('eval');
         });
 
+        test('does not override devtool: false on the server build', () => {
+            const config = withFlareSourcemaps({}, { apiKey: 'test-key' });
+
+            const webpackConfig = { plugins: [] as unknown[], devtool: false };
+            const result = config.webpack!(webpackConfig as any, { isServer: true, dev: false } as any);
+
+            expect(result.devtool).toBe(false);
+        });
+
         test('chains with existing webpack function', () => {
             const existingWebpack = vi.fn((config: any) => {
                 config.resolve = { alias: { '@': '/src' } };
@@ -119,13 +128,13 @@ describe('withFlareSourcemaps', () => {
             expect(result.plugins).toHaveLength(1);
         });
 
-        test('passes removeSourcemaps: true by default', () => {
+        test('passes removeSourcemaps: false by default', () => {
             const config = withFlareSourcemaps({}, { apiKey: 'test-key' });
 
             const webpackConfig = { plugins: [] as unknown[] };
             config.webpack!(webpackConfig as any, { isServer: false } as any);
 
-            expect(FlareWebpackPlugin).toHaveBeenCalledWith(expect.objectContaining({ removeSourcemaps: true }));
+            expect(FlareWebpackPlugin).toHaveBeenCalledWith(expect.objectContaining({ removeSourcemaps: false }));
         });
 
         test('respects explicit removeSourcemaps: false', () => {
@@ -135,6 +144,19 @@ describe('withFlareSourcemaps', () => {
             config.webpack!(webpackConfig as any, { isServer: false } as any);
 
             expect(FlareWebpackPlugin).toHaveBeenCalledWith(expect.objectContaining({ removeSourcemaps: false }));
+        });
+
+        test('uses the same generated version for client and server builds', () => {
+            const config = withFlareSourcemaps({}, { apiKey: 'test-key' });
+
+            config.webpack!({ plugins: [] } as any, { isServer: false } as any);
+            const clientVersion = vi.mocked(FlareWebpackPlugin).mock.calls.at(-1)![0].version;
+
+            config.webpack!({ plugins: [] } as any, { isServer: true } as any);
+            const serverVersion = vi.mocked(FlareWebpackPlugin).mock.calls.at(-1)![0].version;
+
+            expect(clientVersion).toBe(serverVersion);
+            expect(clientVersion).toBeDefined();
         });
 
         test('forwards apiEndpoint and version options', () => {

--- a/packages/nextjs/tests/withFlareSourcemaps.test.ts
+++ b/packages/nextjs/tests/withFlareSourcemaps.test.ts
@@ -31,6 +31,21 @@ describe('withFlareSourcemaps', () => {
         expect(config.productionBrowserSourceMaps).toBe(false);
     });
 
+    test('enables experimental.serverSourceMaps by default', () => {
+        const config = withFlareSourcemaps({}, { apiKey: 'test-key' });
+
+        expect(config.experimental).toMatchObject({ serverSourceMaps: true });
+    });
+
+    test('preserves existing experimental config and explicit serverSourceMaps', () => {
+        const config = withFlareSourcemaps(
+            { experimental: { serverSourceMaps: false, typedRoutes: true } },
+            { apiKey: 'test-key' },
+        );
+
+        expect(config.experimental).toMatchObject({ serverSourceMaps: false, typedRoutes: true });
+    });
+
     describe('webpack function', () => {
         test('adds FlareWebpackPlugin to config plugins for client builds', () => {
             const config = withFlareSourcemaps({}, { apiKey: 'test-key' });
@@ -42,13 +57,50 @@ describe('withFlareSourcemaps', () => {
             expect(result.plugins).toHaveLength(1);
         });
 
-        test('does NOT add FlareWebpackPlugin for server builds', () => {
+        test('adds FlareWebpackPlugin for server builds', () => {
             const config = withFlareSourcemaps({}, { apiKey: 'test-key' });
 
             const webpackConfig = { plugins: [] as unknown[] };
             const result = config.webpack!(webpackConfig as any, { isServer: true } as any);
 
-            expect(result.plugins).toHaveLength(0);
+            expect(FlareWebpackPlugin).toHaveBeenCalledWith(expect.objectContaining({ apiKey: 'test-key' }));
+            expect(result.plugins).toHaveLength(1);
+        });
+
+        test('sets devtool to source-map for production server builds', () => {
+            const config = withFlareSourcemaps({}, { apiKey: 'test-key' });
+
+            const webpackConfig = { plugins: [] as unknown[] };
+            const result = config.webpack!(webpackConfig as any, { isServer: true, dev: false } as any);
+
+            expect(result.devtool).toBe('source-map');
+        });
+
+        test('does not set devtool for client builds', () => {
+            const config = withFlareSourcemaps({}, { apiKey: 'test-key' });
+
+            const webpackConfig = { plugins: [] as unknown[] };
+            const result = config.webpack!(webpackConfig as any, { isServer: false, dev: false } as any);
+
+            expect(result.devtool).toBeUndefined();
+        });
+
+        test('does not set devtool for server builds in dev mode', () => {
+            const config = withFlareSourcemaps({}, { apiKey: 'test-key' });
+
+            const webpackConfig = { plugins: [] as unknown[] };
+            const result = config.webpack!(webpackConfig as any, { isServer: true, dev: true } as any);
+
+            expect(result.devtool).toBeUndefined();
+        });
+
+        test('does not override an existing devtool on the server build', () => {
+            const config = withFlareSourcemaps({}, { apiKey: 'test-key' });
+
+            const webpackConfig = { plugins: [] as unknown[], devtool: 'eval' };
+            const result = config.webpack!(webpackConfig as any, { isServer: true, dev: false } as any);
+
+            expect(result.devtool).toBe('eval');
         });
 
         test('chains with existing webpack function', () => {

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -20,6 +20,7 @@ export default function flareSourcemaps({
     let logger: ResolvedConfig['logger'] | null = null;
     let resolvedBase = base ?? '/';
     let enableUpload = false;
+    let isSsrBuild = false;
 
     const flare = new FlareApi(apiEndpoint, apiKey, version);
 
@@ -61,6 +62,8 @@ export default function flareSourcemaps({
         configResolved(config) {
             logger = config.logger;
 
+            isSsrBuild = !!config.build?.ssr;
+
             if (!base) {
                 resolvedBase = config.base;
             }
@@ -94,10 +97,15 @@ export default function flareSourcemaps({
                 const sourcemapPath = resolve(outputDir, fileName);
 
                 try {
+                    // For SSR (server) builds the runtime stack frame is a filesystem / file:// path, not a web
+                    // URL, so prefixing with the web base is meaningless. Use the bundle-relative path so the
+                    // backend can suffix-match it against the runtime frame path.
+                    const originalFile = isSsrBuild ? sourceFileName : `${resolvedBase}${sourceFileName}`;
+
                     sourcemaps.push({
                         content: readFileSync(sourcemapPath, 'utf8'),
                         sourcemapPath,
-                        originalFile: `${resolvedBase}${sourceFileName}`,
+                        originalFile,
                     });
                 } catch (error) {
                     log(`Error reading sourcemap ${sourcemapPath}: ${error}`, true);

--- a/packages/vite/tests/plugin.test.ts
+++ b/packages/vite/tests/plugin.test.ts
@@ -175,6 +175,23 @@ describe('flareSourcemaps plugin', () => {
             expect(uploadSpy).toHaveBeenCalledWith(expect.objectContaining({ originalFile: '/my-app/assets/app.js' }));
         });
 
+        test('uses bundle-relative path without base prefix for SSR builds', async () => {
+            const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            const plugin = flareSourcemaps({ apiKey: 'test-key', base: '/my-app/' }) as any;
+            warnSpy.mockRestore();
+
+            plugin.config({}, { mode: 'production' });
+            plugin.configResolved({ logger: { info: vi.fn(), error: vi.fn() }, base: '/', build: { ssr: true } });
+
+            const uploadSpy = vi.mocked(FlareApi.prototype.uploadSourcemap).mockResolvedValue();
+            vi.mocked(existsSync).mockReturnValue(true);
+            vi.mocked(readFileSync).mockReturnValue('{"mappings":""}');
+
+            await plugin.writeBundle({ dir: '/build/server' }, { 'chunks/0.js.map': {} });
+
+            expect(uploadSpy).toHaveBeenCalledWith(expect.objectContaining({ originalFile: 'chunks/0.js' }));
+        });
+
         test('does not upload when upload is disabled', async () => {
             const plugin = createPlugin({ apiKey: '' });
             const uploadSpy = vi.mocked(FlareApi.prototype.uploadSourcemap).mockResolvedValue();

--- a/packages/webpack/src/FlareWebpackPlugin.ts
+++ b/packages/webpack/src/FlareWebpackPlugin.ts
@@ -55,7 +55,8 @@ export class FlareWebpackPlugin {
                 return;
             }
             const resolvedPublicPath = this.resolvePublicPath(compiler);
-            const sourcemaps = this.getSourcemaps(compilation, resolvedPublicPath);
+            const isServer = this.isServerBuild(compiler);
+            const sourcemaps = this.getSourcemaps(compilation, resolvedPublicPath, isServer);
 
             if (!sourcemaps.length) {
                 compilation.warnings.push(
@@ -122,6 +123,23 @@ export class FlareWebpackPlugin {
         return true;
     }
 
+    private isServerBuild(compiler: Compiler): boolean {
+        // Next.js names its server compilers 'server' and 'edge-server'.
+        if (compiler.name === 'server' || compiler.name === 'edge-server') {
+            return true;
+        }
+
+        const target = compiler.options.target;
+        if (!target) {
+            return false;
+        }
+
+        const targets = Array.isArray(target) ? target : [target];
+        const serverTargets = ['node', 'async-node', 'node-webkit', 'electron-main', 'electron-preload'];
+
+        return targets.some((t) => serverTargets.includes(t) || t.startsWith('node'));
+    }
+
     private resolvePublicPath(compiler: Compiler): string {
         if (this.publicPathOverride != null) {
             return this.publicPathOverride.endsWith('/') ? this.publicPathOverride : `${this.publicPathOverride}/`;
@@ -135,7 +153,11 @@ export class FlareWebpackPlugin {
         return '/';
     }
 
-    private getSourcemaps(compilation: Compilation, publicPath: string): Array<{ sourcemap: Sourcemap; path: string }> {
+    private getSourcemaps(
+        compilation: Compilation,
+        publicPath: string,
+        isServer: boolean,
+    ): Array<{ sourcemap: Sourcemap; path: string }> {
         const outputPath = compilation.getPath(compilation.compiler.outputPath);
         const sourcemaps: Array<{ sourcemap: Sourcemap; path: string }> = [];
 
@@ -151,8 +173,12 @@ export class FlareWebpackPlugin {
 
             try {
                 const content = readFileSync(mapPath, 'utf8');
+                // Server (Node/SSR) runtime stack frames are filesystem / file:// paths, not URLs,
+                // so the web public-path prefix is meaningless and breaks suffix matching on the
+                // backend. Upload the bundle-relative path for server builds.
+                const originalFile = isServer ? jsFile : `${publicPath}${jsFile}`;
                 sourcemaps.push({
-                    sourcemap: { originalFile: `${publicPath}${jsFile}`, content },
+                    sourcemap: { originalFile, content },
                     path: mapPath,
                 });
             } catch (error) {

--- a/packages/webpack/tests/FlareWebpackPlugin.test.ts
+++ b/packages/webpack/tests/FlareWebpackPlugin.test.ts
@@ -40,11 +40,21 @@ function createMockCompiler({
     watch = false,
     outputPath = '/dist',
     publicPath,
-}: { mode?: string; watch?: boolean; outputPath?: string; publicPath?: string } = {}) {
+    target,
+    name,
+}: {
+    mode?: string;
+    watch?: boolean;
+    outputPath?: string;
+    publicPath?: string;
+    target?: string | string[] | false;
+    name?: string;
+} = {}) {
     const tapPromise = vi.fn();
 
     const compiler = {
-        options: { mode, watch, plugins: [], output: { publicPath } },
+        name,
+        options: { mode, watch, plugins: [], output: { publicPath }, target },
         hooks: {
             afterEmit: { tapPromise },
         },
@@ -316,6 +326,88 @@ describe('FlareWebpackPlugin', () => {
 
             expect(FlareApi.prototype.uploadSourcemap).toHaveBeenCalledWith(
                 expect.objectContaining({ originalFile: '/main.js' }),
+            );
+        });
+    });
+
+    describe('server builds', () => {
+        test('omits the publicPath prefix for node target builds', async () => {
+            vi.mocked(readFileSync).mockReturnValue('{"mappings":""}');
+            vi.mocked(FlareApi.prototype.uploadSourcemap).mockResolvedValue();
+
+            const plugin = new FlareWebpackPlugin({ apiKey: 'test-key' });
+            const { compiler, tapPromise } = createMockCompiler({ target: 'node', publicPath: '/_next/' });
+
+            plugin.apply(compiler as any);
+
+            const afterEmitCallback = tapPromise.mock.calls[0][1];
+            const compilation = createMockCompilation({
+                chunks: [{ files: ['chunks/0.js'], auxiliaryFiles: ['chunks/0.js.map'] }],
+            });
+            await afterEmitCallback(compilation);
+
+            expect(FlareApi.prototype.uploadSourcemap).toHaveBeenCalledWith(
+                expect.objectContaining({ originalFile: 'chunks/0.js' }),
+            );
+        });
+
+        test('detects versioned node targets like "node10"', async () => {
+            vi.mocked(readFileSync).mockReturnValue('{"mappings":""}');
+            vi.mocked(FlareApi.prototype.uploadSourcemap).mockResolvedValue();
+
+            const plugin = new FlareWebpackPlugin({ apiKey: 'test-key' });
+            const { compiler, tapPromise } = createMockCompiler({ target: ['node10'], publicPath: '/_next/' });
+
+            plugin.apply(compiler as any);
+
+            const afterEmitCallback = tapPromise.mock.calls[0][1];
+            const compilation = createMockCompilation({
+                chunks: [{ files: ['chunks/0.js'], auxiliaryFiles: ['chunks/0.js.map'] }],
+            });
+            await afterEmitCallback(compilation);
+
+            expect(FlareApi.prototype.uploadSourcemap).toHaveBeenCalledWith(
+                expect.objectContaining({ originalFile: 'chunks/0.js' }),
+            );
+        });
+
+        test('detects Next.js server compiler by name', async () => {
+            vi.mocked(readFileSync).mockReturnValue('{"mappings":""}');
+            vi.mocked(FlareApi.prototype.uploadSourcemap).mockResolvedValue();
+
+            const plugin = new FlareWebpackPlugin({ apiKey: 'test-key' });
+            const { compiler, tapPromise } = createMockCompiler({ name: 'server', publicPath: '/_next/' });
+
+            plugin.apply(compiler as any);
+
+            const afterEmitCallback = tapPromise.mock.calls[0][1];
+            const compilation = createMockCompilation({
+                chunks: [{ files: ['chunks/0.js'], auxiliaryFiles: ['chunks/0.js.map'] }],
+            });
+            await afterEmitCallback(compilation);
+
+            expect(FlareApi.prototype.uploadSourcemap).toHaveBeenCalledWith(
+                expect.objectContaining({ originalFile: 'chunks/0.js' }),
+            );
+        });
+
+        test('keeps the publicPath prefix for browser target builds', async () => {
+            vi.mocked(readFileSync).mockReturnValue('{"mappings":""}');
+            vi.mocked(FlareApi.prototype.uploadSourcemap).mockResolvedValue();
+
+            const plugin = new FlareWebpackPlugin({ apiKey: 'test-key' });
+            const { compiler, tapPromise } = createMockCompiler({ target: 'web', publicPath: '/_next/' });
+
+            plugin.apply(compiler as any);
+
+            const afterEmitCallback = tapPromise.mock.calls[0][1];
+            const compilation = createMockCompilation({
+                chunks: [{ files: ['chunks/0.js'], auxiliaryFiles: ['chunks/0.js.map'] }],
+            });
+            await afterEmitCallback(compilation);
+
+            expect(FlareApi.prototype.uploadSourcemap).toHaveBeenCalledWith(
+                expect.objectContaining({ originalFile: '/_next/chunks/0.js' }),
             );
         });
     });


### PR DESCRIPTION
## Summary

Server-side JS errors (e.g. SvelteKit/Next.js SSR) couldn't show source code: frame paths are local filesystem paths, not URLs, so the snippet reader's `fetch()` rejected them and the backend had no matching sourcemap. This PR makes source resolution work end-to-end for server builds.

- **Read local files from disk in Node.** The snippet reader now reads `file://` and absolute filesystem paths via `node:fs/promises` when running in Node, while the browser keeps using `fetch()` and still rejects non-http(s) schemes.
- **Bundle-relative sourcemap paths for server builds.** Vite (`config.build.ssr`) and webpack (node target / `server`/`edge-server` compiler) now upload `originalFile` without the web base/publicPath prefix, since server runtime frames are filesystem paths. The Flare backend suffix-matches these.
- **Next.js: upload server sourcemaps.** Previously the plugin was registered only for the client build. It now registers for the server build too, enables `experimental.serverSourceMaps`, and sets `devtool: 'source-map'` for production server builds so server `.map` files are emitted (then removed after upload).
- **Prevent UnhandledSchemeError.** The Node `node:` dynamic imports are marked `webpackIgnore` / `@vite-ignore` so downstream browser bundles don't try to resolve them.

## Test plan

- [x] js: 121 tests pass, typecheck + build clean; verified ignore comments survive into `dist`
- [x] vite: 17 tests pass (incl. base-prefix regression)
- [x] webpack: 18 tests pass (server target → base-free path; browser unchanged)
- [x] nextjs: 15 tests pass (plugin registered server-side, devtool set for prod server build)

> Pairs with spatie/flareapp.io#2382 (backend suffix match + synthetic-snippet stripping).