### PR TITLE
Add support for Vue Router 5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5042,6 +5042,43 @@
             "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
             "license": "MIT"
         },
+        "node_modules/@vue/devtools-kit": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-8.1.1.tgz",
+            "integrity": "sha512-gVBaBv++i+adg4JpH71k9ppl4soyR7Y2McEqO5YNgv0BI1kMZ7BDX5gnwkZ5COYgiCyhejZG+yGNrBAjj6Coqg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vue/devtools-shared": "^8.1.1",
+                "birpc": "^2.6.1",
+                "hookable": "^5.5.3",
+                "perfect-debounce": "^2.0.0"
+            }
+        },
+        "node_modules/@vue/devtools-kit/node_modules/birpc": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
+            "integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
+            "dev": true,
+            "license": "MIT",
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            }
+        },
+        "node_modules/@vue/devtools-kit/node_modules/hookable": {
+            "version": "5.5.3",
+            "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+            "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@vue/devtools-shared": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-8.1.1.tgz",
+            "integrity": "sha512-+h4ttmJYl/txpxHKaoZcaKpC+pvckgLzIDiSQlaQ7kKthKh8KuwoLW2D8hPJEnqKzXOvu15UHEoGyngAXCz0EQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@vue/reactivity": {
             "version": "3.5.33",
             "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.33.tgz",
@@ -5533,6 +5570,40 @@
             },
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/ast-walker-scope": {
+            "version": "0.8.3",
+            "resolved": "https://registry.npmjs.org/ast-walker-scope/-/ast-walker-scope-0.8.3.tgz",
+            "integrity": "sha512-cbdCP0PGOBq0ASG+sjnKIoYkWMKhhz+F/h9pRexUdX2Hd38+WOlBkRKlqkGOSm0YQpcFMQBJeK4WspUAkwsEdg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.28.4",
+                "ast-kit": "^2.1.3"
+            },
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sxzz"
+            }
+        },
+        "node_modules/ast-walker-scope/node_modules/ast-kit": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/ast-kit/-/ast-kit-2.2.0.tgz",
+            "integrity": "sha512-m1Q/RaVOnTp9JxPX+F+Zn7IcLYMzM8kZofDImfsKZd8MbR+ikdOzTeztStWqfrqIxZnYWryyI9ePm3NGjnZgGw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.28.5",
+                "pathe": "^2.0.3"
+            },
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sxzz"
             }
         },
         "node_modules/async-retry": {
@@ -7710,6 +7781,41 @@
                 "url": "https://opencollective.com/webpack"
             }
         },
+        "node_modules/local-pkg": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-1.1.2.tgz",
+            "integrity": "sha512-arhlxbFRmoQHl33a0Zkle/YWlmNwoyt6QNZEIJcqNbdrsix5Lvc4HyyI3EnwxTYlZYc32EbYrQ8SzEZ7dqgg9A==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mlly": "^1.7.4",
+                "pkg-types": "^2.3.0",
+                "quansync": "^0.2.11"
+            },
+            "engines": {
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antfu"
+            }
+        },
+        "node_modules/local-pkg/node_modules/quansync": {
+            "version": "0.2.11",
+            "resolved": "https://registry.npmjs.org/quansync/-/quansync-0.2.11.tgz",
+            "integrity": "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/antfu"
+                },
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/sxzz"
+                }
+            ],
+            "license": "MIT"
+        },
         "node_modules/locate-character": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
@@ -7855,6 +7961,22 @@
                 "@jridgewell/sourcemap-codec": "^1.5.5"
             }
         },
+        "node_modules/magic-string-ast": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/magic-string-ast/-/magic-string-ast-1.0.3.tgz",
+            "integrity": "sha512-CvkkH1i81zl7mmb94DsRiFeG9V2fR2JeuK8yDgS8oiZSFa++wWLEgZ5ufEOyLHbvSbD1gTRKv9NdX69Rnvr9JA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "magic-string": "^0.30.19"
+            },
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sxzz"
+            }
+        },
         "node_modules/merge-stream": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
@@ -7936,6 +8058,38 @@
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": ">=16 || 14 >=14.17"
+            }
+        },
+        "node_modules/mlly": {
+            "version": "1.8.2",
+            "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+            "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "acorn": "^8.16.0",
+                "pathe": "^2.0.3",
+                "pkg-types": "^1.3.1",
+                "ufo": "^1.6.3"
+            }
+        },
+        "node_modules/mlly/node_modules/confbox": {
+            "version": "0.1.8",
+            "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+            "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/mlly/node_modules/pkg-types": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+            "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "confbox": "^0.1.8",
+                "mlly": "^1.7.4",
+                "pathe": "^2.0.1"
             }
         },
         "node_modules/mri": {
@@ -10103,6 +10257,13 @@
                 "node": ">=14.17"
             }
         },
+        "node_modules/ufo": {
+            "version": "1.6.4",
+            "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.4.tgz",
+            "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/unconfig-core": {
             "version": "7.5.0",
             "resolved": "https://registry.npmjs.org/unconfig-core/-/unconfig-core-7.5.0.tgz",
@@ -10140,6 +10301,38 @@
             "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
             "dev": true,
             "license": "ISC"
+        },
+        "node_modules/unplugin": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-3.0.0.tgz",
+            "integrity": "sha512-0Mqk3AT2TZCXWKdcoaufeXNukv2mTrEZExeXlHIOZXdqYoHHr4n51pymnwV8x2BOVxwXbK2HLlI7usrqMpycdg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@jridgewell/remapping": "^2.3.5",
+                "picomatch": "^4.0.3",
+                "webpack-virtual-modules": "^0.6.2"
+            },
+            "engines": {
+                "node": "^20.19.0 || >=22.12.0"
+            }
+        },
+        "node_modules/unplugin-utils": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/unplugin-utils/-/unplugin-utils-0.3.1.tgz",
+            "integrity": "sha512-5lWVjgi6vuHhJ526bI4nlCOmkCIF3nnfXkCMDeMJrtdvxTs6ZFCM8oNufGTsDbKv/tJ/xj8RpvXjRuPBZJuJog==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.3"
+            },
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sxzz"
+            }
         },
         "node_modules/unrun": {
             "version": "0.2.37",
@@ -10821,6 +11014,13 @@
                 "node": ">=10.13.0"
             }
         },
+        "node_modules/webpack-virtual-modules": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.6.2.tgz",
+            "integrity": "sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/whatwg-encoding": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
@@ -11319,7 +11519,7 @@
                 "typescript": "^5.7.0",
                 "vitest": "^4.0.0",
                 "vue": "^3.0.0",
-                "vue-router": "^4.6.4"
+                "vue-router": "^5.0.0"
             },
             "peerDependencies": {
                 "@flareapp/js": "^2.1.0",
@@ -11328,6 +11528,107 @@
             },
             "peerDependenciesMeta": {
                 "vue-router": {
+                    "optional": true
+                }
+            }
+        },
+        "packages/vue/node_modules/@vue/devtools-api": {
+            "version": "8.1.1",
+            "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-8.1.1.tgz",
+            "integrity": "sha512-bsDMJ07b3GN1puVwJb/fyFnj/U2imyswK5UQVLZwVl7O05jDrt6BHxeG5XffmOOdasOj/bOmIjxJvGPxU7pcqw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vue/devtools-kit": "^8.1.1"
+            }
+        },
+        "packages/vue/node_modules/ast-kit": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/ast-kit/-/ast-kit-2.2.0.tgz",
+            "integrity": "sha512-m1Q/RaVOnTp9JxPX+F+Zn7IcLYMzM8kZofDImfsKZd8MbR+ikdOzTeztStWqfrqIxZnYWryyI9ePm3NGjnZgGw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/parser": "^7.28.5",
+                "pathe": "^2.0.3"
+            },
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sxzz"
+            }
+        },
+        "packages/vue/node_modules/vue-router": {
+            "version": "5.0.6",
+            "resolved": "https://registry.npmjs.org/vue-router/-/vue-router-5.0.6.tgz",
+            "integrity": "sha512-9+kmUTGbKMyW9Asoy98IXXYIzrTMT7JDAdpDDeEkorHvybpUvBI2wsrSM5jFOXrFydpzRFJ9vAh+80DN2PGu9w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/generator": "^7.28.6",
+                "@vue-macros/common": "^3.1.1",
+                "@vue/devtools-api": "^8.0.6",
+                "ast-walker-scope": "^0.8.3",
+                "chokidar": "^5.0.0",
+                "json5": "^2.2.3",
+                "local-pkg": "^1.1.2",
+                "magic-string": "^0.30.21",
+                "mlly": "^1.8.0",
+                "muggle-string": "^0.4.1",
+                "pathe": "^2.0.3",
+                "picomatch": "^4.0.3",
+                "scule": "^1.3.0",
+                "tinyglobby": "^0.2.15",
+                "unplugin": "^3.0.0",
+                "unplugin-utils": "^0.3.1",
+                "yaml": "^2.8.2"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/posva"
+            },
+            "peerDependencies": {
+                "@pinia/colada": ">=0.21.2",
+                "@vue/compiler-sfc": "^3.5.17",
+                "pinia": "^3.0.4",
+                "vue": "^3.5.0"
+            },
+            "peerDependenciesMeta": {
+                "@pinia/colada": {
+                    "optional": true
+                },
+                "@vue/compiler-sfc": {
+                    "optional": true
+                },
+                "pinia": {
+                    "optional": true
+                }
+            }
+        },
+        "packages/vue/node_modules/vue-router/node_modules/@vue-macros/common": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@vue-macros/common/-/common-3.1.2.tgz",
+            "integrity": "sha512-h9t4ArDdniO9ekYHAD95t9AZcAbb19lEGK+26iAjUODOIJKmObDNBSe4+6ELQAA3vtYiFPPBtHh7+cQCKi3Dng==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vue/compiler-sfc": "^3.5.22",
+                "ast-kit": "^2.1.2",
+                "local-pkg": "^1.1.2",
+                "magic-string-ast": "^1.0.2",
+                "unplugin-utils": "^0.3.0"
+            },
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/vue-macros"
+            },
+            "peerDependencies": {
+                "vue": "^2.7.0 || ^3.2.25"
+            },
+            "peerDependenciesMeta": {
+                "vue": {
                     "optional": true
                 }
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4951,41 +4951,6 @@
                 "url": "https://opencollective.com/vitest"
             }
         },
-        "node_modules/@volar/language-core": {
-            "version": "2.4.28",
-            "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.28.tgz",
-            "integrity": "sha512-w4qhIJ8ZSitgLAkVay6AbcnC7gP3glYM3fYwKV3srj8m494E3xtrCv6E+bWviiK/8hs6e6t1ij1s2Endql7vzQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@volar/source-map": "2.4.28"
-            }
-        },
-        "node_modules/@volar/source-map": {
-            "version": "2.4.28",
-            "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.28.tgz",
-            "integrity": "sha512-yX2BDBqJkRXfKw8my8VarTyjv48QwxdJtvRgUpNE5erCsgEUdI2DsLbpa+rOQVAJYshY99szEcRDmyHbF10ggQ==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
-        },
-        "node_modules/@volar/typescript": {
-            "version": "2.4.28",
-            "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.28.tgz",
-            "integrity": "sha512-Ja6yvWrbis2QtN4ClAKreeUZPVYMARDYZl9LMEv1iQ1QdepB6wn0jTRxA9MftYmYa4DQ4k/DaSZpFPUfxl8giw==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@volar/language-core": "2.4.28",
-                "path-browserify": "^1.0.1",
-                "vscode-uri": "^3.0.8"
-            }
-        },
         "node_modules/@vue/compiler-core": {
             "version": "3.5.33",
             "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.33.tgz",
@@ -5076,24 +5041,6 @@
             "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
             "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
             "license": "MIT"
-        },
-        "node_modules/@vue/language-core": {
-            "version": "3.2.9",
-            "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-3.2.9.tgz",
-            "integrity": "sha512-ie0ojt/0fU/GfIogh+zgHbaYRPlt9S+cLOxcWwF7nTSFh897BVgnFKL2byT4kpp1mlqYWZ2psGwSniyE2xsxYw==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@volar/language-core": "2.4.28",
-                "@vue/compiler-dom": "^3.5.0",
-                "@vue/shared": "^3.5.0",
-                "alien-signals": "^3.2.0",
-                "muggle-string": "^0.4.1",
-                "path-browserify": "^1.0.1",
-                "picomatch": "^4.0.4"
-            }
         },
         "node_modules/@vue/reactivity": {
             "version": "3.5.33",
@@ -5434,15 +5381,6 @@
             "peerDependencies": {
                 "ajv": "^8.8.2"
             }
-        },
-        "node_modules/alien-signals": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-3.2.1.tgz",
-            "integrity": "sha512-I8FjmltrfnDFoZedi5CG8DghVYNhzb/Ijluz7tCSJH0xpd0484Kowhbb1XDYOxfJpU1p5wnM2X54dA+IfGyD1g==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true
         },
         "node_modules/ansi-escapes": {
             "version": "7.3.0",
@@ -8627,7 +8565,6 @@
             "version": "2.3.2",
             "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
             "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-            "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
             "optional": true,
@@ -10790,25 +10727,6 @@
                 "vue": "^3.5.0"
             }
         },
-        "node_modules/vue-tsc": {
-            "version": "3.2.9",
-            "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-3.2.9.tgz",
-            "integrity": "sha512-qm8/nbo+9eZc1SCndm9wT+gq23pM+wRIdHY0wjm83B3lIginHTwcdrLUyTrKjDWXbMVNjKegNrnymhpdqnCL3A==",
-            "dev": true,
-            "license": "MIT",
-            "optional": true,
-            "peer": true,
-            "dependencies": {
-                "@volar/typescript": "2.4.28",
-                "@vue/language-core": "3.2.9"
-            },
-            "bin": {
-                "vue-tsc": "bin/vue-tsc.js"
-            },
-            "peerDependencies": {
-                "typescript": ">=5.0.0"
-            }
-        },
         "node_modules/w3c-xmlserializer": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
@@ -11273,7 +11191,7 @@
         },
         "packages/js": {
             "name": "@flareapp/js",
-            "version": "2.0.1",
+            "version": "2.1.0",
             "license": "MIT",
             "dependencies": {
                 "error-stack-parser": "^2.0.2"
@@ -11286,10 +11204,10 @@
         },
         "packages/nextjs": {
             "name": "@flareapp/nextjs",
-            "version": "1.0.0",
+            "version": "2.1.0",
             "license": "MIT",
             "dependencies": {
-                "@flareapp/webpack": "^1.0.0"
+                "@flareapp/webpack": "^2.1.0"
             },
             "devDependencies": {
                 "next": "^15.0.0",
@@ -11306,7 +11224,7 @@
         },
         "packages/react": {
             "name": "@flareapp/react",
-            "version": "2.0.1",
+            "version": "2.1.0",
             "license": "MIT",
             "devDependencies": {
                 "@flareapp/js": "file:../js",
@@ -11322,13 +11240,13 @@
                 "vitest": "^4.0.0"
             },
             "peerDependencies": {
-                "@flareapp/js": "^2.0.1",
+                "@flareapp/js": "^2.1.0",
                 "react": "^16.0.0||^17.0.0||^18.0.0||^19.0.0"
             }
         },
         "packages/svelte": {
             "name": "@flareapp/svelte",
-            "version": "2.0.1",
+            "version": "2.1.0",
             "license": "MIT",
             "dependencies": {
                 "error-stack-parser": "^2.1.4"
@@ -11344,16 +11262,16 @@
                 "vitest": "^4.0.0"
             },
             "peerDependencies": {
-                "@flareapp/js": "^2.0.1",
+                "@flareapp/js": "^2.1.0",
                 "svelte": "^5.3.0"
             }
         },
         "packages/sveltekit": {
             "name": "@flareapp/sveltekit",
-            "version": "2.0.1",
+            "version": "2.1.0",
             "license": "MIT",
             "dependencies": {
-                "@flareapp/svelte": "^2.0.1"
+                "@flareapp/svelte": "^2.1.0"
             },
             "devDependencies": {
                 "@flareapp/js": "file:../js",
@@ -11366,14 +11284,14 @@
                 "vitest": "^4.0.0"
             },
             "peerDependencies": {
-                "@flareapp/js": "^2.0.1",
+                "@flareapp/js": "^2.1.0",
                 "@sveltejs/kit": "^2.12.0",
                 "svelte": "^5.3.0"
             }
         },
         "packages/vite": {
             "name": "@flareapp/vite",
-            "version": "2.0.0",
+            "version": "2.1.0",
             "license": "MIT",
             "devDependencies": {
                 "@flareapp/flare-api": "*",
@@ -11391,7 +11309,7 @@
         },
         "packages/vue": {
             "name": "@flareapp/vue",
-            "version": "2.0.1",
+            "version": "2.1.0",
             "license": "MIT",
             "devDependencies": {
                 "@flareapp/js": "file:../js",
@@ -11404,7 +11322,7 @@
                 "vue-router": "^4.6.4"
             },
             "peerDependencies": {
-                "@flareapp/js": "^2.0.1",
+                "@flareapp/js": "^2.1.0",
                 "vue": "^3.0.0",
                 "vue-router": "^4.0.0"
             },
@@ -11416,7 +11334,7 @@
         },
         "packages/webpack": {
             "name": "@flareapp/webpack",
-            "version": "1.0.0",
+            "version": "2.1.0",
             "license": "MIT",
             "devDependencies": {
                 "@flareapp/flare-api": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11324,7 +11324,7 @@
             "peerDependencies": {
                 "@flareapp/js": "^2.1.0",
                 "vue": "^3.0.0",
-                "vue-router": "^4.0.0"
+                "vue-router": "^4.0.0 || ^5.0.0"
             },
             "peerDependenciesMeta": {
                 "vue-router": {

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -51,7 +51,7 @@
         "typescript": "^5.7.0",
         "vitest": "^4.0.0",
         "vue": "^3.0.0",
-        "vue-router": "^4.6.4"
+        "vue-router": "^5.0.0"
     },
     "peerDependencies": {
         "@flareapp/js": "^2.1.0",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -56,7 +56,7 @@
     "peerDependencies": {
         "@flareapp/js": "^2.1.0",
         "vue": "^3.0.0",
-        "vue-router": "^4.0.0"
+        "vue-router": "^4.0.0 || ^5.0.0"
     },
     "peerDependenciesMeta": {
         "vue-router": {


### PR DESCRIPTION
When installing `@flareapp/vue@2` I get this error because there is currently no support for Vue Router 5:

```
npm error code ERESOLVE
npm error ERESOLVE could not resolve
npm error
npm error While resolving: @flareapp/vue@2.1.0
npm error Found: vue-router@5.0.7
npm error node_modules/vue-router
npm error   vue-router@"^5.0.7" from the root project
npm error
npm error Could not resolve dependency:
npm error peerOptional vue-router@"^4.0.0" from @flareapp/vue@2.1.0
npm error node_modules/@flareapp/vue
npm error   @flareapp/vue@"2.1.0" from the root project
npm error
npm error Conflicting peer dependency: vue-router@4.6.4
npm error node_modules/vue-router
npm error   peerOptional vue-router@"^4.0.0" from @flareapp/vue@2.1.0
npm error   node_modules/@flareapp/vue
npm error     @flareapp/vue@"2.1.0" from the root project
```

---

In this PR I add support for version 5 of Vue Router in `peerDependencies` without removing Vue Router 4 support for users. This is possible because Vue Router 5 has no breaking changes if you don't use `unplugin-vue-router` (and you don't):

> Vue Router 5 is a transition release that merges [unplugin-vue-router](https://uvr.esm.is/) (file-based routing) into the core package. **If you're using Vue Router 4 without unplugin-vue-router, there are no breaking changes** - you can upgrade without any code modifications. The only exception is that the iife build no longer includes `@vue/devtools-api` because it has been upgraded to v8 and does not expose an IIFE build itself. You can track that change in [this issue](https://github.com/vuejs/devtools/issues/989).
>
> Vue Router 6 will be ESM-only and remove deprecated APIs. v5 gives you time to prepare for that transition.

From: https://router.vuejs.org/guide/migration/v4-to-v5.html

I also updated to version 5 in `devDependencies` so that it's available when developing locally.