### PR TITLE
feat: standalone structured logging

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ package, and a Playwright-based e2e suite:
 
 - **Language:** TypeScript 5.7, target ES2022, strict mode
 - **Build:** tsdown (outputs CJS + ESM + .d.ts declarations)
-- **Test:** Vitest (tests only in `packages/js/tests/`)
+- **Test:** Vitest, per-package suites in `packages/<pkg>/tests/` (each package has its own `vitest.config.ts`)
 - **Linting:** oxlint (per-package configs extending root `.oxlintrc.json`)
 - **Formatting:** oxfmt (config in `.oxfmtrc.json`, replaces Prettier)
 - **Git hooks:** Husky + lint-staged (pre-commit runs oxlint --fix + oxfmt)
@@ -84,13 +84,19 @@ npm run playgrounds:svelte # Boot the SvelteKit playground on http://localhost:5
 
 ## Tests
 
-All tests are in `packages/js/tests/`:
+Tests live next to the code they cover, in each package's own `tests/` dir. Put a test where its behavior
+lives, not all in one package.
 
-- `configure.test.ts`, `context.test.ts`, `glows.test.ts`, `hooks.test.ts`
-- `light.test.ts`, `report.test.ts`, `solutions.test.ts`
-- `helpers/FakeApi.ts` — Test helper for mocking the API
+- `packages/core/tests/` — the bulk (~22 files): buffer/report/context/encoding/flush logic, plus
+  `helpers/FakeApi.ts` (the shared API mock).
+- `packages/js/tests/` — browser-specific (window listeners, fetch reader, browser context). Has its own
+  `helpers/FakeApi.ts`.
+- `packages/node/tests/` — Node-specific (~16 files): async-scope provider, fatal handlers, lifecycle,
+  disk file reader, Node context.
+- `packages/{react,vue,svelte}/tests/` — framework integration tests.
 
-Run tests: `npm run test` from root, or `npx vitest run` from `packages/js`.
+Run tests: `npm run test` from root (runs every workspace's suite), or `npx vitest run` from a single
+`packages/<pkg>`.
 
 ## Playgrounds
 

--- a/docs/superpowers/specs/2026-06-03-core-logging-design.md
+++ b/docs/superpowers/specs/2026-06-03-core-logging-design.md
@@ -215,6 +215,16 @@ mis-placing a request key on the resource corrupts batched envelopes).
 
 - Resource-level prefixes (the allowlist): `service.`, `telemetry.`, `host.`,
   `os.`, `process.`, `flare.framework.`, `flare.language.`.
+- Record-level exceptions that override the allowlist: `process.uptime`. The Node
+  collector emits `process.uptime` (`process.ts:19`) as a **changing** per-capture
+  value, deliberately re-read each time. Promoting it to the shared resource would
+  tag every batched record with the flush-time uptime, not each record's
+  capture-time uptime — breaking the resource-static assumption. So `process.uptime`
+  is kept record-level despite the `process.` prefix (PHP's resource process data
+  is stable identity — pid / executable / command / owner — and excludes uptime;
+  this keeps the JS resource equally stable). The partition is therefore
+  "resource-prefix allowlist MINUS an explicit record-level exception set, then
+  everything else record-level."
 - Everything else → record-level. The keys the collectors actually emit that fall
   here, verified against source: `http.*`, `url.*`, `enduser.*`, `client.address`
   (`collectNode.ts:104-111` — note it is `enduser.*` / `client.address`, NOT
@@ -231,8 +241,10 @@ collector emits `flare.entry_point.type` / `.value`, and `buildReport`'s
 entry-point overrides emit `flare.entry_point.handler.*`; different sub-keys,
 both kept.
 
-Process/host are instance-static, so merging them into the one resource (last
-write wins across records) dedupes them correctly. This dedupe is only valid for
+Process/host identity (pid, runtime, hostname, arch, os) are instance-static, so
+merging them into the one resource (last write wins across records) dedupes them
+correctly. The one non-static `process.*` key, `process.uptime`, is excluded from
+the resource (kept record-level, above), so the dedupe is only applied to genuinely
 **instance-static** attributes; see the resource-static assumption under "Resource
 assembly".
 

--- a/docs/superpowers/specs/2026-06-03-core-logging-design.md
+++ b/docs/superpowers/specs/2026-06-03-core-logging-design.md
@@ -258,11 +258,19 @@ change an already-buffered record. Merge order, last write wins:
    `NodeScope.ts:6`, not in `pendingAttributes`). Partition its output: the
    record-level keys stay on this record; the resource-level keys are handed to
    the envelope builder (below).
-2. Active scope `pendingAttributes` (custom context from `addContext` /
+2. Entry-point overrides from `scope.entryPoint` (`flare.entry_point.handler.*`),
+   applied after the collector.
+3. Active scope `pendingAttributes` (custom context from `addContext` /
    `addContextGroup`).
-3. Entry-point overrides from `scope.entryPoint` (`flare.entry_point.handler.*`),
-   applied after the collector — matching `buildReport`'s ordering.
 4. User-passed `attributes` (highest precedence).
+
+This order matches `buildReport` exactly (`Flare.ts:462-468`: collector ->
+entry-point overrides -> pending -> extra), so pending scope attrs win over
+entry-point overrides and user/extra attrs win last. This is **intentional
+report/log parity**: a log resolves a colliding key the same way a report would.
+The shared assembly is factored into one method both `buildReport` and the log
+path call (the log path partitions only the collector output first; see "Resource
+vs record attributes").
 
 `context.custom` gets the **same special handling `buildReport` has**
 (`Flare.ts:470`), which the earlier "exactly buildReport's assembly" wording

--- a/docs/superpowers/specs/2026-06-03-core-logging-design.md
+++ b/docs/superpowers/specs/2026-06-03-core-logging-design.md
@@ -1,0 +1,300 @@
+# Core logging — standalone structured logs
+
+Date: 2026-06-03
+Status: Approved (design)
+
+## Problem
+
+The PHP client (`spatie/flare-client-php`) ships structured logs as a first-class
+entity: an in-memory buffer of log records, shipped to Flare's `POST /v1/logs`
+ingest endpoint as an OpenTelemetry `resourceLogs` payload. The JS/TS client has
+no equivalent. It has two adjacent but distinct features:
+
+- `glow()` — breadcrumbs attached to error reports as span events (PHP "glows").
+- `reportMessage(..., isLog: true)` — a single log sent as a report to `/v1/errors`.
+
+Neither provides standalone log shipping. This design adds it: buffer log entries
+and POST them to `/v1/logs` as their own entity, viewable independent of errors.
+
+## Goals
+
+- Standalone structured logs buffered in core and shipped to `/v1/logs`.
+- Wire format mirrors `https://flareapp.io/docs/protocol/logs/payload` exactly
+  (OTel `resourceLogs` envelope).
+- Batching policy (count/weight/timer caps) lives in core, no per-platform
+  duplication.
+- Lifecycle teardown (browser unload, Node shutdown) is a per-environment seam,
+  matching how `Api` / `ScopeProvider` / `FileReader` are already injected.
+- Ergonomic level-helper API (`flare.logger.info(...)`), idiomatic for JS.
+
+## Non-goals (v1)
+
+- Attaching standalone logs onto error reports — glows already cover
+  breadcrumbs-on-report.
+- Monolog/console-bridge style auto-capture of existing log calls.
+- e2e playground triggers + Playwright coverage (follow-up).
+- Auto-merging active-scope context / entry point into log attributes (later
+  enhancement; avoids coupling now).
+
+## Architecture
+
+New capability split across packages, reusing the existing DI seams:
+
+```
+@flareapp/core
+  Logger          buffer + batching policy + flush + OTel envelope build
+  SeverityMapper  level -> severityNumber, severityText
+  otel encoding   attributesToOpenTelemetry / valueToOpenTelemetry
+  Api.logs()      POST envelope to /v1/logs
+  FlushScheduler  INTERFACE (injected) — owns only the lifecycle teardown trigger
+
+@flareapp/js    BrowserFlushScheduler  -> visibilitychange:hidden, flush({ keepalive: true })
+@flareapp/node  NodeFlushScheduler     -> process.on('beforeExit'), flush()
+```
+
+Core owns the count/weight/timer caps. The platform supplies only the
+"drain on teardown" hook. This is the Sentry model: shared batching policy in
+core, one lifecycle hook per environment.
+
+## Public API
+
+On the Flare instance:
+
+```ts
+flare.logger.debug(message, attributes?)
+flare.logger.info(message, attributes?)
+flare.logger.notice(message, attributes?)
+flare.logger.warning(message, attributes?)
+flare.logger.error(message, attributes?)
+flare.logger.critical(message, attributes?)
+flare.logger.alert(message, attributes?)
+flare.logger.emergency(message, attributes?)
+
+flare.flush(timeoutMs?)   // now also drains the log buffer
+```
+
+- `message: string`
+- `attributes?: Attributes` (reuses the existing core `Attributes` type)
+- The 8 levels reuse the existing `MessageLevel` type, which already lists
+  exactly these 8 names.
+- `flare.logger` is the core `Logger` instance, exposing the 8 helpers.
+
+### Config additions (`Config`)
+
+| Key                  | Type            | Default                               | Meaning                                            |
+| -------------------- | --------------- | ------------------------------------- | -------------------------------------------------- |
+| `enableLogs`         | `boolean`       | `false`                               | Opt-in. No surprise log traffic until switched on. |
+| `logsIngestUrl`      | `string`        | `https://ingress.flareapp.io/v1/logs` | Logs endpoint (sibling of `ingestUrl`).            |
+| `minimumLogLevel`    | `MessageLevel?` | `undefined`                           | Drop logs below this level at capture time.        |
+| `maxLogBufferSize`   | `number`        | `100`                                 | Flush when buffer reaches this count.              |
+| `logFlushIntervalMs` | `number`        | `5000`                                | One-shot timer flush interval.                     |
+| `logFlushMaxBytes`   | `number`        | `800_000`                             | Flush when estimated buffer bytes reach this.      |
+
+## Buffer, batching, flush
+
+`Logger` (core), one global buffer per Flare instance.
+
+`record(level, message, attributes)`:
+
+1. If `!config.enableLogs`, return.
+2. If `config.minimumLogLevel` is set and `level` is below it (by severity
+   number), drop.
+3. Build a `LogRecord` (timestamp now, severityNumber + severityText, body,
+   attributes), push to the buffer.
+4. Evaluate auto-flush triggers (below).
+
+Auto-flush triggers (core-owned policy):
+
+- Buffer length `>= maxLogBufferSize` (100) -> flush now.
+- Estimated buffer bytes `>= logFlushMaxBytes` (~0.8 MB) -> flush now.
+- Else, if no timer is active, start a one-shot
+  `setTimeout(flush, logFlushIntervalMs)`. The clock runs from the first
+  buffered item after a flush and is NOT reset per log, so max latency is
+  bounded at the interval. Call `timer.unref?.()` so Node is not held open;
+  harmless no-op in the browser.
+
+`flush(opts?: { keepalive?: boolean })`:
+
+- Snapshot and clear the buffer; clear the timer / active flag.
+- Empty buffer -> no-op.
+- Build the envelope, call `api.logs(envelope, …, opts?.keepalive)`.
+- Register the send in the existing `inflight` set (via the same `track`
+  mechanism reports use) so `flare.flush()` awaits in-flight log sends too.
+
+`FlushScheduler` interface:
+
+```ts
+interface FlushScheduler {
+    register(flush: (opts?: { keepalive?: boolean }) => void): void;
+}
+```
+
+- Default implementation is a no-op (core has no lifecycle to hook).
+- The browser and Node packages inject real schedulers.
+- The count/weight/timer caps stay in core regardless of which scheduler is
+  injected.
+
+`flare.flush(timeoutMs?)` is extended to drain the log buffer (await
+`logger.flush()`) in addition to waiting on in-flight reports.
+
+## Wire format (OTel envelope)
+
+Mirrors `https://flareapp.io/docs/protocol/logs/payload`:
+
+```jsonc
+{
+    "resourceLogs": [
+        {
+            "resource": {
+                "attributes": [
+                    /* KeyValue */
+                ],
+                "droppedAttributesCount": 0,
+            },
+            "scopeLogs": [
+                {
+                    "scope": {
+                        "name": "@flareapp/js",
+                        "version": "<sdk ver>",
+                        "attributes": [],
+                        "droppedAttributesCount": 0,
+                    },
+                    "logRecords": [
+                        {
+                            "timeUnixNano": "<string ns>",
+                            "observedTimeUnixNano": "<string ns>",
+                            "severityNumber": 9,
+                            "severityText": "INFO",
+                            "body": { "stringValue": "the message" },
+                            "attributes": [
+                                /* KeyValue */
+                            ],
+                            "flags": 0,
+                        },
+                    ],
+                },
+            ],
+        },
+    ],
+}
+```
+
+Protocol divergences from the PHP client, locked to the protocol doc:
+
+- Timestamps are **strings** (nanoseconds-as-string). This sidesteps the
+  `Number.MAX_SAFE_INTEGER` nanosecond-precision loss the client already
+  documents for `seenAtUnixNano`. Compute as `String(Date.now()) + '000000'`
+  (ms -> ns, no float math, no precision loss).
+- `flags` is integer `0` (PHP used string `'01'`/`'00'`).
+- `severityText` is uppercase (`"INFO"`, `"ERROR"`).
+
+### OTel value encoding (`valueToOpenTelemetry`)
+
+Ported from PHP `OpenTelemetryAttributeMapper`, with the JS-specific decisions
+made explicit:
+
+| Input                        | Output                                             |
+| ---------------------------- | -------------------------------------------------- |
+| `string`                     | `{ stringValue }`                                  |
+| `boolean`                    | `{ boolValue }`                                    |
+| `number`, `Number.isInteger` | `{ intValue }`                                     |
+| `number`, otherwise          | `{ doubleValue }`                                  |
+| array                        | `{ arrayValue: { values: [...recurse] } }`         |
+| plain object                 | `{ kvlistValue: { values: [{ key, value }...] } }` |
+| `null`                       | dropped (filtered out of the attributes array)     |
+
+`attributesToOpenTelemetry(attrs)` maps each entry to `{ key, value }`, dropping
+null-valued entries.
+
+### SeverityMapper
+
+| Level     | severityNumber |
+| --------- | -------------- |
+| debug     | 5              |
+| info      | 9              |
+| notice    | 10             |
+| warning   | 13             |
+| error     | 17             |
+| critical  | 18             |
+| alert     | 19             |
+| emergency | 21             |
+
+`severityText` = the level name uppercased. Minimum-level comparison uses the
+severity number.
+
+### Resource / scope attributes
+
+- Resource attributes: `service.name`, `service.version` and `service.stage`
+  (when set), `telemetry.sdk.language: "javascript"`, `telemetry.sdk.name` and
+  `telemetry.sdk.version` from `sdkInfo`, framework attributes when set. Reuses
+  the same base-attribute logic `buildReport` already assembles.
+- Scope `name` / `version` come from `sdkInfo`.
+
+### Api.logs
+
+```ts
+Api.logs(envelope, url, key, debug, keepalive?)
+```
+
+Mirrors `Api.report`. Header `x-api-token`. `keepalive` is passed straight to
+`fetch` so a browser unload flush survives; Node's fetch accepts and ignores it
+harmlessly. Treats `201` as success (other codes logged when `debug`).
+
+## Platform schedulers
+
+`@flareapp/js` — `BrowserFlushScheduler`:
+
+- `register(flush)` adds a `document` `visibilitychange` listener; on
+  `visibilityState === 'hidden'`, calls `flush({ keepalive: true })`.
+- Relies on `fetch` `keepalive` for unload-time delivery (no `sendBeacon`).
+
+`@flareapp/node` — `NodeFlushScheduler`:
+
+- `register(flush)` adds `process.on('beforeExit', () => flush())`.
+- The existing fatal handler already calls `flare.flush()`, which now drains
+  logs too, so a crash path also ships buffered logs (best-effort within the
+  shutdown timeout).
+
+## Scope semantics
+
+The log buffer is global per Flare instance, not per-request scope (matches PHP's
+singleton `Logger` and Sentry's per-client buffer). In Node, concurrent requests
+share one buffer; each record carries its own user-passed attributes. v1 does not
+auto-merge active-scope context or entry point into log attributes.
+
+## Testing
+
+Vitest, in `packages/js/tests/`. New `logs.test.ts`:
+
+- Opt-in gating: nothing recorded/sent when `enableLogs` is false.
+- `minimumLogLevel` drops below-threshold records at capture.
+- Count-cap flush at `maxLogBufferSize`.
+- Timer flush via fake timers at `logFlushIntervalMs`.
+- Envelope shape + OTel value encoding (string/number int vs double/bool/
+  array/object/null-drop).
+- Level helpers map to the right severity number/text.
+- `flush()` drains the buffer and awaits the send.
+
+`FakeApi` (test helper) extended to capture `logs()` sends alongside `report()`.
+
+## Files (anticipated)
+
+New in `@flareapp/core`:
+
+- `src/logging/Logger.ts`
+- `src/logging/SeverityMapper.ts`
+- `src/logging/otel.ts` (attribute/value encoding)
+- `src/logging/FlushScheduler.ts` (interface + no-op default)
+- types added to `src/types.ts` (`LogRecord`, OTel envelope types, `Config`
+  additions)
+- `Api.logs()` in `src/api/Api.ts`
+- exports in `src/index.ts`
+- `Logger` wired into `Flare` (new constructor seam: `flushScheduler`)
+
+New in `@flareapp/js`:
+
+- `src/browser/BrowserFlushScheduler.ts`, wired into the browser Flare assembly.
+
+New in `@flareapp/node`:
+
+- `src/logging/NodeFlushScheduler.ts`, wired into the Node Flare assembly.

--- a/docs/superpowers/specs/2026-06-03-core-logging-design.md
+++ b/docs/superpowers/specs/2026-06-03-core-logging-design.md
@@ -33,8 +33,6 @@ and POST them to `/v1/logs` as their own entity, viewable independent of errors.
   breadcrumbs-on-report.
 - Monolog/console-bridge style auto-capture of existing log calls.
 - e2e playground triggers + Playwright coverage (follow-up).
-- Auto-merging active-scope context / entry point into log attributes (later
-  enhancement; avoids coupling now).
 
 ## Architecture
 
@@ -109,9 +107,30 @@ the Flare UI.
 1. If `!config.enableLogs`, return.
 2. If `config.minimumLogLevel` is set and `level` is below it (by severity
    number), drop.
-3. Build a `LogRecord` (timestamp now, severityNumber + severityText, body,
-   attributes), push to the buffer.
-4. Evaluate auto-flush triggers (below).
+3. Resolve the merged attributes for this record (see "Per-record attributes"
+   below): active scope `pendingAttributes` + entry-point attributes +
+   user-passed `attributes`.
+4. Build a `LogRecord` (timestamp now, severityNumber + severityText, body,
+   merged attributes), push to the buffer.
+5. Evaluate auto-flush triggers (below).
+
+### Per-record attributes
+
+Attributes are resolved and **frozen at capture time** (a later mutation of the
+scope must not retroactively change an already-buffered record), mirroring PHP,
+which merges the context recorder and entry-point resolver into each record
+before buffering. Merge order, last write wins:
+
+1. Active scope `pendingAttributes` (`scopeProvider.active().pendingAttributes`)
+   — the same custom context `addContext` / `addContextGroup` feed into reports.
+   In Node this is the per-request `NodeScope`, so request-scoped logs become
+   filterable by request context.
+2. Entry-point attributes from `scope.entryPoint`, emitted under the same
+   `flare.entry_point.handler.*` keys `buildReport` uses.
+3. User-passed `attributes` (highest precedence).
+
+This reuses the attribute-assembly logic `buildReport` already has; factor the
+shared part out rather than duplicating it.
 
 Auto-flush triggers (core-owned policy):
 
@@ -317,8 +336,11 @@ Constraints, all browser-enforced and browser-only:
 
 The log buffer is global per Flare instance, not per-request scope (matches PHP's
 singleton `Logger` and Sentry's per-client buffer). In Node, concurrent requests
-share one buffer; each record carries its own user-passed attributes. v1 does not
-auto-merge active-scope context or entry point into log attributes.
+share one buffer. Each record still captures the **active scope's** context +
+entry-point attributes at `record()` time (see "Per-record attributes"), so a
+record buffered during a request carries that request's context even though the
+buffer itself is shared. The buffer holds fully-resolved records, not references
+to live scopes.
 
 ## Testing
 
@@ -338,6 +360,8 @@ flush policy):
 - Envelope shape + OTel value encoding (string / number int vs double / bool /
   array / object / null-drop).
 - Level helpers map to the right severity number/text.
+- Per-record attributes: scope context + entry-point merged at capture, frozen
+  (later scope mutation does not change a buffered record), user attributes win.
 - Teardown flush chunks to `keepaliveMaxBytes` (multiple envelopes when over).
 - `flush()` starts sends into `inflight`; `flare.flush(timeoutMs)` stays bounded.
 

--- a/docs/superpowers/specs/2026-06-03-core-logging-design.md
+++ b/docs/superpowers/specs/2026-06-03-core-logging-design.md
@@ -165,6 +165,23 @@ drop keeps every buffered record guaranteed-shippable (fits a normal envelope, a
 fits a keepalive teardown envelope when under `keepaliveMaxBytes`). A test asserts
 an over-cap single record is dropped and does not wedge the buffer.
 
+### Disable semantics
+
+`enableLogs` is a master switch, not just a capture gate. `record()` returns early
+when it is false (nothing buffered), and `flush()` returns early when it is false
+(nothing sent) — so a user who buffers logs while enabled and then
+`configure({ enableLogs: false })` before the timer fires (or before `light(key)`)
+gets **no log traffic**, which is the intuitive meaning of "disable logging."
+
+The disable transition also **clears the buffer**: when `configure(...)` flips
+`enableLogs` from true to false, the `Logger` drops its buffered records (the same
+`clearGlows`-style reset). Rationale: a disabled logger that silently retained a
+backlog would either leak it on a later re-enable (surprising) or pin memory
+indefinitely. Clear-on-disable makes "off" mean off. Re-enabling starts a fresh
+buffer; it does not resurrect pre-disable records. A test covers: buffer while
+enabled, `configure({ enableLogs: false })`, assert no `api.logs` call on any
+subsequent flush path and the buffer is empty.
+
 ### Resource vs record attributes
 
 The OTel logs envelope has two attribute homes: the **resource** (once per
@@ -173,23 +190,41 @@ envelope) and each **logRecord** (per log line). PHP keeps these separate — th
 record carries the per-call context + entry point. The JS report path does NOT
 make this distinction (a report is a single entity with one flat `attributes`
 bag), so the existing `contextCollector` returns everything mixed: identity +
-process (`collectNode.ts:45`) alongside per-request `http.*` / `url.*` / `user.*`
-(`collectNode.ts:52+`). Putting that whole bag on every record would both
+process (`collectNode.ts:45`) alongside per-request `http.*` / `url.*` /
+`enduser.*` (`collectNode.ts:52+`). Putting that whole bag on every record would both
 duplicate process/host across all N records and diverge from PHP's placement.
 
 The split is done in core by **partitioning the collector output by key**, so no
-new platform seam is needed:
+new platform seam is needed. The rule is an **resource-prefix allowlist; every
+other key — known or unknown — is record-level**. This default direction matters:
+the collectors emit more keys than any prefix list will enumerate, and a new key
+added to a collector later must land somewhere safe without a spec change.
+Record-level is that safe default (request-varying data belongs on the record;
+mis-placing a static key on the record only costs a little duplication, whereas
+mis-placing a request key on the resource corrupts batched envelopes).
 
-- Resource-level key prefixes: `service.`, `telemetry.`, `host.`, `os.`,
-  `process.`, `flare.framework.`, `flare.language.`.
-- Everything else is record-level: `http.`, `url.`, `request.`, `user.`,
-  `context.`, `flare.entry_point.`.
+- Resource-level prefixes (the allowlist): `service.`, `telemetry.`, `host.`,
+  `os.`, `process.`, `flare.framework.`, `flare.language.`.
+- Everything else → record-level. The keys the collectors actually emit that fall
+  here, verified against source: `http.*`, `url.*`, `enduser.*`, `client.address`
+  (`collectNode.ts:104-111` — note it is `enduser.*` / `client.address`, NOT
+  `user.*`), `user_agent.original`, `document.ready_state` (browser collector),
+  `context.*`, and `flare.entry_point.*`. (Earlier drafts listed `user.` /
+  `request.` prefixes that no collector emits — do not rely on them; the
+  allowlist-plus-default rule is what's load-bearing.)
 
-`flare.entry_point.*` is intentionally placed at **record** level even though the
-resources protocol lists it as a resource attribute: in a batched envelope the
-records can come from different requests, so entry point must travel per-record
-to stay accurate. Process/host are instance-static, so merging them into the one
-resource (last write wins across records) dedupes them correctly.
+`flare.entry_point.*` is intentionally record-level even though the resources
+protocol lists it as a resource attribute: in a batched envelope the records can
+come from different requests, so entry point must travel per-record to stay
+accurate. Two sub-families coexist on the record without clobbering — the
+collector emits `flare.entry_point.type` / `.value`, and `buildReport`'s
+entry-point overrides emit `flare.entry_point.handler.*`; different sub-keys,
+both kept.
+
+Process/host are instance-static, so merging them into the one resource (last
+write wins across records) dedupes them correctly. This dedupe is only valid for
+**instance-static** attributes; see the resource-static assumption under "Resource
+assembly".
 
 #### Per-record assembly (in `record()`, frozen at capture time)
 
@@ -229,6 +264,19 @@ identity (`service.name` when set, `service.version` / `service.stage` when set,
 framework) merged with the resource-level attributes partitioned out of the
 collector (process/host).
 
+Resource-static assumption: one envelope carries one resource shared by all its
+batched records, so resource attributes are assumed **instance-static for the
+buffer's lifetime**. Identity (`sdkInfo`, `framework`, `serviceName`) and
+process/host are stable in normal use, so this holds. The known sharp edge:
+reconfiguring `serviceName` or calling `setFramework(...)` **between** buffering
+records and the flush will tag every already-buffered record in that envelope
+with the new resource value (last-write-wins at flush), not the value in effect
+when each was recorded. This is acceptable — reconfiguring identity mid-batch is
+not a real workflow — but it is a real divergence from the per-record freezing
+that record-level attributes get. If it ever becomes a problem, snapshot the
+resource at the first record after each flush instead of at flush time. Not done
+in v1.
+
 Cost note: running the context collector per log re-reads env context (browser
 cookies/URL, Node process/request) on every `record()`. Matches PHP's per-record
 context behavior and keeps logs filterable, but it is real per-log work; if it
@@ -248,6 +296,10 @@ Auto-flush triggers (core-owned policy):
 `flush(opts?: { keepalive?: boolean })`:
 
 - Empty buffer -> no-op.
+- **Enabled gate (master switch):** if `!config.enableLogs`, no-op — never call
+  `api.logs`. `enableLogs` gates BOTH capture (`record()`) and send (`flush()`),
+  so logs buffered while enabled are not shipped after the user turns logging off.
+  See "Disable semantics" below for what happens to the already-buffered records.
 - **Key gate:** if `assertKey(config.key, config.debug)` is false (no API key
   set yet), reset the timer-active flag (the one-shot has fired) but **leave the
   buffer intact**, then return. This mirrors `sendReport`'s `assertKey` guard
@@ -372,25 +424,54 @@ Protocol divergences from the PHP client, locked to the protocol doc:
 
 - Timestamps are **strings** (nanoseconds-as-string). This sidesteps the
   `Number.MAX_SAFE_INTEGER` nanosecond-precision loss the client already
-  documents for `seenAtUnixNano`. Compute as `String(Date.now()) + '000000'`
-  (ms -> ns, no float math, no precision loss).
+  documents for `seenAtUnixNano`. Compute once as `String(Date.now()) + '000000'`
+  (ms -> ns, no float math, no precision loss), and write that **same value** to
+  both `timeUnixNano` and `observedTimeUnixNano` (the protocol requires at least
+  one; we emit both with the capture time).
 - `flags` is integer `0` (PHP used string `'01'`/`'00'`).
 - `severityText` is uppercase (`"INFO"`, `"ERROR"`).
+- `droppedAttributesCount` is emitted as a literal `0` on resource / scope /
+  record. The client DOES drop attributes (recursive null-drop) and records (trim,
+  oversized, keepalive overflow), but it does not count them into this field — the
+  field is optional per protocol and a hard `0` is simpler than threading a count
+  through. Documented so the `0` is understood as "not tracked," not "nothing was
+  ever dropped."
 
 ### OTel value encoding (`valueToOpenTelemetry`)
 
 Ported from PHP `OpenTelemetryAttributeMapper`, with the JS-specific decisions
 made explicit:
 
-| Input                        | Output                                                           |
-| ---------------------------- | ---------------------------------------------------------------- |
-| `string`                     | `{ stringValue }`                                                |
-| `boolean`                    | `{ boolValue }`                                                  |
-| `number`, `Number.isInteger` | `{ intValue }`                                                   |
-| `number`, otherwise          | `{ doubleValue }`                                                |
-| array                        | `{ arrayValue: { values: [...recurse, null-dropped] } }`         |
-| plain object                 | `{ kvlistValue: { values: [{ key, value }...], null-dropped } }` |
-| `null`                       | dropped (no OTel `anyValue` null type exists)                    |
+| Input                                   | Output                                                           |
+| --------------------------------------- | ---------------------------------------------------------------- |
+| `string`                                | `{ stringValue }`                                                |
+| `boolean`                               | `{ boolValue }`                                                  |
+| non-finite `number` (`NaN`/`±Infinity`) | dropped (see below)                                              |
+| finite `number`, `Number.isInteger`     | `{ intValue }`                                                   |
+| finite `number`, otherwise              | `{ doubleValue }`                                                |
+| array                                   | `{ arrayValue: { values: [...recurse, null-dropped] } }`         |
+| plain object                            | `{ kvlistValue: { values: [{ key, value }...], null-dropped } }` |
+| `null` / `undefined`                    | dropped (no OTel `anyValue` null type exists)                    |
+
+Number edge cases (JS has one `number` type; PHP had distinct int/float, so these
+are JS-specific decisions, not inherited from the PHP mapper):
+
+- **Non-finite (`NaN`, `Infinity`, `-Infinity`):** encode to `null` (i.e.
+  dropped, same as `null`). Critical: the send path is `flatJsonStringify` →
+  `JSON.stringify`, which turns `NaN`/`Infinity` into the JSON literal `null`. So
+  emitting `{ doubleValue: NaN }` would serialize to `{ "doubleValue": null }` — a
+  malformed OTel `anyValue` the ingest can reject. The encoder must detect
+  `!Number.isFinite(n)` BEFORE choosing `intValue`/`doubleValue` and drop it.
+- **`intValue` representation:** a bare JSON number, matching PHP (`json_encode`
+  of a PHP int is a bare number) and what the Flare ingest already accepts from
+  the PHP client. Not stringified. (Contrast timestamps, which are forced to
+  strings because they are ALWAYS ~19 digits; ordinary integer attributes are
+  not.)
+- **Beyond `Number.MAX_SAFE_INTEGER`:** a JS `number` that large has already lost
+  integer precision before it reaches the encoder, so no special handling — it is
+  emitted as the (already-imprecise) `intValue`. Callers needing exact large
+  integers must pass them as strings. Documented, not guarded.
+- **`-0`:** serializes to `0`; harmless, no special case.
 
 `AttributeValue` permits nested nulls (`packages/core/src/types.ts:3`:
 `{ foo: [null] }`, `{ foo: { bar: null } }`). OTel `anyValue` has no null
@@ -515,6 +596,18 @@ Constraints, all browser-enforced and browser-only:
   logs too, so a crash path also ships buffered logs (best-effort within the
   shutdown timeout).
 
+Known `beforeExit` gap: `beforeExit` fires only when the event loop drains
+naturally. It does **not** fire on `process.exit()`, nor on `SIGTERM` / `SIGINT`
+unless the app installs handlers that let the loop empty. So a graceful container
+shutdown that calls `process.exit(0)` from a signal handler bypasses both
+`beforeExit` and the fatal handler, and buffered logs are lost. v1 does **not**
+auto-install `SIGTERM`/`SIGINT` handlers — doing so would silently take over
+signals the host app likely manages itself, a worse surprise than a few dropped
+logs. The documented guidance is: call `await flare.flush()` in your own shutdown
+hook (the same call that already drains reports). This is called out so the
+limitation is a known, documented contract rather than a silent gap. Revisit if
+users report lost logs on graceful shutdown.
+
 ## Scope semantics
 
 The log buffer is global per Flare instance, not per-request scope (matches PHP's
@@ -535,6 +628,9 @@ in `packages/js`.
 flush policy):
 
 - Opt-in gating: nothing recorded/sent when `enableLogs` is false.
+- Disable semantics: buffer logs while `enableLogs: true`, then
+  `configure({ enableLogs: false })`; assert no `api.logs` call on any subsequent
+  flush path AND the buffer was cleared on the disable transition.
 - Key gate: `enableLogs: true` + `key: null` records into the buffer but no flush
   path (manual, timer, count, unload) calls `api.logs`; buffer is retained.
 - Keyless backlog ships on `light(key)`: record several logs with no key (no
@@ -543,7 +639,8 @@ flush policy):
 - Keyless trim bound: with `enableLogs: true` + `key: null`, recording far more
   than `maxLogBufferSize` keeps the buffer at the cap (oldest dropped), does not
   grow unbounded.
-- `minimumLogLevel` drops below-threshold records at capture.
+- `minimumLogLevel` drops below-threshold records at capture; strict `<` by
+  severity number (a record exactly at the threshold is kept, matching PHP).
 - Count-cap flush at `maxLogBufferSize`.
 - Weight-cap flush at `logFlushMaxBytes`.
 - Weight-cap with a key **flushes-and-clears, does not trim**: crossing
@@ -570,6 +667,12 @@ flush policy):
   flush's resource/scope (not stuck at `@flareapp/core`).
 - OTel nested-null drop: `[1, null, 2]` and `{ a: 1, b: null }` drop nulls at
   depth, no null-holes in `arrayValue` / `kvlistValue`.
+- Non-finite numbers: `NaN` / `Infinity` / `-Infinity` attribute values are
+  dropped (never emitted as `{ doubleValue: null }`); a real-number sibling in the
+  same object/array survives.
+- Resource/record partition default: an unknown key (no resource prefix) lands at
+  record level; `enduser.*` / `client.address` / `user_agent.original` are
+  record-level (verified against real collector keys, not the dead `user.*`).
 - Teardown flush sends ONE keepalive envelope `<= keepaliveMaxBytes`; older
   overflow is dropped, not split into a second keepalive POST.
 - Teardown packs newest-first and skips an over-`keepaliveMaxBytes` record: a
@@ -611,9 +714,15 @@ New in `@flareapp/core`:
 - `Logger` wired into `Flare`: new constructor seam `flushScheduler`; `Logger`
   reads SDK/framework lazily (getters into `Flare`), so `setSdkInfo` /
   `setFramework` after `super(...)` are reflected at flush time
-- `Flare.light(...)` (and `configure(...)` when it sets a key) calls
-  `logger.flush()` after applying the key, when the buffer is non-empty, so a
-  backlog buffered before authentication ships as soon as a key arrives
+- `Flare.light(...)` (and `configure(...)` when it sets a key, gated on
+  `config.key !== undefined`, not on any `configure` call) calls `logger.flush()`
+  after applying the key, when the buffer is non-empty, so a backlog buffered
+  before authentication ships as soon as a key arrives
+- `configure(...)` detects an `enableLogs` true->false transition and clears the
+  log buffer (disable semantics)
+- the OTel encoder mirrors `flatJsonStringify`'s `JSON.stringify` reality: drop
+  non-finite numbers BEFORE choosing `intValue`/`doubleValue`, so no
+  `{ doubleValue: null }` reaches the wire
 
 New in `@flareapp/js`:
 

--- a/docs/superpowers/specs/2026-06-03-core-logging-design.md
+++ b/docs/superpowers/specs/2026-06-03-core-logging-design.md
@@ -32,7 +32,10 @@ and POST them to `/v1/logs` as their own entity, viewable independent of errors.
 - Attaching standalone logs onto error reports — glows already cover
   breadcrumbs-on-report.
 - Monolog/console-bridge style auto-capture of existing log calls.
-- e2e playground triggers + Playwright coverage (follow-up).
+- Broad e2e playground triggers + Playwright coverage across all four frameworks
+  (follow-up). The one exception is a single cross-origin unload test that backs
+  the keepalive/preflight guarantee (see Testing) — that one is in scope because
+  it verifies correctness, not just coverage.
 
 ## Architecture
 
@@ -110,44 +113,84 @@ default like `"unknown"` would just be noise in the Flare UI.
 1. If `!config.enableLogs`, return.
 2. If `config.minimumLogLevel` is set and `level` is below it (by severity
    number), drop.
-3. Resolve the merged attributes for this record (see "Per-record attributes"
-   below): active scope `pendingAttributes` + entry-point attributes +
+3. Resolve this record's attributes (see "Resource vs record attributes" below):
+   run the context collector, partition out resource-level keys, merge the
+   record-level keys with scope custom context, entry-point overrides, and
    user-passed `attributes`.
 4. Build a `LogRecord` (timestamp now, severityNumber + severityText, body,
-   merged attributes), push to the buffer.
+   record-level attributes), push to the buffer; stash the partitioned
+   resource-level attributes for the envelope.
 5. Evaluate auto-flush triggers (below).
 
-### Per-record attributes
+### Resource vs record attributes
 
-Attributes are resolved and **frozen at capture time** (a later mutation of the
-scope must not retroactively change an already-buffered record), mirroring PHP,
-which merges the context recorder and entry-point resolver into each record
-before buffering. Merge order, last write wins:
+The OTel logs envelope has two attribute homes: the **resource** (once per
+envelope) and each **logRecord** (per log line). PHP keeps these separate — the
+`Resource` exports static service / SDK / host / process data, while each log
+record carries the per-call context + entry point. The JS report path does NOT
+make this distinction (a report is a single entity with one flat `attributes`
+bag), so the existing `contextCollector` returns everything mixed: identity +
+process (`collectNode.ts:45`) alongside per-request `http.*` / `url.*` / `user.*`
+(`collectNode.ts:52+`). Putting that whole bag on every record would both
+duplicate process/host across all N records and diverge from PHP's placement.
 
-1. `contextCollector(config)` output — the **injected env collector**, same one
-   `buildReport` calls. This is the load-bearing source for Node request/user
-   data: `NodeScope.request` / `NodeScope.user` are separate buckets
-   (`packages/node/src/scope/NodeScope.ts:6`) that do **not** live in
-   `pendingAttributes`; they only become attributes when `makeNodeContextCollector`
-   projects them (`packages/node/src/context/collectNode.ts:52`). Merging just
-   `pendingAttributes` would silently miss request/user context. So `record()`
-   must run the same collector reports do.
-2. Active scope `pendingAttributes` (`scopeProvider.active().pendingAttributes`)
-   — the custom context `addContext` / `addContextGroup` feed into reports.
-3. Entry-point attributes from `scope.entryPoint`, emitted under the same
-   `flare.entry_point.handler.*` keys `buildReport` uses (entry-point overrides
-   applied after the collector, matching `buildReport`).
+The split is done in core by **partitioning the collector output by key**, so no
+new platform seam is needed:
+
+- Resource-level key prefixes: `service.`, `telemetry.`, `host.`, `os.`,
+  `process.`, `flare.framework.`, `flare.language.`.
+- Everything else is record-level: `http.`, `url.`, `request.`, `user.`,
+  `context.`, `flare.entry_point.`.
+
+`flare.entry_point.*` is intentionally placed at **record** level even though the
+resources protocol lists it as a resource attribute: in a batched envelope the
+records can come from different requests, so entry point must travel per-record
+to stay accurate. Process/host are instance-static, so merging them into the one
+resource (last write wins across records) dedupes them correctly.
+
+#### Per-record assembly (in `record()`, frozen at capture time)
+
+Resolved once and stored on the buffered record; a later scope mutation must not
+change an already-buffered record. Merge order, last write wins:
+
+1. Run `contextCollector(config)` (the injected env collector — the only source
+   of Node `NodeScope.request` / `user`, which are separate buckets at
+   `NodeScope.ts:6`, not in `pendingAttributes`). Partition its output: the
+   record-level keys stay on this record; the resource-level keys are handed to
+   the envelope builder (below).
+2. Active scope `pendingAttributes` (custom context from `addContext` /
+   `addContextGroup`).
+3. Entry-point overrides from `scope.entryPoint` (`flare.entry_point.handler.*`),
+   applied after the collector — matching `buildReport`'s ordering.
 4. User-passed `attributes` (highest precedence).
 
-This is exactly `buildReport`'s attribute assembly minus the report-only base
-attributes. Factor the shared assembly into a method both call rather than
-duplicating it.
+`context.custom` gets the **same special handling `buildReport` has**
+(`Flare.ts:470`), which the earlier "exactly buildReport's assembly" wording
+glossed over: when both the scope's `pendingAttributes['context.custom']` and the
+user-passed `attributes['context.custom']` are objects, deep-merge them (user
+keys win per-key) instead of letting the user bag clobber `addContext()` data;
+and inject `context.custom.framework` from the framework name when set. Factor
+this shared merge out of `buildReport` into a helper both call.
+
+#### Resource assembly (in `flush()`, read lazily)
+
+The envelope resource is built at flush time from the **current** Flare state, not
+captured at `Logger` construction. This matters because `setSdkInfo(...)` /
+`setFramework(...)` run AFTER `super(...)` in both platforms (`js/src/index.ts:23`,
+`node/src/Flare.ts:81`); a Logger that snapshotted `sdkInfo` at construction would
+emit `@flareapp/core` forever. The `Logger` therefore reads SDK/framework through
+getters into `Flare` (e.g. `() => this.sdkInfo`, `() => this.framework`) — or
+`Flare` builds the resource and hands it to `Logger.flush()`. Resource =
+identity (`service.name` when set, `service.version` / `service.stage` when set,
+`telemetry.sdk.*` from current `sdkInfo`, `flare.framework.*` from current
+framework) merged with the resource-level attributes partitioned out of the
+collector (process/host).
 
 Cost note: running the context collector per log re-reads env context (browser
-cookies/URL, Node process/request) on every `record()`. That matches PHP's
-per-record context behavior and keeps logs filterable, but it is real per-log
-work; if it shows up as a hotspot under high-volume logging, a later optimization
-can memoize the collector output per scope. Not optimized in v1.
+cookies/URL, Node process/request) on every `record()`. Matches PHP's per-record
+context behavior and keeps logs filterable, but it is real per-log work; if it
+becomes a hotspot under high-volume logging, a later optimization can memoize per
+scope. Not optimized in v1.
 
 Auto-flush triggers (core-owned policy):
 
@@ -312,13 +355,12 @@ severity number.
 
 ### Resource / scope attributes
 
-- Resource attributes: `service.name` (only when `config.serviceName` set,
-  see config table), `service.version` and `service.stage` (when set),
-  `telemetry.sdk.language: "javascript"`, `telemetry.sdk.name` and
-  `telemetry.sdk.version` from `sdkInfo`, framework attributes when set. Reuses
-  the same base-attribute logic `buildReport` already assembles. Null-valued
-  entries are dropped by the OTel mapper, so unset optionals never reach the wire.
-- Scope `name` / `version` come from `sdkInfo`.
+- Resource attributes: see "Resource assembly" above — identity (`service.name`
+  when set, `service.version` / `service.stage` when set, `telemetry.sdk.*` from
+  current `sdkInfo`, `flare.framework.*` from current framework) plus the
+  resource-level keys partitioned out of the collector (process/host). Built at
+  flush time from current Flare state (lazy), never snapshotted at construction.
+- Scope `name` / `version` come from the current `sdkInfo` (same lazy read).
 
 ### Api.logs
 
@@ -329,6 +371,21 @@ Api.logs(envelope, url, key, debug, keepalive?)
 Mirrors `Api.report`. Header `x-api-token`. `keepalive` is passed straight to
 `fetch` so a browser unload flush survives; Node's fetch accepts and ignores it
 harmlessly. Treats `201` as success (other codes logged when `debug`).
+
+CORS preflight: a cross-origin POST with `Content-Type: application/json` plus
+the custom `x-api-token` header is not a CORS-simple request, so the browser
+sends an `OPTIONS` preflight first. The report path already incurs this for every
+report, and the ingest answers it (the e2e fake server keeps CORS open). The new
+risk is specifically the **first log send firing on `visibilitychange:hidden`**
+when no preflight is cached: the unload-time fetch must complete both the
+preflight and the POST. `keepalive` keeps the whole fetch (preflight included)
+alive past document teardown, so this is expected to work — but it is the kind of
+thing that silently fails in one browser. The guarantee is therefore **backed by
+an explicit test** (below), not assumed. If that test shows preflight-on-unload
+is unreliable, the fallback is to lower the steady-state flush thresholds so a
+preflight is essentially always already cached by unload (a normal flush has run),
+rather than changing transport — sendBeacon is not an option (it cannot send the
+`x-api-token` header; see "Why `keepalive`").
 
 ## Platform schedulers
 
@@ -412,9 +469,17 @@ flush policy):
 - Envelope shape + OTel value encoding (string / number int vs double / bool /
   array / object / null-drop).
 - Level helpers map to the right severity number/text.
-- Per-record attributes: context-collector output + scope context + entry-point
-  merged at capture, frozen (later scope mutation does not change a buffered
-  record), user attributes win.
+- Per-record attributes: record-level collector keys + scope context +
+  entry-point merged at capture, frozen (later scope mutation does not change a
+  buffered record), user attributes win.
+- Resource/record partition: a collector emitting both `process.*` and `http.*`
+  puts `process.*` on the envelope resource (once, deduped) and `http.*` on the
+  record. Two records sharing one resource still carry their own request keys.
+- `context.custom` deep-merges scope + user values (user keys win per-key, no
+  clobber of `addContext` data); `context.custom.framework` injected from
+  framework name.
+- Lazy SDK identity: `setSdkInfo` after construction is reflected in the next
+  flush's resource/scope (not stuck at `@flareapp/core`).
 - OTel nested-null drop: `[1, null, 2]` and `{ a: 1, b: null }` drop nulls at
   depth, no null-holes in `arrayValue` / `kvlistValue`.
 - Teardown flush sends ONE keepalive envelope `<= keepaliveMaxBytes`; older
@@ -422,7 +487,11 @@ flush policy):
 - `flush()` starts sends into `inflight`; `flare.flush(timeoutMs)` stays bounded.
 
 `packages/js/tests/` — `BrowserFlushScheduler`: `visibilitychange:hidden`
-triggers a `keepalive` flush.
+triggers a `keepalive` flush. Plus an e2e (Playwright) test for the
+first-send-on-unload path against the **cross-origin** fake-flare-server: record
+a log, navigate away without any prior flush, and assert the server received the
+log (exercises the uncached preflight + keepalive POST on unload). If unsupported
+in a target browser, this test is what catches it.
 
 `packages/node/tests/` — `NodeFlushScheduler`: `beforeExit` triggers a flush;
 the fatal-handler path drains logs within `shutdownTimeoutMs`. Plus: a log
@@ -439,13 +508,18 @@ New in `@flareapp/core`:
 
 - `src/logging/Logger.ts`
 - `src/logging/SeverityMapper.ts`
-- `src/logging/otel.ts` (attribute/value encoding)
+- `src/logging/otel.ts` (attribute/value encoding + resource/record key
+  partition classifier)
 - `src/logging/FlushScheduler.ts` (interface + no-op default)
 - types added to `src/types.ts` (`LogRecord`, OTel envelope types, `Config`
   additions)
 - `Api.logs()` in `src/api/Api.ts`
+- the `context.custom` deep-merge + framework injection factored out of
+  `buildReport` into a shared helper `record()` and `buildReport` both call
 - exports in `src/index.ts`
-- `Logger` wired into `Flare` (new constructor seam: `flushScheduler`)
+- `Logger` wired into `Flare`: new constructor seam `flushScheduler`; `Logger`
+  reads SDK/framework lazily (getters into `Flare`), so `setSdkInfo` /
+  `setFramework` after `super(...)` are reflected at flush time
 
 New in `@flareapp/js`:
 

--- a/docs/superpowers/specs/2026-06-03-core-logging-design.md
+++ b/docs/superpowers/specs/2026-06-03-core-logging-design.md
@@ -248,6 +248,34 @@ harmlessly. Treats `201` as success (other codes logged when `debug`).
   `visibilityState === 'hidden'`, calls `flush({ keepalive: true })`.
 - Relies on `fetch` `keepalive` for unload-time delivery (no `sendBeacon`).
 
+### Why `keepalive`
+
+Logs live in an in-memory buffer until a flush. When the user closes the tab or
+navigates away, the buffer's last flush must still go out. The browser normally
+**aborts all in-flight `fetch` requests when a page unloads**, so a flush fired
+from the `visibilitychange:hidden` handler would be cancelled mid-send and those
+logs would be lost.
+
+`fetch(url, { keepalive: true })` tells the browser to let the request run to
+completion in the background even after the page is gone. It is the modern
+replacement for `navigator.sendBeacon()` and lets us reuse the same `fetch`
+transport instead of a second code path.
+
+Constraints, all browser-enforced and browser-only:
+
+- The browser caps the combined body of all in-flight keepalive requests at
+  ~64 KB; past that it rejects the request. Sentry stops setting `keepalive`
+  above ~60 KB in-flight for this reason. Our per-flush envelopes are small
+  (capped well under the weight limit), so this is not a practical concern for
+  v1, but it is why `keepalive` is set only on the teardown flush, not on every
+  flush.
+- Only the **browser teardown flush** sets `keepalive: true`. Normal timer- and
+  count-triggered flushes run while the page is alive, where a plain `fetch` is
+  fine and not subject to the 64 KB cap.
+- In Node there is no page-unload concept, so `keepalive` is a no-op (undici
+  accepts and ignores it). Node durability comes from the `beforeExit` flush
+  plus the existing shutdown-timeout drain, not from `keepalive`.
+
 `@flareapp/node` — `NodeFlushScheduler`:
 
 - `register(flush)` adds `process.on('beforeExit', () => flush())`.

--- a/docs/superpowers/specs/2026-06-03-core-logging-design.md
+++ b/docs/superpowers/specs/2026-06-03-core-logging-design.md
@@ -81,14 +81,24 @@ flare.flush(timeoutMs?)   // now also drains the log buffer
 
 ### Config additions (`Config`)
 
-| Key                  | Type            | Default                               | Meaning                                            |
-| -------------------- | --------------- | ------------------------------------- | -------------------------------------------------- |
-| `enableLogs`         | `boolean`       | `false`                               | Opt-in. No surprise log traffic until switched on. |
-| `logsIngestUrl`      | `string`        | `https://ingress.flareapp.io/v1/logs` | Logs endpoint (sibling of `ingestUrl`).            |
-| `minimumLogLevel`    | `MessageLevel?` | `undefined`                           | Drop logs below this level at capture time.        |
-| `maxLogBufferSize`   | `number`        | `100`                                 | Flush when buffer reaches this count.              |
-| `logFlushIntervalMs` | `number`        | `5000`                                | One-shot timer flush interval.                     |
-| `logFlushMaxBytes`   | `number`        | `800_000`                             | Flush when estimated buffer bytes reach this.      |
+| Key                  | Type            | Default                               | Meaning                                                                       |
+| -------------------- | --------------- | ------------------------------------- | ----------------------------------------------------------------------------- |
+| `enableLogs`         | `boolean`       | `false`                               | Opt-in. No surprise log traffic until switched on.                            |
+| `logsIngestUrl`      | `string`        | `https://ingress.flareapp.io/v1/logs` | Logs endpoint (sibling of `ingestUrl`).                                       |
+| `minimumLogLevel`    | `MessageLevel?` | `undefined`                           | Drop logs below this level at capture time.                                   |
+| `serviceName`        | `string?`       | `undefined`                           | Emitted as the `service.name` resource attribute when set; omitted otherwise. |
+| `maxLogBufferSize`   | `number`        | `100`                                 | Flush when buffer reaches this count.                                         |
+| `logFlushIntervalMs` | `number`        | `5000`                                | One-shot timer flush interval.                                                |
+| `logFlushMaxBytes`   | `number`        | `800_000`                             | Flush when estimated buffer bytes reach this.                                 |
+| `keepaliveMaxBytes`  | `number`        | `60_000`                              | Max estimated bytes per teardown (keepalive) envelope chunk.                  |
+
+`service.name` has no current source in core config (reports do not emit it and
+are accepted, so the ingest does not require it). It is added here as an
+**optional** config key: when set, it is emitted in the logs resource
+attributes; when unset, the OTel mapper drops the null and the attribute is
+omitted. This is not given a hard default; the wire contract does not require it,
+and inventing a generic default (e.g. `"unknown"`) would just produce noise in
+the Flare UI.
 
 ## Buffer, batching, flush
 
@@ -115,11 +125,23 @@ Auto-flush triggers (core-owned policy):
 
 `flush(opts?: { keepalive?: boolean })`:
 
-- Snapshot and clear the buffer; clear the timer / active flag.
 - Empty buffer -> no-op.
-- Build the envelope, call `api.logs(envelope, …, opts?.keepalive)`.
-- Register the send in the existing `inflight` set (via the same `track`
-  mechanism reports use) so `flare.flush()` awaits in-flight log sends too.
+- Clear the timer / active flag.
+- Split the buffered records into one or more envelopes, then snapshot-and-clear
+  the buffer:
+    - Normal flush (`keepalive` falsy): a single envelope with all buffered
+      records. The buffer is already bounded by `logFlushMaxBytes` (~0.8 MB), fine
+      for a normal `fetch`.
+    - Teardown flush (`keepalive: true`): chunk the records into envelopes each
+      estimated `<= keepaliveMaxBytes` (~60 KB) before clearing. Browsers cap the
+      combined body of in-flight keepalive requests at ~64 KB and reject anything
+      over, so a single oversized unload POST would be dropped along with its logs.
+      Chunking keeps each teardown POST under the cap. See "Why `keepalive`".
+- For each envelope, call `api.logs(envelope, …, opts?.keepalive)` and register
+  the returned send in the existing `inflight` set via the same `track`
+  mechanism reports use. `flush()` itself does **not** await the HTTP round-trip;
+  it starts the send(s) and returns. This is what lets `flare.flush(timeoutMs)`
+  bound the wait (below).
 
 `FlushScheduler` interface:
 
@@ -134,8 +156,14 @@ interface FlushScheduler {
 - The count/weight/timer caps stay in core regardless of which scheduler is
   injected.
 
-`flare.flush(timeoutMs?)` is extended to drain the log buffer (await
-`logger.flush()`) in addition to waiting on in-flight reports.
+`flare.flush(timeoutMs?)` is extended to drain the log buffer. It calls
+`logger.flush()` first, which **starts** the buffered log send(s) and registers
+them in `inflight` (it does not await them). The existing timeout-bounded
+`Promise.allSettled(inflight)` race then covers in-flight log sends and reports
+together under the same `timeoutMs`. This preserves the Node fatal handler's
+guarantee at `packages/node/src/process/fatal.ts:33,49`
+(`await flare.flush(opts.shutdownTimeoutMs)`): a hung log POST cannot extend
+shutdown past `shutdownTimeoutMs`.
 
 ## Wire format (OTel envelope)
 
@@ -224,10 +252,12 @@ severity number.
 
 ### Resource / scope attributes
 
-- Resource attributes: `service.name`, `service.version` and `service.stage`
-  (when set), `telemetry.sdk.language: "javascript"`, `telemetry.sdk.name` and
+- Resource attributes: `service.name` (only when `config.serviceName` set,
+  see config table), `service.version` and `service.stage` (when set),
+  `telemetry.sdk.language: "javascript"`, `telemetry.sdk.name` and
   `telemetry.sdk.version` from `sdkInfo`, framework attributes when set. Reuses
-  the same base-attribute logic `buildReport` already assembles.
+  the same base-attribute logic `buildReport` already assembles. Null-valued
+  entries are dropped by the OTel mapper, so unset optionals never reach the wire.
 - Scope `name` / `version` come from `sdkInfo`.
 
 ### Api.logs
@@ -292,18 +322,33 @@ auto-merge active-scope context or entry point into log attributes.
 
 ## Testing
 
-Vitest, in `packages/js/tests/`. New `logs.test.ts`:
+Each package has its own Vitest suite (`packages/<pkg>/tests/`,
+`packages/<pkg>/vitest.config.ts`). Tests go where the behavior lives, not all
+in `packages/js`.
+
+`packages/core/tests/logs.test.ts` (the bulk — core owns buffer, encoding, API,
+flush policy):
 
 - Opt-in gating: nothing recorded/sent when `enableLogs` is false.
 - `minimumLogLevel` drops below-threshold records at capture.
 - Count-cap flush at `maxLogBufferSize`.
-- Timer flush via fake timers at `logFlushIntervalMs`.
-- Envelope shape + OTel value encoding (string/number int vs double/bool/
-  array/object/null-drop).
+- Weight-cap flush at `logFlushMaxBytes`.
+- Timer flush via fake timers at `logFlushIntervalMs` (one-shot, not reset per
+  log).
+- Envelope shape + OTel value encoding (string / number int vs double / bool /
+  array / object / null-drop).
 - Level helpers map to the right severity number/text.
-- `flush()` drains the buffer and awaits the send.
+- Teardown flush chunks to `keepaliveMaxBytes` (multiple envelopes when over).
+- `flush()` starts sends into `inflight`; `flare.flush(timeoutMs)` stays bounded.
 
-`FakeApi` (test helper) extended to capture `logs()` sends alongside `report()`.
+`packages/js/tests/` — `BrowserFlushScheduler`: `visibilitychange:hidden`
+triggers a `keepalive` flush.
+
+`packages/node/tests/` — `NodeFlushScheduler`: `beforeExit` triggers a flush;
+the fatal-handler path drains logs within `shutdownTimeoutMs`.
+
+The core `FakeApi` test helper is extended to capture `logs()` sends alongside
+`report()`.
 
 ## Files (anticipated)
 

--- a/docs/superpowers/specs/2026-06-03-core-logging-design.md
+++ b/docs/superpowers/specs/2026-06-03-core-logging-design.md
@@ -92,11 +92,14 @@ flare.flush(timeoutMs?)   // now also drains the log buffer
 
 `service.name` has no current source in core config (reports do not emit it and
 are accepted, so the ingest does not require it). It is added here as an
-**optional** config key: when set, it is emitted in the logs resource
-attributes; when unset, the OTel mapper drops the null and the attribute is
-omitted. This is not given a hard default; the wire contract does not require it,
-and inventing a generic default (e.g. `"unknown"`) would just produce noise in
-the Flare UI.
+**optional** config key, default `undefined`. The resource builder adds the
+`service.name` attribute **only when `config.serviceName` is set** (a `truthy`
+guard, the same pattern `buildReport` uses for `service.version` / `service.stage`
+at `packages/core/src/Flare.ts:435`). It does not rely on the OTel mapper's
+null-drop: `undefined` is not part of `AttributeValue`, and putting `undefined`
+into an attribute bag is ill-typed. Build conditionally, never emit the key when
+unset. No hard default; the wire contract does not require it, and a generic
+default like `"unknown"` would just be noise in the Flare UI.
 
 ## Buffer, batching, flush
 
@@ -121,16 +124,30 @@ scope must not retroactively change an already-buffered record), mirroring PHP,
 which merges the context recorder and entry-point resolver into each record
 before buffering. Merge order, last write wins:
 
-1. Active scope `pendingAttributes` (`scopeProvider.active().pendingAttributes`)
-   — the same custom context `addContext` / `addContextGroup` feed into reports.
-   In Node this is the per-request `NodeScope`, so request-scoped logs become
-   filterable by request context.
-2. Entry-point attributes from `scope.entryPoint`, emitted under the same
-   `flare.entry_point.handler.*` keys `buildReport` uses.
-3. User-passed `attributes` (highest precedence).
+1. `contextCollector(config)` output — the **injected env collector**, same one
+   `buildReport` calls. This is the load-bearing source for Node request/user
+   data: `NodeScope.request` / `NodeScope.user` are separate buckets
+   (`packages/node/src/scope/NodeScope.ts:6`) that do **not** live in
+   `pendingAttributes`; they only become attributes when `makeNodeContextCollector`
+   projects them (`packages/node/src/context/collectNode.ts:52`). Merging just
+   `pendingAttributes` would silently miss request/user context. So `record()`
+   must run the same collector reports do.
+2. Active scope `pendingAttributes` (`scopeProvider.active().pendingAttributes`)
+   — the custom context `addContext` / `addContextGroup` feed into reports.
+3. Entry-point attributes from `scope.entryPoint`, emitted under the same
+   `flare.entry_point.handler.*` keys `buildReport` uses (entry-point overrides
+   applied after the collector, matching `buildReport`).
+4. User-passed `attributes` (highest precedence).
 
-This reuses the attribute-assembly logic `buildReport` already has; factor the
-shared part out rather than duplicating it.
+This is exactly `buildReport`'s attribute assembly minus the report-only base
+attributes. Factor the shared assembly into a method both call rather than
+duplicating it.
+
+Cost note: running the context collector per log re-reads env context (browser
+cookies/URL, Node process/request) on every `record()`. That matches PHP's
+per-record context behavior and keeps logs filterable, but it is real per-log
+work; if it shows up as a hotspot under high-volume logging, a later optimization
+can memoize the collector output per scope. Not optimized in v1.
 
 Auto-flush triggers (core-owned policy):
 
@@ -146,21 +163,31 @@ Auto-flush triggers (core-owned policy):
 
 - Empty buffer -> no-op.
 - Clear the timer / active flag.
-- Split the buffered records into one or more envelopes, then snapshot-and-clear
-  the buffer:
+- Build the envelope(s) and snapshot-and-clear the buffer:
     - Normal flush (`keepalive` falsy): a single envelope with all buffered
       records. The buffer is already bounded by `logFlushMaxBytes` (~0.8 MB), fine
       for a normal `fetch`.
-    - Teardown flush (`keepalive: true`): chunk the records into envelopes each
-      estimated `<= keepaliveMaxBytes` (~60 KB) before clearing. Browsers cap the
-      combined body of in-flight keepalive requests at ~64 KB and reject anything
-      over, so a single oversized unload POST would be dropped along with its logs.
-      Chunking keeps each teardown POST under the cap. See "Why `keepalive`".
-- For each envelope, call `api.logs(envelope, …, opts?.keepalive)` and register
-  the returned send in the existing `inflight` set via the same `track`
-  mechanism reports use. `flush()` itself does **not** await the HTTP round-trip;
-  it starts the send(s) and returns. This is what lets `flare.flush(timeoutMs)`
-  bound the wait (below).
+    - Teardown flush (`keepalive: true`): the `keepaliveMaxBytes` (~60 KB) budget
+      is the **combined** limit across all in-flight keepalive requests, not
+      per-request — so this is NOT chunked into several keepalive POSTs (two 60 KB
+      keepalive POSTs sum to 120 KB and the browser rejects them). Send **one**
+      keepalive envelope holding the trailing records that fit under
+      `keepaliveMaxBytes`. If the buffer exceeds the budget, the older overflow is
+      dropped (logged when `debug`): unload is best-effort and the steady-state
+      timer/count flushes keep the buffer small, so overflow is the rare tail
+      case, not the norm. See "Why `keepalive`".
+- For each envelope, call `api.logs(envelope, …, opts?.keepalive)` and pass the
+  returned promise to the injected `track` callback (below), which registers it
+  in `Flare`'s `inflight` set. `flush()` itself does **not** await the HTTP
+  round-trip; it starts the send(s) and returns. This is what lets
+  `flare.flush(timeoutMs)` bound the wait (below).
+
+`track` seam: `track` is private on `Flare` (`packages/core/src/Flare.ts:116`).
+`Flare` owns the `Logger` and injects `this.track.bind(this)` into it at
+construction, so the `Logger`'s own auto-flushes (timer/count, which fire inside
+`record()` without going through `Flare.flush`) still enroll their sends in
+`inflight`. `track` stays private on `Flare`; the `Logger` only holds the bound
+callback. No new public surface on `Flare`.
 
 `FlushScheduler` interface:
 
@@ -240,18 +267,32 @@ Protocol divergences from the PHP client, locked to the protocol doc:
 Ported from PHP `OpenTelemetryAttributeMapper`, with the JS-specific decisions
 made explicit:
 
-| Input                        | Output                                             |
-| ---------------------------- | -------------------------------------------------- |
-| `string`                     | `{ stringValue }`                                  |
-| `boolean`                    | `{ boolValue }`                                    |
-| `number`, `Number.isInteger` | `{ intValue }`                                     |
-| `number`, otherwise          | `{ doubleValue }`                                  |
-| array                        | `{ arrayValue: { values: [...recurse] } }`         |
-| plain object                 | `{ kvlistValue: { values: [{ key, value }...] } }` |
-| `null`                       | dropped (filtered out of the attributes array)     |
+| Input                        | Output                                                           |
+| ---------------------------- | ---------------------------------------------------------------- |
+| `string`                     | `{ stringValue }`                                                |
+| `boolean`                    | `{ boolValue }`                                                  |
+| `number`, `Number.isInteger` | `{ intValue }`                                                   |
+| `number`, otherwise          | `{ doubleValue }`                                                |
+| array                        | `{ arrayValue: { values: [...recurse, null-dropped] } }`         |
+| plain object                 | `{ kvlistValue: { values: [{ key, value }...], null-dropped } }` |
+| `null`                       | dropped (no OTel `anyValue` null type exists)                    |
 
-`attributesToOpenTelemetry(attrs)` maps each entry to `{ key, value }`, dropping
-null-valued entries.
+`AttributeValue` permits nested nulls (`packages/core/src/types.ts:3`:
+`{ foo: [null] }`, `{ foo: { bar: null } }`). OTel `anyValue` has no null
+variant, so a nested `null` cannot be encoded as a value. The drop rule is
+therefore **recursive and applied at every level**, not just the top:
+
+- `attributesToOpenTelemetry(attrs)`: map each entry to `{ key, value }`, drop
+  entries whose value encodes to `null`.
+- `arrayValue.values`: encode each item, drop items that encode to `null`
+  (so `[1, null, 2]` -> two values, not a value-with-null hole).
+- `kvlistValue.values`: encode each entry, drop keys whose value encodes to
+  `null`.
+
+This diverges intentionally from PHP, which only `array_filter`s the top level
+and would emit nested-null holes; the recursive drop keeps every emitted
+`anyValue` well-formed. A test asserts `[1, null, 2]` and `{ a: 1, b: null }`
+drop the nulls at depth.
 
 ### SeverityMapper
 
@@ -312,15 +353,18 @@ transport instead of a second code path.
 
 Constraints, all browser-enforced and browser-only:
 
-- The browser caps the combined body of all in-flight keepalive requests at
-  ~64 KB; past that it rejects the request. Sentry stops setting `keepalive`
-  above ~60 KB in-flight for this reason. Our per-flush envelopes are small
-  (capped well under the weight limit), so this is not a practical concern for
-  v1, but it is why `keepalive` is set only on the teardown flush, not on every
-  flush.
+- The browser caps the **combined body of all in-flight keepalive requests** at
+  ~64 KB; past that it rejects the request. This is a shared budget, not a
+  per-request one, so splitting a large teardown into several keepalive POSTs
+  does **not** help: two 60 KB keepalive POSTs sum to 120 KB and get rejected.
+  The teardown therefore sends a **single** keepalive envelope holding the
+  trailing records that fit under `keepaliveMaxBytes` (~60 KB), and drops the
+  older overflow (logged when `debug`). Best-effort: the steady-state timer/count
+  flushes keep the live buffer small, so on a normal unload the whole buffer fits
+  in one keepalive POST and nothing is dropped.
 - Only the **browser teardown flush** sets `keepalive: true`. Normal timer- and
   count-triggered flushes run while the page is alive, where a plain `fetch` is
-  fine and not subject to the 64 KB cap.
+  fine and not subject to the keepalive cap.
 - In Node there is no page-unload concept, so `keepalive` is a no-op (undici
   accepts and ignores it). Node durability comes from the `beforeExit` flush
   plus the existing shutdown-timeout drain, not from `keepalive`.
@@ -360,16 +404,23 @@ flush policy):
 - Envelope shape + OTel value encoding (string / number int vs double / bool /
   array / object / null-drop).
 - Level helpers map to the right severity number/text.
-- Per-record attributes: scope context + entry-point merged at capture, frozen
-  (later scope mutation does not change a buffered record), user attributes win.
-- Teardown flush chunks to `keepaliveMaxBytes` (multiple envelopes when over).
+- Per-record attributes: context-collector output + scope context + entry-point
+  merged at capture, frozen (later scope mutation does not change a buffered
+  record), user attributes win.
+- OTel nested-null drop: `[1, null, 2]` and `{ a: 1, b: null }` drop nulls at
+  depth, no null-holes in `arrayValue` / `kvlistValue`.
+- Teardown flush sends ONE keepalive envelope `<= keepaliveMaxBytes`; older
+  overflow is dropped, not split into a second keepalive POST.
 - `flush()` starts sends into `inflight`; `flare.flush(timeoutMs)` stays bounded.
 
 `packages/js/tests/` — `BrowserFlushScheduler`: `visibilitychange:hidden`
 triggers a `keepalive` flush.
 
 `packages/node/tests/` — `NodeFlushScheduler`: `beforeExit` triggers a flush;
-the fatal-handler path drains logs within `shutdownTimeoutMs`.
+the fatal-handler path drains logs within `shutdownTimeoutMs`. Plus: a log
+recorded inside a `runWithContext` request scope carries that request's
+`http.*` / user attributes (proves the context-collector merge, not just
+`pendingAttributes`).
 
 The core `FakeApi` test helper is extended to capture `logs()` sends alongside
 `report()`.

--- a/docs/superpowers/specs/2026-06-03-core-logging-design.md
+++ b/docs/superpowers/specs/2026-06-03-core-logging-design.md
@@ -117,31 +117,53 @@ default like `"unknown"` would just be noise in the Flare UI.
    run the context collector, partition out resource-level keys, merge the
    record-level keys with scope custom context, entry-point overrides, and
    user-passed `attributes`.
-4. Build a `LogRecord` (timestamp now, severityNumber + severityText, body,
+4. **Oversized-record guard:** if this single record's estimated bytes exceed
+   `logFlushMaxBytes`, drop it now (logged when `debug`) and return. It cannot be
+   shipped — it does not fit a normal envelope's weight budget, and the trim
+   below could never satisfy the byte cap while keeping it (dropping older records
+   leaves the one oversized record behind). Dropping at capture is deterministic;
+   truncating attributes/body would silently corrupt the log. See "Oversized
+   records" below.
+5. Build a `LogRecord` (timestamp now, severityNumber + severityText, body,
    record-level attributes), push to the buffer; stash the partitioned
    resource-level attributes for the envelope.
-5. **Trim the buffer** (below) — an unconditional bound, independent of whether a
-   flush happens.
-6. Evaluate auto-flush triggers (below).
+6. Evaluate auto-flush triggers (below). With a key, an over-cap push
+   **flushes-and-clears here**, so data is shipped, not trimmed away.
+7. **Trim the buffer** (below) — a safety net that only bites when step 6 did not
+   clear (no API key yet, so the flush no-op'd).
 
-### Buffer trim (hard bound)
+### Buffer trim (hard bound, safety net)
 
-`maxLogBufferSize` and `logFlushMaxBytes` are _flush triggers_, but a trigger that
-fires a flush which then no-ops (the key gate fails, no API key yet) would leave
-the buffer growing without bound — exactly the keyless-retention case. So the
-buffer also has an **independent trim**, applied on every `record()` push
-regardless of flush outcome, the same shape as the glow cap
-(`Scope.addGlow` → `slice(length - max)`):
+`maxLogBufferSize` and `logFlushMaxBytes` are _flush triggers_ first: step 6
+flushes-and-clears when the buffer crosses either cap and a key is set, which is
+the path that actually preserves the data (it gets sent). The trim exists only
+because a triggered flush can **no-op** (the key gate fails, no API key yet),
+which would otherwise let the buffer grow without bound. The trim therefore runs
+**after** the triggers, not before — running it first would pull the buffer back
+under `logFlushMaxBytes` and rob the weight trigger of its chance to fire, turning
+a flush into silent data loss. Same shape as the glow cap (`Scope.addGlow` →
+`slice(length - max)`):
 
 - Drop oldest records until the buffer holds `<= maxLogBufferSize` records, AND
 - Drop oldest records until the estimated buffer bytes are `<= logFlushMaxBytes`.
 
-Trailing records (the most recent) are kept, matching glows and the teardown
-behavior. With a key present this trim almost never bites, because the count /
-weight triggers flush-and-clear first; with no key (or repeated send failure) the
-trim is what guarantees the buffer is bounded. Dropped-on-trim records are lost
-(logged when `debug`); this is the intended back-pressure for "logging enabled
-but never authenticated."
+Because the oversized-record guard (step 4) already removed any single record
+bigger than the byte cap, "drop oldest until under the byte cap" is always
+satisfiable. Trailing records (the most recent) are kept, matching glows and the
+teardown behavior. With a key the trim almost never bites (step 6 flushed first);
+with no key (or repeated send failure) the trim is what bounds the buffer.
+Dropped-on-trim records are lost (logged when `debug`) — intended back-pressure
+for "logging enabled but never authenticated."
+
+### Oversized records
+
+A single record larger than `logFlushMaxBytes` (~0.8 MB of estimated attributes +
+body) is pathological — far past any reasonable log line. It is **dropped at
+capture** (step 4), never buffered, and `debug`-logged. The client does not
+truncate it: a half-attributes log is more misleading than an absent one, and the
+drop keeps every buffered record guaranteed-shippable (fits a normal envelope, and
+fits a keepalive teardown envelope when under `keepaliveMaxBytes`). A test asserts
+an over-cap single record is dropped and does not wedge the buffer.
 
 ### Resource vs record attributes
 
@@ -514,6 +536,12 @@ flush policy):
 - `minimumLogLevel` drops below-threshold records at capture.
 - Count-cap flush at `maxLogBufferSize`.
 - Weight-cap flush at `logFlushMaxBytes`.
+- Weight-cap with a key **flushes-and-clears, does not trim**: crossing
+  `logFlushMaxBytes` ships the records via `api.logs` (no records silently dropped
+  by the trim when keyed).
+- Oversized single record (> `logFlushMaxBytes`) is dropped at capture, never
+  buffered, and does not wedge the buffer (a subsequent normal record still
+  records and flushes).
 - Timer flush via fake timers at `logFlushIntervalMs` (one-shot, not reset per
   log).
 - Envelope shape + OTel value encoding (string / number int vs double / bool /

--- a/docs/superpowers/specs/2026-06-03-core-logging-design.md
+++ b/docs/superpowers/specs/2026-06-03-core-logging-design.md
@@ -120,7 +120,28 @@ default like `"unknown"` would just be noise in the Flare UI.
 4. Build a `LogRecord` (timestamp now, severityNumber + severityText, body,
    record-level attributes), push to the buffer; stash the partitioned
    resource-level attributes for the envelope.
-5. Evaluate auto-flush triggers (below).
+5. **Trim the buffer** (below) — an unconditional bound, independent of whether a
+   flush happens.
+6. Evaluate auto-flush triggers (below).
+
+### Buffer trim (hard bound)
+
+`maxLogBufferSize` and `logFlushMaxBytes` are _flush triggers_, but a trigger that
+fires a flush which then no-ops (the key gate fails, no API key yet) would leave
+the buffer growing without bound — exactly the keyless-retention case. So the
+buffer also has an **independent trim**, applied on every `record()` push
+regardless of flush outcome, the same shape as the glow cap
+(`Scope.addGlow` → `slice(length - max)`):
+
+- Drop oldest records until the buffer holds `<= maxLogBufferSize` records, AND
+- Drop oldest records until the estimated buffer bytes are `<= logFlushMaxBytes`.
+
+Trailing records (the most recent) are kept, matching glows and the teardown
+behavior. With a key present this trim almost never bites, because the count /
+weight triggers flush-and-clear first; with no key (or repeated send failure) the
+trim is what guarantees the buffer is bounded. Dropped-on-trim records are lost
+(logged when `debug`); this is the intended back-pressure for "logging enabled
+but never authenticated."
 
 ### Resource vs record attributes
 
@@ -211,13 +232,21 @@ Auto-flush triggers (core-owned policy):
   (`Flare.ts:527`), but for reports a dropped report is gone; logs are buffered,
   so the records must **survive** until `light()` sets a key — clearing here
   would silently destroy them. Resetting only the timer flag lets the next
-  `record()` re-arm a fresh timer, so once a key exists the buffered logs ship on
-  the following flush. The buffer stays capped by `maxLogBufferSize` (oldest
-  dropped), so a key that never arrives cannot grow it unbounded. Applies to
-  every flush path — manual `flush()`, timer, count/weight auto-flush, and the
+  `record()` re-arm a fresh timer. The buffer cannot grow unbounded while keyless
+  because the per-`record()` trim (above) still applies. Applies to every flush
+  path — manual `flush()`, timer, count/weight auto-flush, and the
   unload/`beforeExit` teardown — so none can emit an unauthenticated `api.logs`
   POST. (`assertKey` only warns when `debug`, so the periodic timer re-check is
   quiet in production.)
+
+The backlog ships when the key is set, not only on the next `record()`:
+`Flare.light(...)` (and `configure(...)` when it sets a key) calls
+`logger.flush()` after applying the key, **if** the buffer is non-empty. Without
+this, a keyless timer flush followed by `light(key)` with no further logging
+would leave the buffered records sitting until the next manual flush or
+unload/`beforeExit`. The post-`light` flush is itself key-gated, so calling it
+when no key was actually provided is a cheap no-op.
+
 - Otherwise (key present): clear the timer / active flag.
 - Build the envelope(s) and snapshot-and-clear the buffer:
     - Normal flush (`keepalive` falsy): a single envelope with all buffered
@@ -475,8 +504,13 @@ flush policy):
 
 - Opt-in gating: nothing recorded/sent when `enableLogs` is false.
 - Key gate: `enableLogs: true` + `key: null` records into the buffer but no flush
-  path (manual, timer, count, unload) calls `api.logs`; buffer is retained; after
-  `light(key)` the next flush ships the previously buffered logs.
+  path (manual, timer, count, unload) calls `api.logs`; buffer is retained.
+- Keyless backlog ships on `light(key)`: record several logs with no key (no
+  send), call `light(key)` with **no further `record()`**, assert the buffered
+  logs are flushed.
+- Keyless trim bound: with `enableLogs: true` + `key: null`, recording far more
+  than `maxLogBufferSize` keeps the buffer at the cap (oldest dropped), does not
+  grow unbounded.
 - `minimumLogLevel` drops below-threshold records at capture.
 - Count-cap flush at `maxLogBufferSize`.
 - Weight-cap flush at `logFlushMaxBytes`.
@@ -536,6 +570,9 @@ New in `@flareapp/core`:
 - `Logger` wired into `Flare`: new constructor seam `flushScheduler`; `Logger`
   reads SDK/framework lazily (getters into `Flare`), so `setSdkInfo` /
   `setFramework` after `super(...)` are reflected at flush time
+- `Flare.light(...)` (and `configure(...)` when it sets a key) calls
+  `logger.flush()` after applying the key, when the buffer is non-empty, so a
+  backlog buffered before authentication ships as soon as a key arrives
 
 New in `@flareapp/js`:
 

--- a/docs/superpowers/specs/2026-06-03-core-logging-design.md
+++ b/docs/superpowers/specs/2026-06-03-core-logging-design.md
@@ -205,7 +205,20 @@ Auto-flush triggers (core-owned policy):
 `flush(opts?: { keepalive?: boolean })`:
 
 - Empty buffer -> no-op.
-- Clear the timer / active flag.
+- **Key gate:** if `assertKey(config.key, config.debug)` is false (no API key
+  set yet), reset the timer-active flag (the one-shot has fired) but **leave the
+  buffer intact**, then return. This mirrors `sendReport`'s `assertKey` guard
+  (`Flare.ts:527`), but for reports a dropped report is gone; logs are buffered,
+  so the records must **survive** until `light()` sets a key — clearing here
+  would silently destroy them. Resetting only the timer flag lets the next
+  `record()` re-arm a fresh timer, so once a key exists the buffered logs ship on
+  the following flush. The buffer stays capped by `maxLogBufferSize` (oldest
+  dropped), so a key that never arrives cannot grow it unbounded. Applies to
+  every flush path — manual `flush()`, timer, count/weight auto-flush, and the
+  unload/`beforeExit` teardown — so none can emit an unauthenticated `api.logs`
+  POST. (`assertKey` only warns when `debug`, so the periodic timer re-check is
+  quiet in production.)
+- Otherwise (key present): clear the timer / active flag.
 - Build the envelope(s) and snapshot-and-clear the buffer:
     - Normal flush (`keepalive` falsy): a single envelope with all buffered
       records. The buffer is already bounded by `logFlushMaxBytes` (~0.8 MB), fine
@@ -461,6 +474,9 @@ in `packages/js`.
 flush policy):
 
 - Opt-in gating: nothing recorded/sent when `enableLogs` is false.
+- Key gate: `enableLogs: true` + `key: null` records into the buffer but no flush
+  path (manual, timer, count, unload) calls `api.logs`; buffer is retained; after
+  `light(key)` the next flush ships the previously buffered logs.
 - `minimumLogLevel` drops below-threshold records at capture.
 - Count-cap flush at `maxLogBufferSize`.
 - Weight-cap flush at `logFlushMaxBytes`.

--- a/docs/superpowers/specs/2026-06-03-core-logging-design.md
+++ b/docs/superpowers/specs/2026-06-03-core-logging-design.md
@@ -278,11 +278,19 @@ when no key was actually provided is a cheap no-op.
       is the **combined** limit across all in-flight keepalive requests, not
       per-request — so this is NOT chunked into several keepalive POSTs (two 60 KB
       keepalive POSTs sum to 120 KB and the browser rejects them). Send **one**
-      keepalive envelope holding the trailing records that fit under
-      `keepaliveMaxBytes`. If the buffer exceeds the budget, the older overflow is
-      dropped (logged when `debug`): unload is best-effort and the steady-state
-      timer/count flushes keep the buffer small, so overflow is the rare tail
-      case, not the norm. See "Why `keepalive`".
+      keepalive envelope, packing records **newest-first** while the running total
+      stays under `keepaliveMaxBytes`. A record that does not fit the remaining
+      budget is **skipped** (left behind, dropped on unload, logged when `debug`)
+      and packing continues with the next-older record — so one large record does
+      not block smaller ones from shipping. This also covers the single-record
+      case the `logFlushMaxBytes` capture guard does not: a record between
+      `keepaliveMaxBytes` and `logFlushMaxBytes` (e.g. 100 KB) is valid for a
+      normal flush but cannot fit a 60 KB unload envelope, so on teardown it is
+      skipped/dropped. Forcing a normal (non-keepalive) flush at unload is not an
+      option — the browser aborts it. Unload is best-effort, and the steady-state
+      timer/count flushes keep the buffer small (and ship the 100 KB record long
+      before unload in practice), so this drop is the rare tail case. See "Why
+      `keepalive`".
 - For each envelope, call `api.logs(envelope, …, opts?.keepalive)` and pass the
   returned promise to the injected `track` callback (below), which registers it
   in `Flare`'s `inflight` set. `flush()` itself does **not** await the HTTP
@@ -486,11 +494,13 @@ Constraints, all browser-enforced and browser-only:
   ~64 KB; past that it rejects the request. This is a shared budget, not a
   per-request one, so splitting a large teardown into several keepalive POSTs
   does **not** help: two 60 KB keepalive POSTs sum to 120 KB and get rejected.
-  The teardown therefore sends a **single** keepalive envelope holding the
-  trailing records that fit under `keepaliveMaxBytes` (~60 KB), and drops the
-  older overflow (logged when `debug`). Best-effort: the steady-state timer/count
-  flushes keep the live buffer small, so on a normal unload the whole buffer fits
-  in one keepalive POST and nothing is dropped.
+  The teardown therefore sends a **single** keepalive envelope, packing records
+  newest-first under `keepaliveMaxBytes` (~60 KB) and skipping any record that
+  does not fit the remaining budget — including a single record that is itself
+  larger than `keepaliveMaxBytes` (valid for a normal flush, too big for unload).
+  Skipped records are dropped (logged when `debug`). Best-effort: the steady-state
+  timer/count flushes keep the live buffer small, so on a normal unload the whole
+  buffer fits in one keepalive POST and nothing is dropped.
 - Only the **browser teardown flush** sets `keepalive: true`. Normal timer- and
   count-triggered flushes run while the page is alive, where a plain `fetch` is
   fine and not subject to the keepalive cap.
@@ -562,6 +572,9 @@ flush policy):
   depth, no null-holes in `arrayValue` / `kvlistValue`.
 - Teardown flush sends ONE keepalive envelope `<= keepaliveMaxBytes`; older
   overflow is dropped, not split into a second keepalive POST.
+- Teardown packs newest-first and skips an over-`keepaliveMaxBytes` record: a
+  buffer of [small, 100 KB, small] ships the two smalls in one keepalive envelope
+  and drops the 100 KB record (with `keepaliveMaxBytes` < 100 KB < `logFlushMaxBytes`).
 - `flush()` starts sends into `inflight`; `flare.flush(timeoutMs)` stays bounded.
 
 `packages/js/tests/` — `BrowserFlushScheduler`: `visibilitychange:hidden`

--- a/docs/superpowers/specs/2026-06-03-core-logging-design.md
+++ b/docs/superpowers/specs/2026-06-03-core-logging-design.md
@@ -88,7 +88,7 @@ flare.flush(timeoutMs?)   // now also drains the log buffer
 | `maxLogBufferSize`   | `number`        | `100`                                 | Flush when buffer reaches this count.                                         |
 | `logFlushIntervalMs` | `number`        | `5000`                                | One-shot timer flush interval.                                                |
 | `logFlushMaxBytes`   | `number`        | `800_000`                             | Flush when estimated buffer bytes reach this.                                 |
-| `keepaliveMaxBytes`  | `number`        | `60_000`                              | Max estimated bytes per teardown (keepalive) envelope chunk.                  |
+| `keepaliveMaxBytes`  | `number`        | `60_000`                              | Combined keepalive budget; the single teardown envelope stays under this.     |
 
 `service.name` has no current source in core config (reports do not emit it and
 are accepted, so the ingest does not require it). It is added here as an
@@ -350,6 +350,14 @@ logs would be lost.
 completion in the background even after the page is gone. It is the modern
 replacement for `navigator.sendBeacon()` and lets us reuse the same `fetch`
 transport instead of a second code path.
+
+Why not `navigator.sendBeacon()`: it **cannot set custom request headers**, and
+the logs ingest authenticates via the `x-api-token` header. No header means no
+auth (401), so sendBeacon cannot deliver an authenticated log POST at all. It
+also shares the same ~64 KB queued-data limit and gives no access to the
+response. MDN steers callers who "need to change any request properties" to
+`fetch` with `keepalive` for exactly this reason; this is also why Sentry's SDK
+uses `fetch` keepalive rather than sendBeacon. Decision: keepalive, not beacon.
 
 Constraints, all browser-enforced and browser-only:
 

--- a/docs/superpowers/specs/2026-06-03-core-logging-design.md
+++ b/docs/superpowers/specs/2026-06-03-core-logging-design.md
@@ -173,14 +173,24 @@ when it is false (nothing buffered), and `flush()` returns early when it is fals
 `configure({ enableLogs: false })` before the timer fires (or before `light(key)`)
 gets **no log traffic**, which is the intuitive meaning of "disable logging."
 
-The disable transition also **clears the buffer**: when `configure(...)` flips
-`enableLogs` from true to false, the `Logger` drops its buffered records (the same
-`clearGlows`-style reset). Rationale: a disabled logger that silently retained a
+The disable transition also **clears the buffer AND the timer**: when
+`configure(...)` flips `enableLogs` from true to false, the `Logger` drops its
+buffered records (the same `clearGlows`-style reset) AND clears any pending
+`setTimeout` plus resets the timer-active flag. Clearing the timer flag is not
+optional bookkeeping: if a timer is active when logs are disabled and logs are
+later re-enabled, a stale `isTimerActive === true` would make the next `record()`
+believe a flush is already scheduled and never arm a new one, so the buffer would
+sit until a count/weight trigger or manual flush. Resetting the flag on disable
+means the first `record()` after re-enable arms a fresh timer normally.
+
+Rationale for clearing the buffer: a disabled logger that silently retained a
 backlog would either leak it on a later re-enable (surprising) or pin memory
 indefinitely. Clear-on-disable makes "off" mean off. Re-enabling starts a fresh
-buffer; it does not resurrect pre-disable records. A test covers: buffer while
+buffer; it does not resurrect pre-disable records. Tests cover: (1) buffer while
 enabled, `configure({ enableLogs: false })`, assert no `api.logs` call on any
-subsequent flush path and the buffer is empty.
+subsequent flush path and the buffer is empty; (2) timer active, disable,
+re-enable, `record()`, assert a timer flush still fires (the flag was not left
+stuck).
 
 ### Resource vs record attributes
 
@@ -293,6 +303,14 @@ Auto-flush triggers (core-owned policy):
   bounded at the interval. Call `timer.unref?.()` so Node is not held open;
   harmless no-op in the browser.
 
+Byte accounting: these triggers and the buffer trim use a **cheap estimate**
+(e.g. summed per-record sizes) — they are soft heuristics, so an approximation is
+fine and avoids re-serializing the whole buffer on every `record()`. The
+**keepalive teardown cap is the exception**: it is a hard, browser-enforced limit,
+so it is checked against the **actual serialized body bytes**
+(`TextEncoder().encode(flatJsonStringify(envelope)).length`, see "Teardown
+flush"), not the estimate.
+
 `flush(opts?: { keepalive?: boolean })`:
 
 - Empty buffer -> no-op.
@@ -330,19 +348,24 @@ when no key was actually provided is a cheap no-op.
       is the **combined** limit across all in-flight keepalive requests, not
       per-request — so this is NOT chunked into several keepalive POSTs (two 60 KB
       keepalive POSTs sum to 120 KB and the browser rejects them). Send **one**
-      keepalive envelope, packing records **newest-first** while the running total
-      stays under `keepaliveMaxBytes`. A record that does not fit the remaining
-      budget is **skipped** (left behind, dropped on unload, logged when `debug`)
-      and packing continues with the next-older record — so one large record does
-      not block smaller ones from shipping. This also covers the single-record
-      case the `logFlushMaxBytes` capture guard does not: a record between
-      `keepaliveMaxBytes` and `logFlushMaxBytes` (e.g. 100 KB) is valid for a
-      normal flush but cannot fit a 60 KB unload envelope, so on teardown it is
-      skipped/dropped. Forcing a normal (non-keepalive) flush at unload is not an
-      option — the browser aborts it. Unload is best-effort, and the steady-state
-      timer/count flushes keep the buffer small (and ship the 100 KB record long
-      before unload in practice), so this drop is the rare tail case. See "Why
-      `keepalive`".
+      keepalive envelope, packing records **newest-first**. The budget is measured
+      on the **actual serialized body**, not summed per-record estimates:
+      `TextEncoder().encode(flatJsonStringify(envelope)).length <= keepaliveMaxBytes`.
+      This matters because the envelope wrapper (`resourceLogs` / `resource` /
+      `scopeLogs` overhead) and JSON escaping add bytes that per-record estimates
+      miss; the browser cap is on the real body, so the gate must be too. Build up
+      the envelope newest-first and back off when adding the next record would push
+      the serialized body over the cap. A record that does not fit is **skipped**
+      (left behind, dropped on unload, logged when `debug`) and packing continues
+      with the next-older record — so one large record does not block smaller ones.
+      This also covers the single-record case the `logFlushMaxBytes` capture guard
+      does not: a record between `keepaliveMaxBytes` and `logFlushMaxBytes` (e.g.
+      100 KB) is valid for a normal flush but cannot fit a 60 KB unload envelope,
+      so on teardown it is skipped/dropped. Forcing a normal (non-keepalive) flush
+      at unload is not an option — the browser aborts it. Unload is best-effort,
+      and the steady-state timer/count flushes keep the buffer small (and ship the
+      100 KB record long before unload in practice), so this drop is the rare tail
+      case. See "Why `keepalive`".
 - For each envelope, call `api.logs(envelope, …, opts?.keepalive)` and pass the
   returned promise to the injected `track` callback (below), which registers it
   in `Flare`'s `inflight` set. `flush()` itself does **not** await the HTTP
@@ -484,6 +507,21 @@ therefore **recursive and applied at every level**, not just the top:
   (so `[1, null, 2]` -> two values, not a value-with-null hole).
 - `kvlistValue.values`: encode each entry, drop keys whose value encodes to
   `null`.
+
+**Cycle safety.** `valueToOpenTelemetry` recurses into arrays and plain objects,
+so a cyclic attribute value (a realistic case — user context can hold Vue/React
+instances or self-referential objects) would infinite-loop and stack-overflow
+**inside the encoder**, before the value ever reaches `flatJsonStringify`. The
+existing `flatJsonStringify` decycles (`flatJsonStringify.ts:1`), but only at
+serialize time — and the encoder runs first, transforming attributes into the
+OTel `keyValue` shape, so that decycle is too late. The encoder must do its own
+cycle detection, mirroring `decycle`'s approach: track ancestors on the current
+branch with a `WeakSet` (add on enter, remove on exit — a branch-local path set,
+not a global "seen" set, so the same object referenced twice in sibling branches
+is not falsely flagged), and replace a back-edge with the same `'[Circular]'`
+sentinel `flatJsonStringify` uses, encoded as `{ stringValue: '[Circular]' }`. A
+test asserts a self-referential object attribute encodes with `'[Circular]'` and
+does not throw.
 
 This diverges intentionally from PHP, which only `array_filter`s the top level
 and would emit nested-null holes; the recursive drop keeps every emitted
@@ -670,6 +708,13 @@ flush policy):
 - Non-finite numbers: `NaN` / `Infinity` / `-Infinity` attribute values are
   dropped (never emitted as `{ doubleValue: null }`); a real-number sibling in the
   same object/array survives.
+- Cyclic attribute: a self-referential object value encodes with a `'[Circular]'`
+  sentinel and does not throw / stack-overflow.
+- Keepalive boundary: a teardown envelope whose **serialized** body (envelope
+  overhead + escaping included) would exceed `keepaliveMaxBytes` packs fewer
+  records so the actual `TextEncoder` byte length stays `<= keepaliveMaxBytes`.
+- Disable clears the timer: timer active, `configure({ enableLogs: false })`, then
+  re-enable and `record()`; a timer flush still fires (flag not left stuck).
 - Resource/record partition default: an unknown key (no resource prefix) lands at
   record level; `enduser.*` / `client.address` / `user_agent.original` are
   record-level (verified against real collector keys, not the dead `user.*`).
@@ -719,10 +764,15 @@ New in `@flareapp/core`:
   after applying the key, when the buffer is non-empty, so a backlog buffered
   before authentication ships as soon as a key arrives
 - `configure(...)` detects an `enableLogs` true->false transition and clears the
-  log buffer (disable semantics)
+  log buffer **and the timer** (disable semantics)
 - the OTel encoder mirrors `flatJsonStringify`'s `JSON.stringify` reality: drop
-  non-finite numbers BEFORE choosing `intValue`/`doubleValue`, so no
-  `{ doubleValue: null }` reaches the wire
+  non-finite numbers BEFORE choosing `intValue`/`doubleValue` (so no
+  `{ doubleValue: null }` reaches the wire), and carry its own branch-local
+  `WeakSet` cycle detection (the `flatJsonStringify` decycle runs too late — the
+  encoder recurses first)
+- keepalive teardown packing measures the **actual** serialized body
+  (`TextEncoder().encode(flatJsonStringify(envelope)).length`) against
+  `keepaliveMaxBytes`, not summed estimates
 
 New in `@flareapp/js`:
 

--- a/docs/superpowers/specs/2026-06-04-playground-logging-design.md
+++ b/docs/superpowers/specs/2026-06-04-playground-logging-design.md
@@ -1,0 +1,288 @@
+# Playground logging — shared log-scenarios across frameworks
+
+Date: 2026-06-04
+Status: Approved (design)
+
+## Problem
+
+The logging feature (`flare.logger.*`, spec `2026-06-03-core-logging-design.md`) is
+implemented and shipped. The playgrounds exercise the SDK uniformly across four
+frameworks (js, react, vue, svelte) via a shared spec — `errorScenarios` +
+`coverageFor` + `testIds` — rendered on each `/broken` page and asserted by a
+shared Playwright runner. Logging has no equivalent: only the js playground has a
+single ad-hoc "Record a log" button (added for the unload e2e in the core-logging
+work). This design adds logging to the playgrounds the same way error scenarios
+work: a shared, data-driven log-scenarios model rendered across all four
+frameworks, with e2e coverage per framework.
+
+## Goals
+
+- A shared `logScenarios` list mirroring the `errorScenarios` pattern.
+- A curated scenario set: info, warning, error, info-with-context, burst.
+- Each framework's `/broken` page renders a button per log scenario.
+- Each framework's flare init opts logging in (`enableLogs` + `logsIngestUrl`).
+- Data-driven e2e: each log scenario asserted across all four frameworks.
+- The existing js keepalive-on-unload test is folded into the shared model as a
+  non-flushing, js-only scenario (replacing the ad-hoc button).
+
+## Non-goals
+
+- Per-level exhaustive coverage (all 8 levels) — the curated set is enough.
+- Unit tests (this is playground UI + e2e only).
+- Changing any `@flareapp/*` package behavior.
+- A dedicated logging route — triggers live in a section on the existing
+  `/broken` page.
+
+## Shared log-scenarios model
+
+New files in `playgrounds/shared/src/`, exported from `index.ts`.
+
+### `logScenarios.ts`
+
+```ts
+export type LogLevel = 'debug' | 'info' | 'notice' | 'warning' | 'error' | 'critical' | 'alert' | 'emergency';
+
+export type LogScenario = {
+    id: string;
+    label: string;
+    level: LogLevel;
+    message: string;
+    attributes?: Record<string, unknown>;
+    count: number; // 1, or N for a burst
+    flushOnTrigger: boolean; // true: record then flush() for deterministic e2e
+};
+
+export const logScenarios: LogScenario[] = [
+    { id: 'log-info', label: 'Log info', level: 'info', message: 'playground-info', count: 1, flushOnTrigger: true },
+    {
+        id: 'log-warning',
+        label: 'Log warning',
+        level: 'warning',
+        message: 'playground-warning',
+        count: 1,
+        flushOnTrigger: true,
+    },
+    {
+        id: 'log-error',
+        label: 'Log error',
+        level: 'error',
+        message: 'playground-error',
+        count: 1,
+        flushOnTrigger: true,
+    },
+    {
+        id: 'log-context',
+        label: 'Log info with context',
+        level: 'info',
+        message: 'playground-context',
+        count: 1,
+        flushOnTrigger: true,
+        attributes: { 'context.scenario': { source: 'logger', userId: 'usr_42' } },
+    },
+    {
+        id: 'log-burst',
+        label: 'Log burst (5)',
+        level: 'info',
+        message: 'playground-burst',
+        count: 5,
+        flushOnTrigger: true,
+    },
+    // js-only: keepalive-on-unload. Buffered, NOT flushed on click; the unload
+    // navigation triggers the keepalive flush.
+    {
+        id: 'log-unload',
+        label: 'Log then unload',
+        level: 'info',
+        message: 'e2e-unload-log',
+        count: 1,
+        flushOnTrigger: false,
+    },
+];
+
+export const logScenarioById = (id: string): LogScenario | undefined => logScenarios.find((s) => s.id === id);
+```
+
+The `LogLevel` union duplicates `@flareapp/core`'s `MessageLevel` deliberately —
+`playgrounds/shared` is a framework-agnostic fixture package and must not depend
+on an SDK package. The 8 level names are stable.
+
+### `logCoverage` (in `coverage.ts`, alongside `coverageFor`)
+
+```ts
+import { logScenarios, type LogScenario } from './logScenarios';
+
+const excludeLogs: Record<Framework, string[]> = {
+    js: [],
+    react: ['log-unload'],
+    vue: ['log-unload'],
+    svelte: ['log-unload'],
+};
+
+export const logCoverageFor = (framework: Framework): LogScenario[] =>
+    logScenarios.filter((s) => !excludeLogs[framework].includes(s.id));
+```
+
+`log-unload` is js-only: keepalive-on-unload is identical browser behavior across
+all frameworks (they all run the same `@flareapp/js` browser flare), so testing
+it once is sufficient.
+
+### `testIds.ts`
+
+Add: `logTrigger: (scenarioId: string) => \`log-trigger-${scenarioId}\``.
+
+### `logTrigger.ts` — the one place log-firing logic lives
+
+```ts
+import type { LogLevel, LogScenario } from './logScenarios';
+
+// Structural type so shared has no @flareapp dependency.
+export type PlaygroundFlare = {
+    logger: Record<LogLevel, (message: string, attributes?: Record<string, unknown>) => void>;
+    flush: (timeoutMs?: number) => Promise<void>;
+};
+
+export function fireLogScenario(flare: PlaygroundFlare, scenario: LogScenario): void {
+    for (let i = 0; i < scenario.count; i++) {
+        flare.logger[scenario.level](scenario.message, scenario.attributes);
+    }
+    if (scenario.flushOnTrigger) {
+        void flare.flush();
+    }
+}
+```
+
+`flushOnTrigger: true` records then flushes so the e2e sees the log within the
+HTTP round-trip rather than after the 5s batch timer — no need to lower the
+playground's flush interval. The burst records 5 then flushes once, producing a
+single envelope with 5 records (exercising in-envelope batching).
+
+## Per-framework wiring
+
+### Flare init (enable logs)
+
+In each framework's flare init, when `VITE_FLARE_URL` is set, add to the
+`flare.configure({ ingestUrl: url, ... })` call:
+`logsIngestUrl: url.replace('/api/reports', '/api/logs')` and `enableLogs: true`.
+
+- `playgrounds/react/src/flare.ts`
+- `playgrounds/vue/src/flare.ts`
+- `playgrounds/svelte/src/lib/flare.client.ts`
+- `playgrounds/js/src/flare.ts` already has this (from the core-logging work) — no
+  change.
+
+(The svelte server init `flare.server.ts` is not touched — logging triggers are
+client-side browser logs.)
+
+### UI — a "Logging" section on each `/broken` page
+
+Each framework's broken page renders a button per `logCoverageFor(framework)`
+scenario, with `data-testid={testIds.logTrigger(scenario.id)}`, click ->
+`fireLogScenario(flare, scenario)`. The section sits below the existing error
+scenario buttons.
+
+- `playgrounds/js/src/pages/broken.ts` — REPLACE the existing ad-hoc
+  `trigger-log` button with the data-driven log buttons. The unload behavior is
+  now the `log-unload` scenario (`flushOnTrigger: false`), whose button keeps the
+  same firing semantics (record without flush). Its test id changes from
+  `trigger-log` to `log-trigger-log-unload`.
+- `playgrounds/react/src/routes/broken.tsx`
+- `playgrounds/vue/` broken route (`brokenTrigger.ts` + the route component)
+- `playgrounds/svelte/src/routes/broken/+page.svelte`
+
+Each framework imports `logCoverageFor`, `testIds`, `fireLogScenario` from
+`@flareapp/playgrounds-shared` and its own `flare`.
+
+## e2e (all frameworks, data-driven)
+
+### `e2e/specs/logShared.ts`
+
+```ts
+import { expect, type Page } from '@playwright/test';
+import { logCoverageFor, testIds, type Framework, type LogScenario } from '../../playgrounds/shared/src';
+import type { FakeFlare, FakeFlareRecord } from '../fixtures/fake-flare';
+
+type LogRecord = { body?: { stringValue?: string }; severityText?: string; attributes?: unknown[] };
+
+const recordsIn = (record: FakeFlareRecord): LogRecord[] => {
+    const env = record.bodyJson as { resourceLogs?: Array<{ scopeLogs?: Array<{ logRecords?: LogRecord[] }> }> } | null;
+    return env?.resourceLogs?.flatMap((rl) => rl.scopeLogs?.flatMap((sl) => sl.logRecords ?? []) ?? []) ?? [];
+};
+
+export const runLogScenario = async (page: Page, fakeFlare: FakeFlare, scenario: LogScenario): Promise<void> => {
+    const logPromise = fakeFlare.waitForLog({
+        predicate: (rec) => recordsIn(rec).some((r) => r.body?.stringValue === scenario.message),
+    });
+
+    await page.getByTestId(testIds.logTrigger(scenario.id)).click();
+    const received = await logPromise;
+
+    const matching = recordsIn(received).filter((r) => r.body?.stringValue === scenario.message);
+    expect(matching.length).toBe(scenario.count);
+    expect(matching[0].severityText).toBe(scenario.level.toUpperCase());
+    if (scenario.attributes) {
+        expect(Array.isArray(matching[0].attributes)).toBe(true);
+        expect((matching[0].attributes ?? []).length).toBeGreaterThan(0);
+    }
+};
+
+export const logScenariosFor = (framework: Framework): LogScenario[] => logCoverageFor(framework);
+```
+
+### Per-framework specs
+
+Each of `e2e/specs/{js,react,vue,svelte}.spec.ts` gets:
+
+```ts
+test.describe('<framework> logging', () => {
+    for (const scenario of logScenariosFor('<framework>')) {
+        test(scenario.id, async ({ page, fakeFlare }) => {
+            await page.goto('/broken');
+            await page.waitForLoadState('networkidle');
+            await runLogScenario(page, fakeFlare, scenario);
+        });
+    }
+});
+```
+
+For js, `logScenariosFor('js')` includes `log-unload`, but the unload scenario is
+`flushOnTrigger: false` — clicking it does NOT send, so the data-driven
+`runLogScenario` (which waits for the log right after click) would time out.
+Therefore `log-unload` is EXCLUDED from the js data-driven loop and keeps its
+dedicated existing unload test (records, asserts none sent, navigates to
+`about:blank`, asserts the keepalive POST arrives). Concretely: the js spec loops
+`logScenariosFor('js').filter((s) => s.flushOnTrigger)` for the data-driven block,
+and the existing `js logging` unload test is updated to click
+`testIds.logTrigger('log-unload')` instead of the old `trigger-log` id.
+
+The fake server already records `POST /api/logs` (endpoint `logs`) and the fixture
+exposes `waitForLog` + `logs()` (added in the core-logging e2e work). The fixture
+auto-resets per test, so each log test starts clean.
+
+## Testing
+
+- e2e is the test surface. `npx playwright test --project=<fw>` per framework, or
+  `npm run test:e2e` for all four. Each framework's logging describe block must
+  pass; the js unload test must still pass against the renamed test id.
+- No unit tests (playground/fixture code).
+
+## Files
+
+New:
+
+- `playgrounds/shared/src/logScenarios.ts`
+- `playgrounds/shared/src/logTrigger.ts`
+- `e2e/specs/logShared.ts`
+
+Modified:
+
+- `playgrounds/shared/src/coverage.ts` (add `logCoverageFor`)
+- `playgrounds/shared/src/testIds.ts` (add `logTrigger`)
+- `playgrounds/shared/src/index.ts` (export the new modules)
+- `playgrounds/react/src/flare.ts`, `playgrounds/vue/src/flare.ts`,
+  `playgrounds/svelte/src/lib/flare.client.ts` (enable logs)
+- `playgrounds/js/src/pages/broken.ts` (replace ad-hoc button with data-driven
+  log section)
+- `playgrounds/react/src/routes/broken.tsx`, the vue broken route,
+  `playgrounds/svelte/src/routes/broken/+page.svelte` (add log section)
+- `e2e/specs/js.spec.ts`, `react.spec.ts`, `vue.spec.ts`, `svelte.spec.ts` (add
+  logging describe blocks; js: update the unload test's test id)

--- a/docs/superpowers/specs/2026-06-04-playground-logging-design.md
+++ b/docs/superpowers/specs/2026-06-04-playground-logging-design.md
@@ -21,7 +21,9 @@ frameworks, with e2e coverage per framework.
 - A curated scenario set: info, warning, error, info-with-context, burst.
 - Each framework's `/broken` page renders a button per log scenario.
 - Each framework's flare init opts logging in (`enableLogs` + `logsIngestUrl`).
-- Data-driven e2e: each log scenario asserted across all four frameworks.
+- Data-driven e2e: every FLUSHING log scenario asserted across all four
+  frameworks; the non-flushing `log-unload` scenario is exercised only by the
+  dedicated js keepalive-on-unload test.
 - The existing js keepalive-on-unload test is folded into the shared model as a
   non-flushing, js-only scenario (replacing the ad-hoc button).
 
@@ -32,6 +34,11 @@ frameworks, with e2e coverage per framework.
 - Changing any `@flareapp/*` package behavior.
 - A dedicated logging route — triggers live in a section on the existing
   `/broken` page.
+- The Next.js playground (`playgrounds/nextjs`). It is not part of the shared-spec
+  framework set: `coverageFor`'s `Framework` union and the Playwright projects are
+  `js | react | vue | svelte` only, and the existing error scenarios likewise do
+  not cover it. Logging follows the same boundary. (Adding Next.js to the shared
+  framework set is a separate, larger change for both errors and logs.)
 
 ## Shared log-scenarios model
 
@@ -42,12 +49,26 @@ New files in `playgrounds/shared/src/`, exported from `index.ts`.
 ```ts
 export type LogLevel = 'debug' | 'info' | 'notice' | 'warning' | 'error' | 'critical' | 'alert' | 'emergency';
 
+// Structurally identical to @flareapp/core's `AttributeValue`, redefined here so
+// `playgrounds/shared` stays dependency-free. Because it is structurally the same,
+// `Record<string, LogAttributeValue>` is assignable to the SDK's
+// `Attributes = Record<string, AttributeValue>`, so these attributes can be passed
+// straight to `flare.logger.*` under strict TypeScript. (A `Record<string, unknown>`
+// would NOT be assignable — `unknown` is not an `AttributeValue`.)
+export type LogAttributeValue =
+    | string
+    | number
+    | boolean
+    | null
+    | LogAttributeValue[]
+    | { [key: string]: LogAttributeValue };
+
 export type LogScenario = {
     id: string;
     label: string;
     level: LogLevel;
     message: string;
-    attributes?: Record<string, unknown>;
+    attributes?: Record<string, LogAttributeValue>;
     count: number; // 1, or N for a burst
     flushOnTrigger: boolean; // true: record then flush() for deterministic e2e
 };
@@ -133,11 +154,13 @@ Add: `logTrigger: (scenarioId: string) => \`log-trigger-${scenarioId}\``.
 ### `logTrigger.ts` — the one place log-firing logic lives
 
 ```ts
-import type { LogLevel, LogScenario } from './logScenarios';
+import type { LogAttributeValue, LogLevel, LogScenario } from './logScenarios';
 
-// Structural type so shared has no @flareapp dependency.
+// Structural type so shared has no @flareapp dependency. The attribute param uses
+// `LogAttributeValue` (not `unknown`) so the real `flare` satisfies this type and
+// `scenario.attributes` passes to `flare.logger.*` under strict TypeScript.
 export type PlaygroundFlare = {
-    logger: Record<LogLevel, (message: string, attributes?: Record<string, unknown>) => void>;
+    logger: Record<LogLevel, (message: string, attributes?: Record<string, LogAttributeValue>) => void>;
     flush: (timeoutMs?: number) => Promise<void>;
 };
 
@@ -201,12 +224,26 @@ import { expect, type Page } from '@playwright/test';
 import { logCoverageFor, testIds, type Framework, type LogScenario } from '../../playgrounds/shared/src';
 import type { FakeFlare, FakeFlareRecord } from '../fixtures/fake-flare';
 
-type LogRecord = { body?: { stringValue?: string }; severityText?: string; attributes?: unknown[] };
+// OTel anyValue is minimal here; the only nested shape we assert is the
+// `context.scenario` kvlist. Decode just enough to read its leaf values.
+type AnyValue = {
+    stringValue?: string;
+    intValue?: number;
+    kvlistValue?: { values: KeyValue[] };
+};
+type KeyValue = { key: string; value: AnyValue };
+type LogRecord = { body?: { stringValue?: string }; severityText?: string; attributes?: KeyValue[] };
 
 const recordsIn = (record: FakeFlareRecord): LogRecord[] => {
     const env = record.bodyJson as { resourceLogs?: Array<{ scopeLogs?: Array<{ logRecords?: LogRecord[] }> }> } | null;
     return env?.resourceLogs?.flatMap((rl) => rl.scopeLogs?.flatMap((sl) => sl.logRecords ?? []) ?? []) ?? [];
 };
+
+const attr = (record: LogRecord, key: string): AnyValue | undefined =>
+    record.attributes?.find((kv) => kv.key === key)?.value;
+
+const kv = (value: AnyValue | undefined, key: string): AnyValue | undefined =>
+    value?.kvlistValue?.values.find((entry) => entry.key === key)?.value;
 
 export const runLogScenario = async (page: Page, fakeFlare: FakeFlare, scenario: LogScenario): Promise<void> => {
     const logPromise = fakeFlare.waitForLog({
@@ -219,9 +256,14 @@ export const runLogScenario = async (page: Page, fakeFlare: FakeFlare, scenario:
     const matching = recordsIn(received).filter((r) => r.body?.stringValue === scenario.message);
     expect(matching.length).toBe(scenario.count);
     expect(matching[0].severityText).toBe(scenario.level.toUpperCase());
-    if (scenario.attributes) {
-        expect(Array.isArray(matching[0].attributes)).toBe(true);
-        expect((matching[0].attributes ?? []).length).toBeGreaterThan(0);
+
+    // For the context scenario, assert the EXACT nested attribute values, not just
+    // "some attributes exist" — browser/framework attributes are always present, so
+    // a presence check would pass even if the user attributes were dropped.
+    if (scenario.id === 'log-context') {
+        const scope = attr(matching[0], 'context.scenario');
+        expect(kv(scope, 'source')?.stringValue).toBe('logger');
+        expect(kv(scope, 'userId')?.stringValue).toBe('usr_42');
     }
 };
 
@@ -234,7 +276,10 @@ Each of `e2e/specs/{js,react,vue,svelte}.spec.ts` gets:
 
 ```ts
 test.describe('<framework> logging', () => {
-    for (const scenario of logScenariosFor('<framework>')) {
+    // Only flushing scenarios go through the data-driven runner — it waits for the
+    // log right after the click. The non-flushing log-unload scenario buffers and
+    // would time out here; it is covered by the dedicated js unload test below.
+    for (const scenario of logScenariosFor('<framework>').filter((s) => s.flushOnTrigger)) {
         test(scenario.id, async ({ page, fakeFlare }) => {
             await page.goto('/broken');
             await page.waitForLoadState('networkidle');
@@ -244,14 +289,12 @@ test.describe('<framework> logging', () => {
 });
 ```
 
-For js, `logScenariosFor('js')` includes `log-unload`, but the unload scenario is
-`flushOnTrigger: false` — clicking it does NOT send, so the data-driven
-`runLogScenario` (which waits for the log right after click) would time out.
-Therefore `log-unload` is EXCLUDED from the js data-driven loop and keeps its
-dedicated existing unload test (records, asserts none sent, navigates to
-`about:blank`, asserts the keepalive POST arrives). Concretely: the js spec loops
-`logScenariosFor('js').filter((s) => s.flushOnTrigger)` for the data-driven block,
-and the existing `js logging` unload test is updated to click
+The `.filter((s) => s.flushOnTrigger)` applies uniformly to all four frameworks.
+For react/vue/svelte it is a no-op (their `logCoverageFor` already excludes
+`log-unload`). For js it drops `log-unload` from the data-driven block; that
+scenario is instead exercised by the existing dedicated `js logging` unload test
+(records, asserts none sent before navigation, navigates to `about:blank`, asserts
+the keepalive POST arrives), which is updated to click
 `testIds.logTrigger('log-unload')` instead of the old `trigger-log` id.
 
 The fake server already records `POST /api/logs` (endpoint `logs`) and the fixture

--- a/e2e/fake-flare-server/server.ts
+++ b/e2e/fake-flare-server/server.ts
@@ -5,6 +5,7 @@ import type { FakeFlareEndpoint, FakeFlareRecord, FakeFlareServer, WaitForOption
 
 const REPORTS_PATH = '/api/reports';
 const SOURCEMAPS_PATH = '/api/sourcemaps';
+const LOGS_PATH = '/api/logs';
 const INSPECT_REPORTS = '/__inspect/reports';
 const INSPECT_RESET = '/__inspect/reset';
 
@@ -102,6 +103,12 @@ export const startFakeFlareServer = async (options: { port?: number } = {}): Pro
                 return;
             }
 
+            if (req.method === 'POST' && url.startsWith(LOGS_PATH)) {
+                await record(req, 'logs');
+                writeJson(res, 201, {});
+                return;
+            }
+
             if (req.method === 'GET' && url === INSPECT_REPORTS) {
                 writeJson(res, 200, records);
                 return;
@@ -166,6 +173,7 @@ export const startFakeFlareServer = async (options: { port?: number } = {}): Pro
         records: () => [...records],
         reports: () => records.filter((r) => r.endpoint === 'reports'),
         sourcemaps: () => records.filter((r) => r.endpoint === 'sourcemaps'),
+        logs: () => records.filter((r) => r.endpoint === 'logs'),
         reset,
         waitForReport,
         stop,

--- a/e2e/fake-flare-server/types.ts
+++ b/e2e/fake-flare-server/types.ts
@@ -1,4 +1,4 @@
-export type FakeFlareEndpoint = 'reports' | 'sourcemaps';
+export type FakeFlareEndpoint = 'reports' | 'sourcemaps' | 'logs';
 
 export type FakeFlareRecord = {
     endpoint: FakeFlareEndpoint;
@@ -21,6 +21,7 @@ export type FakeFlareServer = {
     records(): FakeFlareRecord[];
     reports(): FakeFlareRecord[];
     sourcemaps(): FakeFlareRecord[];
+    logs(): FakeFlareRecord[];
     reset(): void;
     waitForReport(options?: WaitForOptions): Promise<FakeFlareRecord>;
     stop(): Promise<void>;

--- a/e2e/fixtures/fake-flare.ts
+++ b/e2e/fixtures/fake-flare.ts
@@ -66,6 +66,7 @@ const waitForLog = async (options: WaitOptions = {}): Promise<FakeFlareRecord> =
 export type FakeFlare = {
     reset: typeof reset;
     reports: () => Promise<FakeFlareRecord[]>;
+    logs: () => Promise<FakeFlareRecord[]>;
     waitForReport: typeof waitForReport;
     waitForLog: typeof waitForLog;
     assertNoReports: typeof assertNoReports;
@@ -77,6 +78,7 @@ export const test = base.extend<{ fakeFlare: FakeFlare }>({
         await use({
             reset,
             reports: async () => (await fetchReports()).filter((r) => r.endpoint === 'reports'),
+            logs: async () => (await fetchReports()).filter((r) => r.endpoint === 'logs'),
             waitForReport,
             waitForLog,
             assertNoReports,

--- a/e2e/fixtures/fake-flare.ts
+++ b/e2e/fixtures/fake-flare.ts
@@ -48,10 +48,26 @@ const assertNoReports = async (within = 500): Promise<void> => {
     }
 };
 
+const waitForLog = async (options: WaitOptions = {}): Promise<FakeFlareRecord> => {
+    const { timeout = 5000, predicate } = options;
+    const deadline = Date.now() + timeout;
+    let lastCount = 0;
+    while (Date.now() < deadline) {
+        const records = await fetchReports();
+        const logs = records.filter((r) => r.endpoint === 'logs');
+        const match = predicate ? logs.find(predicate) : logs[0];
+        if (match) return match;
+        lastCount = logs.length;
+        await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    throw new Error(`waitForLog timed out after ${timeout}ms (${lastCount} logs captured)`);
+};
+
 export type FakeFlare = {
     reset: typeof reset;
     reports: () => Promise<FakeFlareRecord[]>;
     waitForReport: typeof waitForReport;
+    waitForLog: typeof waitForLog;
     assertNoReports: typeof assertNoReports;
 };
 
@@ -62,6 +78,7 @@ export const test = base.extend<{ fakeFlare: FakeFlare }>({
             reset,
             reports: async () => (await fetchReports()).filter((r) => r.endpoint === 'reports'),
             waitForReport,
+            waitForLog,
             assertNoReports,
         });
     },

--- a/e2e/specs/js.spec.ts
+++ b/e2e/specs/js.spec.ts
@@ -39,6 +39,10 @@ test.describe('js logging', () => {
         // Record a log; it is buffered (timer is 5s), not yet sent.
         await page.getByTestId('trigger-log').click();
 
+        // The log is buffered (5s timer), NOT sent on click. Prove it before unload.
+        await page.waitForTimeout(300);
+        expect(await fakeFlare.logs()).toHaveLength(0);
+
         // Navigate away with no prior flush — fires visibilitychange:hidden and the
         // BrowserFlushScheduler does a keepalive POST that must survive unload.
         await page.goto('about:blank');

--- a/e2e/specs/js.spec.ts
+++ b/e2e/specs/js.spec.ts
@@ -28,3 +28,26 @@ test.describe('js playground', () => {
         }
     });
 });
+
+test.describe('js logging', () => {
+    test('ships a buffered log on page unload (cross-origin keepalive)', async ({ page, fakeFlare }) => {
+        await fakeFlare.reset();
+
+        await page.goto('/broken');
+        await page.waitForLoadState('networkidle');
+
+        // Record a log; it is buffered (timer is 5s), not yet sent.
+        await page.getByTestId('trigger-log').click();
+
+        // Navigate away with no prior flush — fires visibilitychange:hidden and the
+        // BrowserFlushScheduler does a keepalive POST that must survive unload.
+        await page.goto('about:blank');
+
+        const log = await fakeFlare.waitForLog({
+            predicate: (r) => JSON.stringify(r.bodyJson).includes('e2e-unload-log'),
+        });
+
+        expect(log.endpoint).toBe('logs');
+        expect(log.headers['x-api-token']).toBeTruthy();
+    });
+});

--- a/e2e/specs/js.spec.ts
+++ b/e2e/specs/js.spec.ts
@@ -60,4 +60,42 @@ test.describe('js logging', () => {
         expect(log.endpoint).toBe('logs');
         expect(log.headers['x-api-token']).toBeTruthy();
     });
+
+    test('backgrounding a tab retains over-keepalive logs and ships them on resume', async ({ page, fakeFlare }) => {
+        await fakeFlare.reset();
+
+        await page.goto('/broken');
+        await page.waitForLoadState('networkidle');
+
+        // Lower the keepalive budget and buffer a record larger than it. visibilitychange
+        // :hidden fires on backgrounding too, not only on unload, so the over-budget
+        // record must survive a hidden/visible cycle instead of being dropped.
+        const oversized = 'e2e-bg-resume-' + 'x'.repeat(5000);
+        await page.evaluate((message) => {
+            const flare = (globalThis as { __flare?: any }).__flare;
+            flare.configure({ keepaliveMaxBytes: 2000, logFlushIntervalMs: 999_999 });
+            flare.logger.info(message);
+        }, oversized);
+
+        // Simulate the tab being backgrounded (not unloaded).
+        await page.evaluate(() => {
+            Object.defineProperty(document, 'visibilityState', { configurable: true, get: () => 'hidden' });
+            document.dispatchEvent(new Event('visibilitychange'));
+        });
+
+        // Nothing fit the keepalive budget, so no envelope shipped and the record is kept.
+        await page.waitForTimeout(300);
+        expect(await fakeFlare.logs()).toHaveLength(0);
+
+        // Tab resumes; a normal flush ships the retained record.
+        await page.evaluate(() => {
+            Object.defineProperty(document, 'visibilityState', { configurable: true, get: () => 'visible' });
+            return (globalThis as { __flare?: any }).__flare.flush();
+        });
+
+        const log = await fakeFlare.waitForLog({
+            predicate: (r) => JSON.stringify(r.bodyJson).includes('e2e-bg-resume-'),
+        });
+        expect(log.endpoint).toBe('logs');
+    });
 });

--- a/e2e/specs/js.spec.ts
+++ b/e2e/specs/js.spec.ts
@@ -1,5 +1,6 @@
 import { testIds } from '../../playgrounds/shared/src';
 import { expect, test } from '../fixtures/fake-flare';
+import { logScenariosFor, runLogScenario } from './logShared';
 import { runScenario, scenariosFor } from './shared';
 
 test.describe('js playground', () => {
@@ -30,21 +31,26 @@ test.describe('js playground', () => {
 });
 
 test.describe('js logging', () => {
+    for (const scenario of logScenariosFor('js').filter((s) => s.flushOnTrigger)) {
+        test(scenario.id, async ({ page, fakeFlare }) => {
+            await page.goto('/broken');
+            await page.waitForLoadState('networkidle');
+            await runLogScenario(page, fakeFlare, scenario);
+        });
+    }
+
     test('ships a buffered log on page unload (cross-origin keepalive)', async ({ page, fakeFlare }) => {
         await fakeFlare.reset();
 
         await page.goto('/broken');
         await page.waitForLoadState('networkidle');
 
-        // Record a log; it is buffered (timer is 5s), not yet sent.
-        await page.getByTestId('trigger-log').click();
+        // log-unload is flushOnTrigger:false — buffered, not sent on click.
+        await page.getByTestId(testIds.logTrigger('log-unload')).click();
 
-        // The log is buffered (5s timer), NOT sent on click. Prove it before unload.
         await page.waitForTimeout(300);
         expect(await fakeFlare.logs()).toHaveLength(0);
 
-        // Navigate away with no prior flush — fires visibilitychange:hidden and the
-        // BrowserFlushScheduler does a keepalive POST that must survive unload.
         await page.goto('about:blank');
 
         const log = await fakeFlare.waitForLog({

--- a/e2e/specs/logShared.ts
+++ b/e2e/specs/logShared.ts
@@ -35,7 +35,8 @@ export const runLogScenario = async (page: Page, fakeFlare: FakeFlare, scenario:
     expect(matching[0].severityText).toBe(scenario.level.toUpperCase());
 
     if (scenario.id === 'log-context') {
-        const scope = attr(matching[0], 'context.scenario');
+        // The second argument is PHP-style context: the SDK nests it under `log.context`.
+        const scope = kv(attr(matching[0], 'log.context'), 'context.scenario');
         expect(kv(scope, 'source')?.stringValue).toBe('logger');
         expect(kv(scope, 'userId')?.stringValue).toBe('usr_42');
     }

--- a/e2e/specs/logShared.ts
+++ b/e2e/specs/logShared.ts
@@ -1,0 +1,44 @@
+import { expect, type Page } from '@playwright/test';
+
+import { logCoverageFor, testIds, type Framework, type LogScenario } from '../../playgrounds/shared/src';
+import type { FakeFlare, FakeFlareRecord } from '../fixtures/fake-flare';
+
+type AnyValue = {
+    stringValue?: string;
+    intValue?: number;
+    kvlistValue?: { values: KeyValue[] };
+};
+type KeyValue = { key: string; value: AnyValue };
+type LogRecord = { body?: { stringValue?: string }; severityText?: string; attributes?: KeyValue[] };
+
+const recordsIn = (record: FakeFlareRecord): LogRecord[] => {
+    const env = record.bodyJson as { resourceLogs?: Array<{ scopeLogs?: Array<{ logRecords?: LogRecord[] }> }> } | null;
+    return env?.resourceLogs?.flatMap((rl) => rl.scopeLogs?.flatMap((sl) => sl.logRecords ?? []) ?? []) ?? [];
+};
+
+const attr = (record: LogRecord, key: string): AnyValue | undefined =>
+    record.attributes?.find((kv) => kv.key === key)?.value;
+
+const kv = (value: AnyValue | undefined, key: string): AnyValue | undefined =>
+    value?.kvlistValue?.values.find((entry) => entry.key === key)?.value;
+
+export const runLogScenario = async (page: Page, fakeFlare: FakeFlare, scenario: LogScenario): Promise<void> => {
+    const logPromise = fakeFlare.waitForLog({
+        predicate: (rec) => recordsIn(rec).some((r) => r.body?.stringValue === scenario.message),
+    });
+
+    await page.getByTestId(testIds.logTrigger(scenario.id)).click();
+    const received = await logPromise;
+
+    const matching = recordsIn(received).filter((r) => r.body?.stringValue === scenario.message);
+    expect(matching.length).toBe(scenario.count);
+    expect(matching[0].severityText).toBe(scenario.level.toUpperCase());
+
+    if (scenario.id === 'log-context') {
+        const scope = attr(matching[0], 'context.scenario');
+        expect(kv(scope, 'source')?.stringValue).toBe('logger');
+        expect(kv(scope, 'userId')?.stringValue).toBe('usr_42');
+    }
+};
+
+export const logScenariosFor = (framework: Framework): LogScenario[] => logCoverageFor(framework);

--- a/e2e/specs/react.spec.ts
+++ b/e2e/specs/react.spec.ts
@@ -1,5 +1,6 @@
 import { testIds } from '../../playgrounds/shared/src';
 import { expect, test } from '../fixtures/fake-flare';
+import { logScenariosFor, runLogScenario } from './logShared';
 import { runScenario, scenariosFor } from './shared';
 
 test.describe('react playground', () => {
@@ -27,4 +28,14 @@ test.describe('react playground', () => {
             });
         }
     });
+});
+
+test.describe('react logging', () => {
+    for (const scenario of logScenariosFor('react').filter((s) => s.flushOnTrigger)) {
+        test(scenario.id, async ({ page, fakeFlare }) => {
+            await page.goto('/broken');
+            await page.waitForLoadState('networkidle');
+            await runLogScenario(page, fakeFlare, scenario);
+        });
+    }
 });

--- a/e2e/specs/svelte.spec.ts
+++ b/e2e/specs/svelte.spec.ts
@@ -1,5 +1,6 @@
 import { testIds } from '../../playgrounds/shared/src';
 import { expect, test } from '../fixtures/fake-flare';
+import { logScenariosFor, runLogScenario } from './logShared';
 import { runScenario, scenariosFor } from './shared';
 
 test.describe('svelte playground', () => {
@@ -29,4 +30,14 @@ test.describe('svelte playground', () => {
             });
         }
     });
+});
+
+test.describe('svelte logging', () => {
+    for (const scenario of logScenariosFor('svelte').filter((s) => s.flushOnTrigger)) {
+        test(scenario.id, async ({ page, fakeFlare }) => {
+            await page.goto('/broken');
+            await page.waitForLoadState('networkidle');
+            await runLogScenario(page, fakeFlare, scenario);
+        });
+    }
 });

--- a/e2e/specs/vue.spec.ts
+++ b/e2e/specs/vue.spec.ts
@@ -1,5 +1,6 @@
 import { testIds } from '../../playgrounds/shared/src';
 import { expect, test } from '../fixtures/fake-flare';
+import { logScenariosFor, runLogScenario } from './logShared';
 import { runScenario, scenariosFor } from './shared';
 
 test.describe('vue playground', () => {
@@ -27,4 +28,14 @@ test.describe('vue playground', () => {
             });
         }
     });
+});
+
+test.describe('vue logging', () => {
+    for (const scenario of logScenariosFor('vue').filter((s) => s.flushOnTrigger)) {
+        test(scenario.id, async ({ page, fakeFlare }) => {
+            await page.goto('/broken');
+            await page.waitForLoadState('networkidle');
+            await runLogScenario(page, fakeFlare, scenario);
+        });
+    }
 });

--- a/packages/core/src/Flare.ts
+++ b/packages/core/src/Flare.ts
@@ -38,6 +38,12 @@ export class Flare {
         sampleRate: 1,
         beforeEvaluate: (error) => error,
         beforeSubmit: (report) => report,
+        enableLogs: false,
+        logsIngestUrl: 'https://ingress.flareapp.io/v1/logs',
+        maxLogBufferSize: 100,
+        logFlushIntervalMs: 5000,
+        logFlushMaxBytes: 800_000,
+        keepaliveMaxBytes: 60_000,
     };
 
     private sdkInfo: SdkInfo = { name: DEFAULT_SDK_NAME, version: CLIENT_VERSION };

--- a/packages/core/src/Flare.ts
+++ b/packages/core/src/Flare.ts
@@ -1,5 +1,7 @@
 import { Api } from './api';
 import { CLIENT_VERSION, KEY, SOURCEMAP_VERSION } from './env';
+import { Logger, partitionAttributes } from './logging';
+import { FlushScheduler, NoopFlushScheduler } from './logging';
 import { GlobalScopeProvider, type ScopeProvider } from './Scope';
 import { createStackTrace } from './stacktrace';
 import type { FileReader } from './stacktrace/fileReader';
@@ -23,6 +25,8 @@ const DEFAULT_SDK_NAME = '@flareapp/core';
 
 export class Flare {
     private inflight = new Set<Promise<void>>();
+
+    private _logger!: Logger;
 
     private _config: Config = {
         key: null,
@@ -66,7 +70,18 @@ export class Flare {
         private contextCollector: ContextCollector = () => ({}),
         private fileReader: FileReader = new NullFileReader(),
         private scopeProvider: ScopeProvider = new GlobalScopeProvider(),
-    ) {}
+        scheduler: FlushScheduler = new NoopFlushScheduler(),
+    ) {
+        this._logger = new Logger({
+            api: this.api,
+            getConfig: () => this._config,
+            getSdkInfo: () => this.sdkInfo,
+            getFramework: () => this.framework,
+            buildLogAttributes: (userAttributes) => this.buildLogAttributes(userAttributes),
+            track: (p) => this.track(p),
+            scheduler,
+        });
+    }
 
     /**
      * Register an in-flight report so `flush()` can wait for it. Called by
@@ -209,6 +224,7 @@ export class Flare {
      *     again if you need to wait for those too.
      */
     flush(timeoutMs = 2000): Promise<void> {
+        this._logger.flush();
         const pending = [...this.inflight];
         if (pending.length === 0) return Promise.resolve();
         return new Promise<void>((resolve) => {
@@ -228,15 +244,22 @@ export class Flare {
         return this.scopeProvider.active().glows;
     }
 
+    get logger(): Logger {
+        return this._logger;
+    }
+
     light(key: string = KEY, debug?: boolean): this {
         this._config.key = key;
         if (debug !== undefined) {
             this._config.debug = debug;
         }
+        this._logger.flush();
         return this;
     }
 
     configure(config: Partial<Config>): this {
+        const wasLogsEnabled = this._config.enableLogs;
+
         this._config = { ...this._config, ...config };
 
         if (config.sampleRate !== undefined) {
@@ -247,6 +270,13 @@ export class Flare {
             config.urlDenylist,
             config.replaceDefaultUrlDenylist ?? this._config.replaceDefaultUrlDenylist,
         );
+
+        if (wasLogsEnabled && this._config.enableLogs === false) {
+            this._logger.clear();
+        }
+        if (config.key !== undefined) {
+            this._logger.flush();
+        }
 
         return this;
     }
@@ -419,65 +449,44 @@ export class Flare {
         });
     }
 
-    private buildReport(input: {
-        exceptionClass: string;
-        message: string;
-        stacktrace: Report['stacktrace'];
-        isLog: boolean;
-        level: MessageLevel | undefined;
-        extraAttributes: Attributes;
-        code: string | undefined;
-        seenAtUnixNano: number;
-    }): Report {
+    private assembleAttributes(
+        collectorAttributes: Attributes,
+        extraAttributes: Attributes,
+        includeBase: boolean,
+    ): Attributes {
         const activeScope = this.scopeProvider.active();
 
-        const baseAttributes: Attributes = {
-            'telemetry.sdk.language': 'javascript',
-            'telemetry.sdk.name': this.sdkInfo.name,
-            'telemetry.sdk.version': this.sdkInfo.version,
-            'flare.language.name': 'javascript',
-        };
+        const baseAttributes: Attributes = includeBase
+            ? {
+                  'telemetry.sdk.language': 'javascript',
+                  'telemetry.sdk.name': this.sdkInfo.name,
+                  'telemetry.sdk.version': this.sdkInfo.version,
+                  'flare.language.name': 'javascript',
+              }
+            : {};
 
-        if (this._config.stage) {
-            baseAttributes['service.stage'] = this._config.stage;
-        }
-        if (this._config.version) {
-            baseAttributes['service.version'] = this._config.version;
-        }
-        if (this.framework?.name) {
-            baseAttributes['flare.framework.name'] = this.framework.name;
-        }
-        if (this.framework?.version) {
-            baseAttributes['flare.framework.version'] = this.framework.version;
-        }
+        if (includeBase && this._config.stage) baseAttributes['service.stage'] = this._config.stage;
+        if (includeBase && this._config.version) baseAttributes['service.version'] = this._config.version;
+        if (includeBase && this.framework?.name) baseAttributes['flare.framework.name'] = this.framework.name;
+        if (includeBase && this.framework?.version) baseAttributes['flare.framework.version'] = this.framework.version;
 
-        // Scope entryPoint overrides are applied after the context collector so that
-        // explicitly set values (via setEntryPoint) win over collector-provided defaults.
         const entryPoint = activeScope.entryPoint;
         const entryPointOverrides: Attributes = {};
-        if (entryPoint?.identifier !== undefined) {
+        if (entryPoint?.identifier !== undefined)
             entryPointOverrides['flare.entry_point.handler.identifier'] = entryPoint.identifier;
-        }
-        if (entryPoint?.type !== undefined) {
-            entryPointOverrides['flare.entry_point.handler.type'] = entryPoint.type;
-        }
-        if (entryPoint?.name !== undefined) {
-            entryPointOverrides['flare.entry_point.handler.name'] = entryPoint.name;
-        }
+        if (entryPoint?.type !== undefined) entryPointOverrides['flare.entry_point.handler.type'] = entryPoint.type;
+        if (entryPoint?.name !== undefined) entryPointOverrides['flare.entry_point.handler.name'] = entryPoint.name;
 
         const attributes: Attributes = {
             ...baseAttributes,
-            ...this.contextCollector(this._config),
+            ...collectorAttributes,
             ...entryPointOverrides,
             ...activeScope.pendingAttributes,
-            ...input.extraAttributes,
+            ...extraAttributes,
         };
 
-        // Merge `context.custom` from extraAttributes into pendingAttributes' value
-        // instead of overwriting, so framework adapters can attach custom context
-        // without clobbering user-set context from addContext().
         const pendingCustom = activeScope.pendingAttributes['context.custom'];
-        const extraCustom = input.extraAttributes['context.custom'];
+        const extraCustom = extraAttributes['context.custom'];
         if (
             pendingCustom &&
             extraCustom &&
@@ -492,13 +501,34 @@ export class Flare {
             };
         }
 
-        // Emit context.custom.framework from instance state so it is present even
-        // inside a fresh request scope (where pendingAttributes starts empty).
-        // This mirrors the pre-refactor behavior: setFramework always set framework.
         if (this.framework?.name) {
             const existing = (attributes['context.custom'] as Record<string, AttributeValue> | undefined) ?? {};
             attributes['context.custom'] = { ...existing, framework: this.framework.name.toLowerCase() };
         }
+
+        return attributes;
+    }
+
+    private buildLogAttributes(userAttributes: Attributes): { record: Attributes; resource: Attributes } {
+        const { resource, record: collectorRecord } = partitionAttributes(this.contextCollector(this._config));
+        return {
+            resource,
+            record: this.assembleAttributes(collectorRecord, userAttributes, false),
+        };
+    }
+
+    private buildReport(input: {
+        exceptionClass: string;
+        message: string;
+        stacktrace: Report['stacktrace'];
+        isLog: boolean;
+        level: MessageLevel | undefined;
+        extraAttributes: Attributes;
+        code: string | undefined;
+        seenAtUnixNano: number;
+    }): Report {
+        const activeScope = this.scopeProvider.active();
+        const attributes = this.assembleAttributes(this.contextCollector(this._config), input.extraAttributes, true);
 
         // seenAtUnixNano: real nanoseconds. Date.now() * 1_000_000 exceeds Number.MAX_SAFE_INTEGER
         // by ~3 bits (~256 ns of drift), but browser clocks are millisecond-precision so the lost

--- a/packages/core/src/Flare.ts
+++ b/packages/core/src/Flare.ts
@@ -1,7 +1,6 @@
 import { Api } from './api';
 import { CLIENT_VERSION, KEY, SOURCEMAP_VERSION } from './env';
-import { Logger, partitionAttributes } from './logging';
-import { FlushScheduler, NoopFlushScheduler } from './logging';
+import { Logger, NoopFlushScheduler, partitionAttributes, type FlushScheduler } from './logging';
 import { GlobalScopeProvider, type ScopeProvider } from './Scope';
 import { createStackTrace } from './stacktrace';
 import type { FileReader } from './stacktrace/fileReader';
@@ -271,6 +270,7 @@ export class Flare {
             config.replaceDefaultUrlDenylist ?? this._config.replaceDefaultUrlDenylist,
         );
 
+        // Only clear the buffer/timer on a real enabled->disabled transition.
         if (wasLogsEnabled && this._config.enableLogs === false) {
             this._logger.clear();
         }
@@ -449,6 +449,22 @@ export class Flare {
         });
     }
 
+    private buildBaseAttributes(): Attributes {
+        const baseAttributes: Attributes = {
+            'telemetry.sdk.language': 'javascript',
+            'telemetry.sdk.name': this.sdkInfo.name,
+            'telemetry.sdk.version': this.sdkInfo.version,
+            'flare.language.name': 'javascript',
+        };
+
+        if (this._config.stage) baseAttributes['service.stage'] = this._config.stage;
+        if (this._config.version) baseAttributes['service.version'] = this._config.version;
+        if (this.framework?.name) baseAttributes['flare.framework.name'] = this.framework.name;
+        if (this.framework?.version) baseAttributes['flare.framework.version'] = this.framework.version;
+
+        return baseAttributes;
+    }
+
     private assembleAttributes(
         collectorAttributes: Attributes,
         extraAttributes: Attributes,
@@ -456,19 +472,7 @@ export class Flare {
     ): Attributes {
         const activeScope = this.scopeProvider.active();
 
-        const baseAttributes: Attributes = includeBase
-            ? {
-                  'telemetry.sdk.language': 'javascript',
-                  'telemetry.sdk.name': this.sdkInfo.name,
-                  'telemetry.sdk.version': this.sdkInfo.version,
-                  'flare.language.name': 'javascript',
-              }
-            : {};
-
-        if (includeBase && this._config.stage) baseAttributes['service.stage'] = this._config.stage;
-        if (includeBase && this._config.version) baseAttributes['service.version'] = this._config.version;
-        if (includeBase && this.framework?.name) baseAttributes['flare.framework.name'] = this.framework.name;
-        if (includeBase && this.framework?.version) baseAttributes['flare.framework.version'] = this.framework.version;
+        const baseAttributes: Attributes = includeBase ? this.buildBaseAttributes() : {};
 
         const entryPoint = activeScope.entryPoint;
         const entryPointOverrides: Attributes = {};
@@ -477,6 +481,8 @@ export class Flare {
         if (entryPoint?.type !== undefined) entryPointOverrides['flare.entry_point.handler.type'] = entryPoint.type;
         if (entryPoint?.name !== undefined) entryPointOverrides['flare.entry_point.handler.name'] = entryPoint.name;
 
+        // entryPointOverrides come after the collector so explicitly-set entry-point values
+        // win over any defaults the collector provided.
         const attributes: Attributes = {
             ...baseAttributes,
             ...collectorAttributes,
@@ -485,6 +491,9 @@ export class Flare {
             ...extraAttributes,
         };
 
+        // Deep-merge context.custom: combine the scope's pendingAttributes['context.custom']
+        // with the user-supplied extra context.custom per-key (user wins) so scope-set context
+        // is not clobbered by the spread above.
         const pendingCustom = activeScope.pendingAttributes['context.custom'];
         const extraCustom = extraAttributes['context.custom'];
         if (
@@ -501,6 +510,8 @@ export class Flare {
             };
         }
 
+        // Inject the framework name into context.custom so it is emitted even inside a fresh
+        // request scope that carries no other custom context.
         if (this.framework?.name) {
             const existing = (attributes['context.custom'] as Record<string, AttributeValue> | undefined) ?? {};
             attributes['context.custom'] = { ...existing, framework: this.framework.name.toLowerCase() };

--- a/packages/core/src/api/Api.ts
+++ b/packages/core/src/api/Api.ts
@@ -1,4 +1,4 @@
-import { Report } from '../types';
+import { LogsEnvelope, Report } from '../types';
 import { flatJsonStringify } from '../util';
 
 export class Api {
@@ -23,6 +23,36 @@ export class Api {
             (response) => {
                 if (debug && response.status !== 201) {
                     console.error(`Received response with status ${response.status} from Flare`);
+                }
+            },
+            (error) => {
+                if (debug) {
+                    console.error(error);
+                }
+            },
+        );
+    }
+
+    logs(
+        envelope: LogsEnvelope,
+        url: string,
+        key: string | null,
+        debug: boolean = false,
+        keepalive: boolean = false,
+    ): Promise<void> {
+        return fetch(url, {
+            method: 'POST',
+            keepalive,
+            headers: {
+                'Accept': 'application/json',
+                'Content-Type': 'application/json',
+                'x-api-token': key ?? '',
+            },
+            body: flatJsonStringify(envelope),
+        }).then(
+            (response) => {
+                if (debug && response.status !== 201) {
+                    console.error(`Received response with status ${response.status} from Flare logs`);
                 }
             },
             (error) => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,11 +1,16 @@
 export type {
+    AnyValue,
     AttributeValue,
     Attributes,
+    BufferedLog,
     Config,
     EntryPointHandler,
     Framework,
     Glow,
+    KeyValue,
+    LogsEnvelope,
     MessageLevel,
+    OtelLogRecord,
     OverriddenGrouping,
     Report,
     SdkInfo,
@@ -33,6 +38,9 @@ export type { ContextCollector } from './Flare';
 
 export { Scope, GlobalScopeProvider } from './Scope';
 export type { ScopeProvider } from './Scope';
+
+export { Logger, NoopFlushScheduler } from './logging';
+export type { FlushScheduler, FlushFn, LoggerDeps } from './logging';
 
 export { NullFileReader } from './stacktrace/NullFileReader';
 export type { FileReader } from './stacktrace/fileReader';

--- a/packages/core/src/logging/FlushScheduler.ts
+++ b/packages/core/src/logging/FlushScheduler.ts
@@ -1,0 +1,14 @@
+export type FlushFn = (opts?: { keepalive?: boolean }) => void;
+
+/**
+ * The seam through which a platform package wires the "drain on lifecycle end"
+ * trigger (browser unload, Node process exit). Core ships a no-op default; the
+ * count/weight/timer batching policy lives in `Logger` regardless.
+ */
+export interface FlushScheduler {
+    register(flush: FlushFn): void;
+}
+
+export class NoopFlushScheduler implements FlushScheduler {
+    register(): void {}
+}

--- a/packages/core/src/logging/Logger.ts
+++ b/packages/core/src/logging/Logger.ts
@@ -1,0 +1,215 @@
+import type { Api } from '../api';
+import type { Attributes, BufferedLog, Config, Framework, LogsEnvelope, MessageLevel, SdkInfo } from '../types';
+import { assertKey, flatJsonStringify } from '../util';
+import { buildLogsEnvelope } from './envelope';
+import type { FlushFn, FlushScheduler } from './FlushScheduler';
+import { isAtOrAboveMinimum, severityNumber, severityText } from './severity';
+
+export type LoggerDeps = {
+    api: Api;
+    getConfig: () => Config;
+    getSdkInfo: () => SdkInfo;
+    getFramework: () => Framework | null;
+    // Returns attributes ALREADY split into resource-level (only the collector's
+    // resource keys) and record-level (collector record keys + scope + entry point
+    // + user attrs). The Logger does NOT partition — only the collector output is
+    // partitionable; scope/user/entry-point attributes always stay record-level.
+    buildLogAttributes: (userAttributes: Attributes) => { record: Attributes; resource: Attributes };
+    track: <T>(p: Promise<T>) => Promise<T>;
+    scheduler: FlushScheduler;
+};
+
+export class Logger {
+    private buffer: BufferedLog[] = [];
+    private resourceAttributes: Attributes = {};
+    private timer: ReturnType<typeof setTimeout> | undefined;
+    private timerActive = false;
+
+    constructor(private deps: LoggerDeps) {
+        const flush: FlushFn = (opts) => this.flush(opts);
+        this.deps.scheduler.register(flush);
+    }
+
+    debug(message: string, attributes: Attributes = {}): void {
+        this.record('debug', message, attributes);
+    }
+    info(message: string, attributes: Attributes = {}): void {
+        this.record('info', message, attributes);
+    }
+    notice(message: string, attributes: Attributes = {}): void {
+        this.record('notice', message, attributes);
+    }
+    warning(message: string, attributes: Attributes = {}): void {
+        this.record('warning', message, attributes);
+    }
+    error(message: string, attributes: Attributes = {}): void {
+        this.record('error', message, attributes);
+    }
+    critical(message: string, attributes: Attributes = {}): void {
+        this.record('critical', message, attributes);
+    }
+    alert(message: string, attributes: Attributes = {}): void {
+        this.record('alert', message, attributes);
+    }
+    emergency(message: string, attributes: Attributes = {}): void {
+        this.record('emergency', message, attributes);
+    }
+
+    bufferLength(): number {
+        return this.buffer.length;
+    }
+
+    hasBuffered(): boolean {
+        return this.buffer.length > 0;
+    }
+
+    private record(level: MessageLevel, message: string, userAttributes: Attributes): void {
+        const config = this.deps.getConfig();
+        if (!config.enableLogs) return;
+        if (config.minimumLogLevel && !isAtOrAboveMinimum(level, config.minimumLogLevel)) return;
+
+        const { record, resource } = this.deps.buildLogAttributes(userAttributes);
+
+        const buffered: BufferedLog = {
+            timeUnixNano: String(Date.now()) + '000000',
+            severityNumber: severityNumber(level),
+            severityText: severityText(level),
+            message,
+            recordAttributes: record,
+            resourceAttributes: resource,
+        };
+
+        // Oversized-record guard: a single record bigger than the byte cap can
+        // never ship (and would make the trim unsatisfiable). Drop at capture.
+        if (this.estimateBytes(buffered) > config.logFlushMaxBytes) {
+            if (config.debug) console.error('Flare: dropping oversized log record');
+            return;
+        }
+
+        this.buffer.push(buffered);
+        this.resourceAttributes = resource;
+
+        // Triggers run BEFORE the trim: a keyed over-cap push flushes-and-clears
+        // here (data shipped); the trim is only the safety net when the flush
+        // no-ops (no key).
+        this.evaluateTriggers(config);
+        this.trim(config);
+    }
+
+    private evaluateTriggers(config: Config): void {
+        if (this.buffer.length >= config.maxLogBufferSize) {
+            this.flush();
+            return;
+        }
+        if (this.bufferBytes() >= config.logFlushMaxBytes) {
+            this.flush();
+            return;
+        }
+        if (!this.timerActive) {
+            this.timerActive = true;
+            this.timer = setTimeout(() => this.flush(), config.logFlushIntervalMs);
+            // Node's Timeout has unref(); the browser's number does not.
+            (this.timer as { unref?: () => void }).unref?.();
+        }
+    }
+
+    private trim(config: Config): void {
+        if (this.buffer.length > config.maxLogBufferSize) {
+            this.buffer = this.buffer.slice(this.buffer.length - config.maxLogBufferSize);
+        }
+        while (this.buffer.length > 1 && this.bufferBytes() > config.logFlushMaxBytes) {
+            this.buffer.shift();
+        }
+    }
+
+    flush(opts?: { keepalive?: boolean }): void {
+        const config = this.deps.getConfig();
+        if (!config.enableLogs) return;
+        if (this.buffer.length === 0) return;
+
+        // Key gate: never send unauthenticated. Use assertKey (not a bare
+        // truthiness check) so debug mode logs the same missing-key diagnostic
+        // reports get. Reset the timer (one-shot fired) but keep the buffer so
+        // records survive until a key is set.
+        if (!assertKey(config.key, config.debug)) {
+            this.clearTimer();
+            return;
+        }
+
+        this.clearTimer();
+
+        const records = opts?.keepalive ? this.packForKeepalive(config) : this.buffer;
+        this.buffer = [];
+        if (records.length === 0) return;
+
+        this.deps.track(
+            this.deps.api.logs(
+                this.buildEnvelope(records),
+                config.logsIngestUrl,
+                config.key,
+                config.debug,
+                !!opts?.keepalive,
+            ),
+        );
+    }
+
+    clear(): void {
+        this.buffer = [];
+        this.clearTimer();
+    }
+
+    private packForKeepalive(config: Config): BufferedLog[] {
+        let selected: BufferedLog[] = [];
+        for (let i = this.buffer.length - 1; i >= 0; i--) {
+            const trial = [this.buffer[i], ...selected];
+            const bytes = new TextEncoder().encode(flatJsonStringify(this.buildEnvelope(trial))).length;
+            if (bytes <= config.keepaliveMaxBytes) {
+                selected = trial;
+            } else if (config.debug) {
+                console.error('Flare: dropping log record from keepalive envelope (over budget)');
+            }
+        }
+        return selected;
+    }
+
+    private buildEnvelope(records: BufferedLog[]): LogsEnvelope {
+        const sdk = this.deps.getSdkInfo();
+        return buildLogsEnvelope(records, this.resourceForFlush(), sdk.name, sdk.version);
+    }
+
+    private resourceForFlush(): Attributes {
+        const config = this.deps.getConfig();
+        const sdk = this.deps.getSdkInfo();
+        const framework = this.deps.getFramework();
+        const identity: Attributes = {
+            'telemetry.sdk.language': 'javascript',
+            'telemetry.sdk.name': sdk.name,
+            'telemetry.sdk.version': sdk.version,
+            'flare.language.name': 'javascript',
+        };
+        if (config.serviceName) identity['service.name'] = config.serviceName;
+        if (config.version) identity['service.version'] = config.version;
+        if (config.stage) identity['service.stage'] = config.stage;
+        if (framework?.name) identity['flare.framework.name'] = framework.name;
+        if (framework?.version) identity['flare.framework.version'] = framework.version;
+        return { ...this.resourceAttributes, ...identity };
+    }
+
+    private clearTimer(): void {
+        if (this.timer) {
+            clearTimeout(this.timer);
+            this.timer = undefined;
+        }
+        this.timerActive = false;
+    }
+
+    private estimateBytes(log: BufferedLog): number {
+        // flatJsonStringify (not JSON.stringify) because record attributes are raw
+        // user data that can contain cycles.
+        return flatJsonStringify(log).length;
+    }
+
+    private bufferBytes(): number {
+        return this.buffer.reduce((sum, log) => sum + this.estimateBytes(log), 0);
+    }
+}

--- a/packages/core/src/logging/Logger.ts
+++ b/packages/core/src/logging/Logger.ts
@@ -114,12 +114,15 @@ export class Logger {
             this.flush();
             return;
         }
-        if (!this.timerActive) {
-            this.timerActive = true;
-            this.timer = setTimeout(() => this.flush(), config.logFlushIntervalMs);
-            // Node's Timeout has unref(); the browser's number does not.
-            (this.timer as { unref?: () => void }).unref?.();
-        }
+        this.armTimer(config);
+    }
+
+    private armTimer(config: Config): void {
+        if (this.timerActive) return;
+        this.timerActive = true;
+        this.timer = setTimeout(() => this.flush(), config.logFlushIntervalMs);
+        // Node's Timeout has unref(); the browser's number does not.
+        (this.timer as { unref?: () => void }).unref?.();
     }
 
     private trim(config: Config): void {
@@ -147,8 +150,22 @@ export class Logger {
 
         this.clearTimer();
 
-        const records = opts?.keepalive ? this.packForKeepalive(config) : this.buffer;
-        this.buffer = [];
+        // keepalive fires on visibilitychange:hidden, which also fires when a tab is
+        // merely backgrounded (not just on unload). packForKeepalive ships only what
+        // fits the browser's ~64KB keepalive budget, so retain the over-budget tail in
+        // the buffer instead of clearing it — a resumed tab can still send those records
+        // normally. A real unload discards the buffer with the page either way.
+        let records: BufferedLog[];
+        if (opts?.keepalive) {
+            records = this.packForKeepalive(config);
+            this.buffer = this.buffer.filter((log) => !records.includes(log));
+            // Re-arm the interval so retained records flush on resume without waiting
+            // for the next captured log.
+            if (this.buffer.length > 0) this.armTimer(config);
+        } else {
+            records = this.buffer;
+            this.buffer = [];
+        }
         if (records.length === 0) return;
 
         this.deps.track(

--- a/packages/core/src/logging/Logger.ts
+++ b/packages/core/src/logging/Logger.ts
@@ -204,12 +204,26 @@ export class Logger {
     }
 
     private estimateBytes(log: BufferedLog): number {
+        // Intentionally approximate heuristic used ONLY for the soft batching caps
+        // (logFlushMaxBytes weight-flush, oversized-record drop guard, trim loop).
+        // Two known approximations:
+        //   1. .length counts UTF-16 code units, not UTF-8 bytes — multi-byte
+        //      characters may be under- or over-counted vs the real wire size.
+        //   2. BufferedLog includes resourceAttributes, which are hoisted to the
+        //      envelope resource object and sent once per request, not per record —
+        //      so repeated resource attributes are counted once per record here.
+        // Both are acceptable: these caps are soft batching heuristics and /v1/logs
+        // has no hard per-request byte limit.  The HARD keepalive cap is measured
+        // separately with exact UTF-8 bytes in packForKeepalive(), because that one
+        // is a real browser-enforced limit (~64 KB on keepalive request bodies).
+        //
         // flatJsonStringify (not JSON.stringify) because record attributes are raw
         // user data that can contain cycles.
         return flatJsonStringify(log).length;
     }
 
     private bufferBytes(): number {
+        // Uses estimateBytes() — see its comment for the deliberate approximations.
         return this.buffer.reduce((sum, log) => sum + this.estimateBytes(log), 0);
     }
 }

--- a/packages/core/src/logging/Logger.ts
+++ b/packages/core/src/logging/Logger.ts
@@ -31,40 +31,45 @@ export class Logger {
         this.deps.scheduler.register(flush);
     }
 
-    debug(message: string, attributes: Attributes = {}): void {
-        this.record('debug', message, attributes);
+    debug(message: string, context: Attributes = {}, attributes: Attributes = {}): void {
+        this.record('debug', message, context, attributes);
     }
-    info(message: string, attributes: Attributes = {}): void {
-        this.record('info', message, attributes);
+    info(message: string, context: Attributes = {}, attributes: Attributes = {}): void {
+        this.record('info', message, context, attributes);
     }
-    notice(message: string, attributes: Attributes = {}): void {
-        this.record('notice', message, attributes);
+    notice(message: string, context: Attributes = {}, attributes: Attributes = {}): void {
+        this.record('notice', message, context, attributes);
     }
-    warning(message: string, attributes: Attributes = {}): void {
-        this.record('warning', message, attributes);
+    warning(message: string, context: Attributes = {}, attributes: Attributes = {}): void {
+        this.record('warning', message, context, attributes);
     }
-    error(message: string, attributes: Attributes = {}): void {
-        this.record('error', message, attributes);
+    error(message: string, context: Attributes = {}, attributes: Attributes = {}): void {
+        this.record('error', message, context, attributes);
     }
-    critical(message: string, attributes: Attributes = {}): void {
-        this.record('critical', message, attributes);
+    critical(message: string, context: Attributes = {}, attributes: Attributes = {}): void {
+        this.record('critical', message, context, attributes);
     }
-    alert(message: string, attributes: Attributes = {}): void {
-        this.record('alert', message, attributes);
+    alert(message: string, context: Attributes = {}, attributes: Attributes = {}): void {
+        this.record('alert', message, context, attributes);
     }
-    emergency(message: string, attributes: Attributes = {}): void {
-        this.record('emergency', message, attributes);
+    emergency(message: string, context: Attributes = {}, attributes: Attributes = {}): void {
+        this.record('emergency', message, context, attributes);
     }
 
     bufferLength(): number {
         return this.buffer.length;
     }
 
-    private record(level: MessageLevel, message: string, userAttributes: Attributes): void {
+    // Mirrors the PHP client's Logger::record(message, level, context, attributes):
+    // the everyday `context` is nested under `log.context` (rendered as the "Context"
+    // section in Flare), while `attributes` is an advanced raw passthrough spread flat
+    // onto the record (subject to the same resource/record partitioning).
+    private record(level: MessageLevel, message: string, context: Attributes, attributes: Attributes): void {
         const config = this.deps.getConfig();
         if (!config.enableLogs) return;
         if (config.minimumLogLevel && !isAtOrAboveMinimum(level, config.minimumLogLevel)) return;
 
+        const userAttributes: Attributes = { 'log.context': context, ...attributes };
         const { record, resource } = this.deps.buildLogAttributes(userAttributes);
 
         const buffered: BufferedLog = {

--- a/packages/core/src/logging/Logger.ts
+++ b/packages/core/src/logging/Logger.ts
@@ -59,10 +59,6 @@ export class Logger {
         return this.buffer.length;
     }
 
-    hasBuffered(): boolean {
-        return this.buffer.length > 0;
-    }
-
     private record(level: MessageLevel, message: string, userAttributes: Attributes): void {
         const config = this.deps.getConfig();
         if (!config.enableLogs) return;
@@ -87,6 +83,13 @@ export class Logger {
         }
 
         this.buffer.push(buffered);
+        // Last-write-wins: the envelope stamps ALL batched records with this single
+        // most-recent resource map. That is correct ONLY because every
+        // resource-prefixed key in the partition allowlist is instance-static for the
+        // process lifetime (the one varying process.* key, process.uptime, is held
+        // back to record-level via the partition's exception set). A future collector
+        // emitting a request-varying resource-prefixed key would silently mis-stamp
+        // batched records.
         this.resourceAttributes = resource;
 
         // Triggers run BEFORE the trim: a keyed over-cap push flushes-and-clears

--- a/packages/core/src/logging/Logger.ts
+++ b/packages/core/src/logging/Logger.ts
@@ -3,6 +3,7 @@ import type { Attributes, BufferedLog, Config, Framework, LogsEnvelope, MessageL
 import { assertKey, flatJsonStringify } from '../util';
 import { buildLogsEnvelope } from './envelope';
 import type { FlushFn, FlushScheduler } from './FlushScheduler';
+import { attributesToOpenTelemetry } from './otel';
 import { isAtOrAboveMinimum, severityNumber, severityText } from './severity';
 
 export type LoggerDeps = {
@@ -71,7 +72,7 @@ export class Logger {
             severityNumber: severityNumber(level),
             severityText: severityText(level),
             message,
-            recordAttributes: record,
+            recordAttributes: attributesToOpenTelemetry(record),
             resourceAttributes: resource,
         };
 

--- a/packages/core/src/logging/envelope.ts
+++ b/packages/core/src/logging/envelope.ts
@@ -28,7 +28,7 @@ export function buildLogsEnvelope(
                             severityNumber: record.severityNumber,
                             severityText: record.severityText,
                             body: { stringValue: record.message },
-                            attributes: attributesToOpenTelemetry(record.recordAttributes),
+                            attributes: record.recordAttributes,
                             flags: 0,
                             droppedAttributesCount: 0,
                         })),

--- a/packages/core/src/logging/envelope.ts
+++ b/packages/core/src/logging/envelope.ts
@@ -1,0 +1,40 @@
+import type { Attributes, BufferedLog, LogsEnvelope } from '../types';
+import { attributesToOpenTelemetry } from './otel';
+
+export function buildLogsEnvelope(
+    records: BufferedLog[],
+    resourceAttributes: Attributes,
+    scopeName: string,
+    scopeVersion: string,
+): LogsEnvelope {
+    return {
+        resourceLogs: [
+            {
+                resource: {
+                    attributes: attributesToOpenTelemetry(resourceAttributes),
+                    droppedAttributesCount: 0,
+                },
+                scopeLogs: [
+                    {
+                        scope: {
+                            name: scopeName,
+                            version: scopeVersion,
+                            attributes: [],
+                            droppedAttributesCount: 0,
+                        },
+                        logRecords: records.map((record) => ({
+                            timeUnixNano: record.timeUnixNano,
+                            observedTimeUnixNano: record.timeUnixNano,
+                            severityNumber: record.severityNumber,
+                            severityText: record.severityText,
+                            body: { stringValue: record.message },
+                            attributes: attributesToOpenTelemetry(record.recordAttributes),
+                            flags: 0,
+                            droppedAttributesCount: 0,
+                        })),
+                    },
+                ],
+            },
+        ],
+    };
+}

--- a/packages/core/src/logging/index.ts
+++ b/packages/core/src/logging/index.ts
@@ -1,0 +1,8 @@
+export { Logger } from './Logger';
+export type { LoggerDeps } from './Logger';
+export { NoopFlushScheduler } from './FlushScheduler';
+export type { FlushScheduler, FlushFn } from './FlushScheduler';
+export { valueToOpenTelemetry, attributesToOpenTelemetry } from './otel';
+export { partitionAttributes } from './partition';
+export { buildLogsEnvelope } from './envelope';
+export { severityNumber, severityText, isAtOrAboveMinimum } from './severity';

--- a/packages/core/src/logging/otel.ts
+++ b/packages/core/src/logging/otel.ts
@@ -1,0 +1,49 @@
+import type { AnyValue, AttributeValue, Attributes, KeyValue } from '../types';
+
+// `inPath` tracks ancestors on the current branch only (added on enter, removed on
+// exit), mirroring flatJsonStringify's decycle. A global "seen" set would mis-flag
+// the same object referenced twice in sibling branches as circular.
+export function valueToOpenTelemetry(value: AttributeValue, inPath: WeakSet<object> = new WeakSet()): AnyValue | null {
+    if (typeof value === 'string') return { stringValue: value };
+    if (typeof value === 'boolean') return { boolValue: value };
+    if (typeof value === 'number') {
+        if (!Number.isFinite(value)) return null;
+        return Number.isInteger(value) ? { intValue: value } : { doubleValue: value };
+    }
+    if (value === null || value === undefined) return null;
+
+    if (Array.isArray(value)) {
+        if (inPath.has(value)) return { stringValue: '[Circular]' };
+        inPath.add(value);
+        const values: AnyValue[] = [];
+        for (const item of value) {
+            const mapped = valueToOpenTelemetry(item, inPath);
+            if (mapped !== null) values.push(mapped);
+        }
+        inPath.delete(value);
+        return { arrayValue: { values } };
+    }
+
+    if (typeof value === 'object') {
+        if (inPath.has(value)) return { stringValue: '[Circular]' };
+        inPath.add(value);
+        const values: KeyValue[] = [];
+        for (const [key, item] of Object.entries(value)) {
+            const mapped = valueToOpenTelemetry(item as AttributeValue, inPath);
+            if (mapped !== null) values.push({ key, value: mapped });
+        }
+        inPath.delete(value);
+        return { kvlistValue: { values } };
+    }
+
+    return null;
+}
+
+export function attributesToOpenTelemetry(attributes: Attributes): KeyValue[] {
+    const out: KeyValue[] = [];
+    for (const [key, value] of Object.entries(attributes)) {
+        const mapped = valueToOpenTelemetry(value);
+        if (mapped !== null) out.push({ key, value: mapped });
+    }
+    return out;
+}

--- a/packages/core/src/logging/partition.ts
+++ b/packages/core/src/logging/partition.ts
@@ -1,0 +1,30 @@
+import type { Attributes } from '../types';
+
+// Allowlist of resource-level key prefixes. Every other key — known or unknown —
+// is record-level. Mis-placing a static key on a record costs a little duplication;
+// mis-placing a request-varying key on the shared resource corrupts batched
+// envelopes, so record-level is the safe default.
+const RESOURCE_PREFIXES = ['service.', 'telemetry.', 'host.', 'os.', 'process.', 'flare.framework.', 'flare.language.'];
+
+// Keys that match a resource prefix but are NOT instance-static, so they must stay
+// record-level. `process.uptime` changes every read; promoting it to the shared
+// envelope resource would tag batched records with the flush-time value.
+const RECORD_LEVEL_EXCEPTIONS = new Set(['process.uptime']);
+
+export function partitionAttributes(attributes: Attributes): {
+    resource: Attributes;
+    record: Attributes;
+} {
+    const resource: Attributes = {};
+    const record: Attributes = {};
+    for (const [key, value] of Object.entries(attributes)) {
+        const isResource =
+            !RECORD_LEVEL_EXCEPTIONS.has(key) && RESOURCE_PREFIXES.some((prefix) => key.startsWith(prefix));
+        if (isResource) {
+            resource[key] = value;
+        } else {
+            record[key] = value;
+        }
+    }
+    return { resource, record };
+}

--- a/packages/core/src/logging/severity.ts
+++ b/packages/core/src/logging/severity.ts
@@ -1,0 +1,24 @@
+import type { MessageLevel } from '../types';
+
+const SEVERITY_NUMBERS: Record<MessageLevel, number> = {
+    debug: 5,
+    info: 9,
+    notice: 10,
+    warning: 13,
+    error: 17,
+    critical: 18,
+    alert: 19,
+    emergency: 21,
+};
+
+export function severityNumber(level: MessageLevel): number {
+    return SEVERITY_NUMBERS[level];
+}
+
+export function severityText(level: MessageLevel): string {
+    return level.toUpperCase();
+}
+
+export function isAtOrAboveMinimum(level: MessageLevel, minimum: MessageLevel): boolean {
+    return severityNumber(level) >= severityNumber(minimum);
+}

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -133,6 +133,6 @@ export type BufferedLog = {
     severityNumber: number;
     severityText: string;
     message: string;
-    recordAttributes: Attributes;
+    recordAttributes: KeyValue[];
     resourceAttributes: Attributes;
 };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -16,6 +16,14 @@ export type Config = {
     urlDenylist: RegExp;
     replaceDefaultUrlDenylist: boolean;
     sampleRate: number;
+    enableLogs: boolean;
+    logsIngestUrl: string;
+    minimumLogLevel?: MessageLevel;
+    serviceName?: string;
+    maxLogBufferSize: number;
+    logFlushIntervalMs: number;
+    logFlushMaxBytes: number;
+    keepaliveMaxBytes: number;
     beforeEvaluate: (error: Error) => Error | false | null | Promise<Error | false | null>;
     beforeSubmit: (report: Report) => Report | false | null | Promise<Report | false | null>;
 };
@@ -79,3 +87,52 @@ export type EntryPointHandler = {
 export type SdkInfo = { name: string; version: string };
 
 export type Framework = { name: string; version?: string };
+
+// --- Logging ---
+
+export type AnyValue =
+    | { stringValue: string }
+    | { boolValue: boolean }
+    | { intValue: number }
+    | { doubleValue: number }
+    | { arrayValue: { values: AnyValue[] } }
+    | { kvlistValue: { values: KeyValue[] } };
+
+export type KeyValue = { key: string; value: AnyValue };
+
+export type OtelResource = { attributes: KeyValue[]; droppedAttributesCount: number };
+
+export type OtelScope = {
+    name: string;
+    version: string;
+    attributes: KeyValue[];
+    droppedAttributesCount: number;
+};
+
+export type OtelLogRecord = {
+    timeUnixNano: string;
+    observedTimeUnixNano: string;
+    severityNumber: number;
+    severityText: string;
+    body: AnyValue;
+    attributes: KeyValue[];
+    flags: number;
+    droppedAttributesCount: number;
+};
+
+export type LogsEnvelope = {
+    resourceLogs: Array<{
+        resource: OtelResource;
+        scopeLogs: Array<{ scope: OtelScope; logRecords: OtelLogRecord[] }>;
+    }>;
+};
+
+// Internal buffered shape (pre-encoding).
+export type BufferedLog = {
+    timeUnixNano: string;
+    severityNumber: number;
+    severityText: string;
+    message: string;
+    recordAttributes: Attributes;
+    resourceAttributes: Attributes;
+};

--- a/packages/core/tests/helpers/FakeApi.ts
+++ b/packages/core/tests/helpers/FakeApi.ts
@@ -1,13 +1,18 @@
 import { Api } from '../../src/api';
-import { Report } from '../../src/types';
+import { LogsEnvelope, Report } from '../../src/types';
 
 export class FakeApi extends Api {
     reports: Report[] = [];
+    logEnvelopes: LogsEnvelope[] = [];
 
     lastReport?: Report;
     lastUrl?: string;
     lastKey?: string | null;
     lastReportBrowserExtensionErrors?: boolean;
+
+    lastLogUrl?: string;
+    lastLogKey?: string | null;
+    lastLogKeepalive?: boolean;
 
     report(report: Report, url: string, key: string | null, reportBrowserExtensionErrors: boolean): Promise<void> {
         this.reports.push(report);
@@ -15,6 +20,14 @@ export class FakeApi extends Api {
         this.lastKey = key;
         this.lastReportBrowserExtensionErrors = reportBrowserExtensionErrors;
         this.lastReport = report;
+        return Promise.resolve();
+    }
+
+    logs(envelope: LogsEnvelope, url: string, key: string | null, _debug?: boolean, keepalive = false): Promise<void> {
+        this.logEnvelopes.push(envelope);
+        this.lastLogUrl = url;
+        this.lastLogKey = key;
+        this.lastLogKeepalive = keepalive;
         return Promise.resolve();
     }
 }

--- a/packages/core/tests/logApi.test.ts
+++ b/packages/core/tests/logApi.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { Api } from '../src/api';
+import type { LogsEnvelope } from '../src/types';
+
+const envelope: LogsEnvelope = {
+    resourceLogs: [{ resource: { attributes: [], droppedAttributesCount: 0 }, scopeLogs: [] }],
+};
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('Api.logs', () => {
+    it('POSTs the envelope with the x-api-token header and keepalive flag', async () => {
+        const fetchMock = vi.fn().mockResolvedValue({ status: 201 });
+        vi.stubGlobal('fetch', fetchMock);
+
+        await new Api().logs(envelope, 'https://example.test/v1/logs', 'KEY', false, true);
+
+        expect(fetchMock).toHaveBeenCalledTimes(1);
+        const [url, init] = fetchMock.mock.calls[0];
+        expect(url).toBe('https://example.test/v1/logs');
+        expect(init.method).toBe('POST');
+        expect(init.keepalive).toBe(true);
+        expect(init.headers['x-api-token']).toBe('KEY');
+        expect(JSON.parse(init.body)).toEqual(envelope);
+    });
+
+    it('never rejects on network failure', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('boom')));
+        await expect(new Api().logs(envelope, 'u', 'k')).resolves.toBeUndefined();
+    });
+});

--- a/packages/core/tests/logEnvelope.test.ts
+++ b/packages/core/tests/logEnvelope.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildLogsEnvelope } from '../src/logging/envelope';
+import type { BufferedLog } from '../src/types';
+
+const record: BufferedLog = {
+    timeUnixNano: '1700000000000000000',
+    severityNumber: 9,
+    severityText: 'INFO',
+    message: 'hello',
+    recordAttributes: { 'http.request.method': 'GET' },
+    resourceAttributes: {},
+};
+
+describe('buildLogsEnvelope', () => {
+    it('builds an OTel resourceLogs envelope', () => {
+        const envelope = buildLogsEnvelope([record], { 'service.name': 'svc' }, '@flareapp/js', '2.0.0');
+
+        expect(envelope.resourceLogs).toHaveLength(1);
+        const rl = envelope.resourceLogs[0];
+        expect(rl.resource.attributes).toEqual([{ key: 'service.name', value: { stringValue: 'svc' } }]);
+        expect(rl.resource.droppedAttributesCount).toBe(0);
+
+        const sl = rl.scopeLogs[0];
+        expect(sl.scope).toEqual({ name: '@flareapp/js', version: '2.0.0', attributes: [], droppedAttributesCount: 0 });
+
+        expect(sl.logRecords).toHaveLength(1);
+        expect(sl.logRecords[0]).toEqual({
+            timeUnixNano: '1700000000000000000',
+            observedTimeUnixNano: '1700000000000000000',
+            severityNumber: 9,
+            severityText: 'INFO',
+            body: { stringValue: 'hello' },
+            attributes: [{ key: 'http.request.method', value: { stringValue: 'GET' } }],
+            flags: 0,
+            droppedAttributesCount: 0,
+        });
+    });
+});

--- a/packages/core/tests/logEnvelope.test.ts
+++ b/packages/core/tests/logEnvelope.test.ts
@@ -8,7 +8,7 @@ const record: BufferedLog = {
     severityNumber: 9,
     severityText: 'INFO',
     message: 'hello',
-    recordAttributes: { 'http.request.method': 'GET' },
+    recordAttributes: [{ key: 'http.request.method', value: { stringValue: 'GET' } }],
     resourceAttributes: {},
 };
 

--- a/packages/core/tests/logOtel.test.ts
+++ b/packages/core/tests/logOtel.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+
+import { attributesToOpenTelemetry, valueToOpenTelemetry } from '../src/logging/otel';
+
+describe('valueToOpenTelemetry', () => {
+    it('encodes primitives', () => {
+        expect(valueToOpenTelemetry('x')).toEqual({ stringValue: 'x' });
+        expect(valueToOpenTelemetry(true)).toEqual({ boolValue: true });
+        expect(valueToOpenTelemetry(3)).toEqual({ intValue: 3 });
+        expect(valueToOpenTelemetry(3.5)).toEqual({ doubleValue: 3.5 });
+    });
+
+    it('drops null, undefined and non-finite numbers', () => {
+        expect(valueToOpenTelemetry(null)).toBeNull();
+        expect(valueToOpenTelemetry(undefined as never)).toBeNull();
+        expect(valueToOpenTelemetry(NaN)).toBeNull();
+        expect(valueToOpenTelemetry(Infinity)).toBeNull();
+        expect(valueToOpenTelemetry(-Infinity)).toBeNull();
+    });
+
+    it('drops nulls recursively in arrays and objects', () => {
+        expect(valueToOpenTelemetry([1, null, 2])).toEqual({
+            arrayValue: { values: [{ intValue: 1 }, { intValue: 2 }] },
+        });
+        expect(valueToOpenTelemetry({ a: 1, b: null })).toEqual({
+            kvlistValue: { values: [{ key: 'a', value: { intValue: 1 } }] },
+        });
+    });
+
+    it('replaces cyclic references with a [Circular] sentinel without throwing', () => {
+        const cyclic: Record<string, unknown> = { a: 1 };
+        cyclic.self = cyclic;
+        expect(() => valueToOpenTelemetry(cyclic as never)).not.toThrow();
+        const encoded = valueToOpenTelemetry(cyclic as never) as {
+            kvlistValue: { values: Array<{ key: string; value: unknown }> };
+        };
+        const selfEntry = encoded.kvlistValue.values.find((v) => v.key === 'self');
+        expect(selfEntry?.value).toEqual({ stringValue: '[Circular]' });
+    });
+});
+
+describe('attributesToOpenTelemetry', () => {
+    it('maps entries to key/value and drops null-valued entries', () => {
+        expect(attributesToOpenTelemetry({ a: 'x', b: null })).toEqual([{ key: 'a', value: { stringValue: 'x' } }]);
+    });
+});

--- a/packages/core/tests/logPartition.test.ts
+++ b/packages/core/tests/logPartition.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import { partitionAttributes } from '../src/logging/partition';
+
+describe('partitionAttributes', () => {
+    it('routes resource-prefixed keys to resource, everything else to record', () => {
+        const { resource, record } = partitionAttributes({
+            'process.pid': 1,
+            'host.name': 'h',
+            'service.version': '1.0',
+            'http.request.method': 'GET',
+            'enduser.id': '42',
+            'client.address': '1.2.3.4',
+            'user_agent.original': 'UA',
+            'flare.entry_point.type': 'server',
+            'context.custom': { a: 1 },
+        });
+
+        expect(resource).toEqual({
+            'process.pid': 1,
+            'host.name': 'h',
+            'service.version': '1.0',
+        });
+        expect(record).toEqual({
+            'http.request.method': 'GET',
+            'enduser.id': '42',
+            'client.address': '1.2.3.4',
+            'user_agent.original': 'UA',
+            'flare.entry_point.type': 'server',
+            'context.custom': { a: 1 },
+        });
+    });
+
+    it('defaults unknown keys to record level', () => {
+        const { resource, record } = partitionAttributes({ 'something.new': 1 });
+        expect(resource).toEqual({});
+        expect(record).toEqual({ 'something.new': 1 });
+    });
+
+    it('keeps process.uptime record-level despite the process. prefix', () => {
+        const { resource, record } = partitionAttributes({ 'process.pid': 1, 'process.uptime': 12.3 });
+        expect(resource).toEqual({ 'process.pid': 1 });
+        expect(record).toEqual({ 'process.uptime': 12.3 });
+    });
+});

--- a/packages/core/tests/logSeverity.test.ts
+++ b/packages/core/tests/logSeverity.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { isAtOrAboveMinimum, severityNumber, severityText } from '../src/logging/severity';
+
+describe('severity', () => {
+    it('maps each level to the PHP severity number', () => {
+        expect(severityNumber('debug')).toBe(5);
+        expect(severityNumber('info')).toBe(9);
+        expect(severityNumber('notice')).toBe(10);
+        expect(severityNumber('warning')).toBe(13);
+        expect(severityNumber('error')).toBe(17);
+        expect(severityNumber('critical')).toBe(18);
+        expect(severityNumber('alert')).toBe(19);
+        expect(severityNumber('emergency')).toBe(21);
+    });
+
+    it('uppercases the level for severityText', () => {
+        expect(severityText('info')).toBe('INFO');
+        expect(severityText('error')).toBe('ERROR');
+    });
+
+    it('compares min-level with strict >= on severity number', () => {
+        expect(isAtOrAboveMinimum('warning', 'warning')).toBe(true);
+        expect(isAtOrAboveMinimum('error', 'warning')).toBe(true);
+        expect(isAtOrAboveMinimum('info', 'warning')).toBe(false);
+    });
+});

--- a/packages/core/tests/logger.test.ts
+++ b/packages/core/tests/logger.test.ts
@@ -153,7 +153,7 @@ describe('Logger triggers', () => {
         vi.useRealTimers();
     });
 
-    it('teardown drops an over-keepalive record but ships the smaller ones', () => {
+    it('teardown ships the smaller records and retains the over-keepalive one', () => {
         const api = new FakeApi();
         const logger = makeLogger(
             makeConfig({ keepaliveMaxBytes: 2000, logFlushMaxBytes: 1_000_000, logFlushIntervalMs: 999_999 }),
@@ -169,6 +169,31 @@ describe('Logger triggers', () => {
         expect(bodies).toContainEqual({ stringValue: 'small-1' });
         expect(bodies).toContainEqual({ stringValue: 'small-2' });
         expect(bodies.some((b) => 'stringValue' in b && b.stringValue.length > 1000)).toBe(false);
+        // The over-budget record is not dropped — a backgrounded tab may resume.
+        expect(logger.bufferLength()).toBe(1);
+    });
+
+    it('backgrounded tab keeps over-keepalive records and ships them on a later normal flush', () => {
+        const api = new FakeApi();
+        const logger = makeLogger(
+            makeConfig({ keepaliveMaxBytes: 2000, logFlushMaxBytes: 1_000_000, logFlushIntervalMs: 999_999 }),
+            api,
+        );
+        logger.info('x'.repeat(5000)); // > keepaliveMaxBytes, < logFlushMaxBytes
+
+        // visibilitychange:hidden on a backgrounded (not unloading) tab. Nothing fits
+        // the keepalive budget, so no envelope ships and the record must survive.
+        logger.flush({ keepalive: true });
+        expect(api.logEnvelopes).toHaveLength(0);
+        expect(logger.bufferLength()).toBe(1);
+
+        // Tab resumes; a normal flush ships the retained record.
+        logger.flush();
+        expect(api.logEnvelopes).toHaveLength(1);
+        expect(api.lastLogKeepalive).toBe(false);
+        const bodies = api.logEnvelopes[0].resourceLogs[0].scopeLogs[0].logRecords.map((r) => r.body);
+        expect(bodies.some((b) => 'stringValue' in b && b.stringValue.length > 1000)).toBe(true);
+        expect(logger.bufferLength()).toBe(0);
     });
 
     it('teardown envelope stays under keepaliveMaxBytes by actual serialized bytes', () => {

--- a/packages/core/tests/logger.test.ts
+++ b/packages/core/tests/logger.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { Api } from '../src/api';
+import { NoopFlushScheduler } from '../src/logging/FlushScheduler';
+import { Logger } from '../src/logging/Logger';
+import type { Attributes, Config, Framework, SdkInfo } from '../src/types';
+
+function makeConfig(overrides: Partial<Config> = {}): Config {
+    return {
+        key: 'KEY',
+        version: '',
+        sourcemapVersionId: '',
+        stage: '',
+        maxGlowsPerReport: 30,
+        ingestUrl: 'https://ingress.test/v1/errors',
+        reportBrowserExtensionErrors: false,
+        debug: false,
+        urlDenylist: /(?:)/,
+        replaceDefaultUrlDenylist: false,
+        sampleRate: 1,
+        beforeEvaluate: (e) => e,
+        beforeSubmit: (r) => r,
+        enableLogs: true,
+        logsIngestUrl: 'https://ingress.test/v1/logs',
+        maxLogBufferSize: 100,
+        logFlushIntervalMs: 5000,
+        logFlushMaxBytes: 800_000,
+        keepaliveMaxBytes: 60_000,
+        ...overrides,
+    };
+}
+
+function makeLogger(config: Config, api: Api = new Api()) {
+    const sdkInfo: SdkInfo = { name: '@flareapp/core', version: '0.0.0' };
+    const framework: Framework | null = null;
+    return new Logger({
+        api,
+        getConfig: () => config,
+        getSdkInfo: () => sdkInfo,
+        getFramework: () => framework,
+        buildLogAttributes: (userAttributes: Attributes) => ({ record: { ...userAttributes }, resource: {} }),
+        track: (p) => p,
+        scheduler: new NoopFlushScheduler(),
+    });
+}
+
+describe('Logger record/buffer', () => {
+    beforeEach(() => vi.useRealTimers());
+
+    it('does not buffer when enableLogs is false', () => {
+        const logger = makeLogger(makeConfig({ enableLogs: false }));
+        logger.info('hi');
+        expect(logger.bufferLength()).toBe(0);
+    });
+
+    it('drops records below minimumLogLevel', () => {
+        const logger = makeLogger(makeConfig({ minimumLogLevel: 'warning' }));
+        logger.info('low');
+        logger.error('high');
+        expect(logger.bufferLength()).toBe(1);
+    });
+
+    it('drops a single record larger than logFlushMaxBytes at capture', () => {
+        // Cap sits above a minimal record's serialized size (~140B incl. timestamp,
+        // severity, empty attribute maps) but below the 500-char record (~640B), so
+        // only the big one is dropped at capture.
+        const logger = makeLogger(makeConfig({ logFlushMaxBytes: 300, maxLogBufferSize: 100 }));
+        logger.info('x'.repeat(500));
+        expect(logger.bufferLength()).toBe(0);
+        logger.info('ok');
+        expect(logger.bufferLength()).toBe(1);
+    });
+
+    it('trims oldest records past maxLogBufferSize (keyless, so the count-cap flush no-ops)', () => {
+        // With a key, hitting the count cap would flush-and-clear, so the buffer
+        // would never accumulate to the cap. key: null makes flush no-op, so the
+        // hard trim is what bounds the buffer — which is exactly what we assert.
+        const logger = makeLogger(makeConfig({ key: null, maxLogBufferSize: 3, logFlushIntervalMs: 999_999 }));
+        for (let i = 0; i < 10; i++) logger.info(`m${i}`);
+        expect(logger.bufferLength()).toBe(3);
+    });
+});

--- a/packages/core/tests/logger.test.ts
+++ b/packages/core/tests/logger.test.ts
@@ -129,3 +129,106 @@ describe('Logger flush', () => {
         expect(api.logEnvelopes).toHaveLength(0);
     });
 });
+
+describe('Logger triggers', () => {
+    it('flushes when the buffer reaches maxLogBufferSize', () => {
+        const api = new FakeApi();
+        const logger = makeLogger(makeConfig({ maxLogBufferSize: 3, logFlushIntervalMs: 999_999 }), api);
+        logger.info('a');
+        logger.info('b');
+        expect(api.logEnvelopes).toHaveLength(0);
+        logger.info('c');
+        expect(api.logEnvelopes).toHaveLength(1);
+        expect(logger.bufferLength()).toBe(0);
+    });
+
+    it('flushes on the timer', () => {
+        vi.useFakeTimers();
+        const api = new FakeApi();
+        const logger = makeLogger(makeConfig({ logFlushIntervalMs: 5000 }), api);
+        logger.info('a');
+        expect(api.logEnvelopes).toHaveLength(0);
+        vi.advanceTimersByTime(5000);
+        expect(api.logEnvelopes).toHaveLength(1);
+        vi.useRealTimers();
+    });
+
+    it('teardown drops an over-keepalive record but ships the smaller ones', () => {
+        const api = new FakeApi();
+        const logger = makeLogger(
+            makeConfig({ keepaliveMaxBytes: 2000, logFlushMaxBytes: 1_000_000, logFlushIntervalMs: 999_999 }),
+            api,
+        );
+        logger.info('small-1');
+        logger.info('x'.repeat(5000)); // > keepaliveMaxBytes, < logFlushMaxBytes
+        logger.info('small-2');
+        logger.flush({ keepalive: true });
+        expect(api.logEnvelopes).toHaveLength(1);
+        expect(api.lastLogKeepalive).toBe(true);
+        const bodies = api.logEnvelopes[0].resourceLogs[0].scopeLogs[0].logRecords.map((r) => r.body);
+        expect(bodies).toContainEqual({ stringValue: 'small-1' });
+        expect(bodies).toContainEqual({ stringValue: 'small-2' });
+        expect(bodies.some((b) => 'stringValue' in b && b.stringValue.length > 1000)).toBe(false);
+    });
+
+    it('teardown envelope stays under keepaliveMaxBytes by actual serialized bytes', () => {
+        const api = new FakeApi();
+        const config = makeConfig({
+            keepaliveMaxBytes: 1500,
+            logFlushMaxBytes: 1_000_000,
+            logFlushIntervalMs: 999_999,
+        });
+        const logger = makeLogger(config, api);
+        for (let i = 0; i < 30; i++) logger.info('x'.repeat(200)); // each ~200B; 30 would blow 1500B
+        logger.flush({ keepalive: true });
+        expect(api.logEnvelopes).toHaveLength(1);
+        const serialized = new TextEncoder().encode(JSON.stringify(api.logEnvelopes[0])).length;
+        expect(serialized).toBeLessThanOrEqual(1500);
+    });
+
+    it('weight cap flushes-and-clears with a key (ships, does not trim away)', () => {
+        const api = new FakeApi();
+        // logFlushMaxBytes chosen so a SINGLE record stays under it (no oversized
+        // drop at capture), but TWO cross it — so the 2nd push fires the weight
+        // trigger. Each ~250-char message serializes to ~380B incl. envelope keys.
+        const logger = makeLogger(
+            makeConfig({ logFlushMaxBytes: 700, maxLogBufferSize: 100, logFlushIntervalMs: 999_999 }),
+            api,
+        );
+        logger.info('x'.repeat(250));
+        logger.info('y'.repeat(250));
+        expect(api.logEnvelopes.length).toBeGreaterThanOrEqual(1);
+        expect(logger.bufferLength()).toBe(0); // shipped, not silently trimmed
+    });
+
+    it('clear() resets the timer so a later record re-arms it', () => {
+        vi.useFakeTimers();
+        const api = new FakeApi();
+        const logger = makeLogger(makeConfig({ logFlushIntervalMs: 5000 }), api);
+        logger.info('a'); // arms the timer
+        logger.clear(); // disable transition clears buffer + timer flag
+        logger.info('b'); // must re-arm
+        vi.advanceTimersByTime(5000);
+        expect(api.logEnvelopes).toHaveLength(1); // the re-armed timer fired
+        vi.useRealTimers();
+    });
+
+    it('reads SDK identity lazily at flush (not snapshotted at construction)', () => {
+        const api = new FakeApi();
+        const sdkInfo = { name: '@flareapp/core', version: '0.0.0' };
+        const config = makeConfig({ logFlushIntervalMs: 999_999 });
+        const logger = new Logger({
+            api,
+            getConfig: () => config,
+            getSdkInfo: () => sdkInfo,
+            getFramework: () => null,
+            buildLogAttributes: (u) => ({ record: { ...u }, resource: {} }),
+            track: (p) => p,
+            scheduler: new NoopFlushScheduler(),
+        });
+        logger.info('a');
+        sdkInfo.name = '@flareapp/js'; // changes after construction (mirrors setSdkInfo)
+        logger.flush();
+        expect(api.logEnvelopes[0].resourceLogs[0].scopeLogs[0].scope.name).toBe('@flareapp/js');
+    });
+});

--- a/packages/core/tests/logger.test.ts
+++ b/packages/core/tests/logger.test.ts
@@ -4,6 +4,7 @@ import { Api } from '../src/api';
 import { NoopFlushScheduler } from '../src/logging/FlushScheduler';
 import { Logger } from '../src/logging/Logger';
 import type { Attributes, Config, Framework, SdkInfo } from '../src/types';
+import { FakeApi } from './helpers/FakeApi';
 
 function makeConfig(overrides: Partial<Config> = {}): Config {
     return {
@@ -78,5 +79,53 @@ describe('Logger record/buffer', () => {
         const logger = makeLogger(makeConfig({ key: null, maxLogBufferSize: 3, logFlushIntervalMs: 999_999 }));
         for (let i = 0; i < 10; i++) logger.info(`m${i}`);
         expect(logger.bufferLength()).toBe(3);
+    });
+});
+
+describe('Logger flush', () => {
+    it('sends a buffered log to /v1/logs with the key', () => {
+        const api = new FakeApi();
+        const logger = makeLogger(makeConfig({ logFlushIntervalMs: 999_999 }), api);
+        logger.info('hello');
+        logger.flush();
+        expect(api.logEnvelopes).toHaveLength(1);
+        expect(api.lastLogUrl).toBe('https://ingress.test/v1/logs');
+        expect(api.lastLogKey).toBe('KEY');
+        const rec = api.logEnvelopes[0].resourceLogs[0].scopeLogs[0].logRecords[0];
+        expect(rec.body).toEqual({ stringValue: 'hello' });
+    });
+
+    it('does not send when there is no key, but retains the buffer', () => {
+        const api = new FakeApi();
+        const logger = makeLogger(makeConfig({ key: null, logFlushIntervalMs: 999_999 }), api);
+        logger.info('hello');
+        logger.flush();
+        expect(api.logEnvelopes).toHaveLength(0);
+        expect(logger.bufferLength()).toBe(1);
+    });
+
+    it('emits identity resource attributes', () => {
+        const api = new FakeApi();
+        const logger = makeLogger(
+            makeConfig({ serviceName: 'svc', version: '1.2.3', logFlushIntervalMs: 999_999 }),
+            api,
+        );
+        logger.info('hello');
+        logger.flush();
+        const attrs = api.logEnvelopes[0].resourceLogs[0].resource.attributes;
+        const byKey = Object.fromEntries(attrs.map((a) => [a.key, a.value]));
+        expect(byKey['service.name']).toEqual({ stringValue: 'svc' });
+        expect(byKey['service.version']).toEqual({ stringValue: '1.2.3' });
+        expect(byKey['telemetry.sdk.name']).toEqual({ stringValue: '@flareapp/core' });
+    });
+
+    it('clears the buffer on clear()', () => {
+        const api = new FakeApi();
+        const logger = makeLogger(makeConfig({ logFlushIntervalMs: 999_999 }), api);
+        logger.info('hello');
+        logger.clear();
+        expect(logger.bufferLength()).toBe(0);
+        logger.flush();
+        expect(api.logEnvelopes).toHaveLength(0);
     });
 });

--- a/packages/core/tests/loggerFlare.test.ts
+++ b/packages/core/tests/loggerFlare.test.ts
@@ -104,4 +104,22 @@ describe('Flare logging integration', () => {
         expect(customOf(0)).toEqual({ stringValue: 'v1' });
         expect(customOf(1)).toEqual({ stringValue: 'v2' });
     });
+
+    it('freezes nested attribute values at capture (mutation after info() does not change the buffered log)', () => {
+        const api = new FakeApi();
+        const flare = new Flare(api);
+        flare.light('KEY');
+        flare.configure({ enableLogs: true, logFlushIntervalMs: 999_999 });
+
+        const nested = { count: 1 };
+        flare.logger.info('x', { 'context.scenario': nested });
+        nested.count = 999; // mutate AFTER capture, BEFORE flush
+        flare.logger.flush();
+
+        const attrs = api.logEnvelopes[0].resourceLogs[0].scopeLogs[0].logRecords[0].attributes;
+        const scenario = attrs.find((a) => a.key === 'context.scenario');
+        // must still reflect the value at capture time (1), not the mutated 999
+        expect(JSON.stringify(scenario?.value)).toContain('1');
+        expect(JSON.stringify(scenario?.value)).not.toContain('999');
+    });
 });

--- a/packages/core/tests/loggerFlare.test.ts
+++ b/packages/core/tests/loggerFlare.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+
+import { Flare } from '../src/Flare';
+import { FakeApi } from './helpers/FakeApi';
+
+describe('Flare logging integration', () => {
+    it('exposes flare.logger and ships logs through configure/flush', async () => {
+        const api = new FakeApi();
+        const flare = new Flare(api);
+        flare.light('KEY');
+        flare.configure({ enableLogs: true, logFlushIntervalMs: 999_999 });
+
+        flare.logger.info('hello', { foo: 'bar' });
+        expect(api.logEnvelopes).toHaveLength(0);
+
+        await flare.flush();
+        expect(api.logEnvelopes).toHaveLength(1);
+        const rec = api.logEnvelopes[0].resourceLogs[0].scopeLogs[0].logRecords[0];
+        expect(rec.body).toEqual({ stringValue: 'hello' });
+        expect(rec.attributes).toContainEqual({ key: 'foo', value: { stringValue: 'bar' } });
+    });
+
+    it('keeps a user-supplied resource-prefixed attribute on the record, not the shared resource', () => {
+        const api = new FakeApi();
+        const flare = new Flare(api);
+        flare.light('KEY');
+        flare.configure({ enableLogs: true, logFlushIntervalMs: 999_999 });
+
+        flare.logger.info('hello', { 'service.name': 'user-supplied' });
+        flare.logger.flush();
+
+        const rl = api.logEnvelopes[0].resourceLogs[0];
+        const resourceKeys = rl.resource.attributes.map((a) => a.key);
+        // user 'service.name' must NOT be promoted onto the shared resource
+        expect(rl.resource.attributes).not.toContainEqual({
+            key: 'service.name',
+            value: { stringValue: 'user-supplied' },
+        });
+        // it stays on the record
+        expect(rl.scopeLogs[0].logRecords[0].attributes).toContainEqual({
+            key: 'service.name',
+            value: { stringValue: 'user-supplied' },
+        });
+        void resourceKeys;
+    });
+
+    it('ships a backlog buffered before light() once the key is set', () => {
+        const api = new FakeApi();
+        const flare = new Flare(api);
+        flare.configure({ enableLogs: true, logFlushIntervalMs: 999_999 });
+        flare.logger.info('queued');
+        expect(api.logEnvelopes).toHaveLength(0); // no key yet
+
+        flare.light('KEY');
+        expect(api.logEnvelopes).toHaveLength(1);
+    });
+
+    it('clears the buffer and never sends when logs are disabled', () => {
+        const api = new FakeApi();
+        const flare = new Flare(api);
+        flare.light('KEY');
+        flare.configure({ enableLogs: true, logFlushIntervalMs: 999_999 });
+        flare.logger.info('a');
+        flare.configure({ enableLogs: false });
+        flare.logger.flush();
+        expect(api.logEnvelopes).toHaveLength(0);
+    });
+
+    it('deep-merges scope and user context.custom without clobbering addContext data', () => {
+        const api = new FakeApi();
+        const flare = new Flare(api);
+        flare.light('KEY');
+        flare.configure({ enableLogs: true, logFlushIntervalMs: 999_999 });
+        flare.addContext('fromScope', 1);
+        flare.logger.info('x', { 'context.custom': { fromUser: 2 } });
+        flare.logger.flush();
+
+        const attrs = api.logEnvelopes[0].resourceLogs[0].scopeLogs[0].logRecords[0].attributes;
+        const custom = attrs.find((a) => a.key === 'context.custom');
+        const values = (custom!.value as { kvlistValue: { values: Array<{ key: string }> } }).kvlistValue.values.map(
+            (v) => v.key,
+        );
+        expect(values).toContain('fromScope');
+        expect(values).toContain('fromUser');
+    });
+
+    it('freezes per-record attributes at capture time', () => {
+        const api = new FakeApi();
+        const flare = new Flare(api);
+        flare.light('KEY');
+        flare.configure({ enableLogs: true, logFlushIntervalMs: 999_999 });
+
+        flare.addContext('k', 'v1');
+        flare.logger.info('first');
+        flare.addContext('k', 'v2');
+        flare.logger.info('second');
+        flare.logger.flush();
+
+        const records = api.logEnvelopes[0].resourceLogs[0].scopeLogs[0].logRecords;
+        const customOf = (i: number) =>
+            (
+                records[i].attributes.find((a) => a.key === 'context.custom')!.value as {
+                    kvlistValue: { values: Array<{ key: string; value: { stringValue?: string } }> };
+                }
+            ).kvlistValue.values.find((v) => v.key === 'k')?.value;
+        expect(customOf(0)).toEqual({ stringValue: 'v1' });
+        expect(customOf(1)).toEqual({ stringValue: 'v2' });
+    });
+});

--- a/packages/core/tests/loggerFlare.test.ts
+++ b/packages/core/tests/loggerFlare.test.ts
@@ -10,14 +10,51 @@ describe('Flare logging integration', () => {
         flare.light('KEY');
         flare.configure({ enableLogs: true, logFlushIntervalMs: 999_999 });
 
-        flare.logger.info('hello', { foo: 'bar' });
+        flare.logger.info('hello');
         expect(api.logEnvelopes).toHaveLength(0);
 
         await flare.flush();
         expect(api.logEnvelopes).toHaveLength(1);
         const rec = api.logEnvelopes[0].resourceLogs[0].scopeLogs[0].logRecords[0];
         expect(rec.body).toEqual({ stringValue: 'hello' });
-        expect(rec.attributes).toContainEqual({ key: 'foo', value: { stringValue: 'bar' } });
+    });
+
+    it('nests the second argument under log.context (PHP-style context)', () => {
+        const api = new FakeApi();
+        const flare = new Flare(api);
+        flare.light('KEY');
+        flare.configure({ enableLogs: true, logFlushIntervalMs: 999_999 });
+
+        flare.logger.info('checkout', { cartId: 'cart_8f21', total: 49.95 });
+        flare.logger.flush();
+
+        const attrs = api.logEnvelopes[0].resourceLogs[0].scopeLogs[0].logRecords[0].attributes;
+        const ctx = attrs.find((a) => a.key === 'log.context');
+        expect(ctx).toBeDefined();
+        const keys = (ctx!.value as { kvlistValue: { values: Array<{ key: string }> } }).kvlistValue.values.map(
+            (v) => v.key,
+        );
+        expect(keys).toContain('cartId');
+        expect(keys).toContain('total');
+        // The context keys must NOT leak to the top level of the record.
+        expect(attrs.find((a) => a.key === 'cartId')).toBeUndefined();
+    });
+
+    it('passes the third argument through as raw record attributes (advanced)', () => {
+        const api = new FakeApi();
+        const flare = new Flare(api);
+        flare.light('KEY');
+        flare.configure({ enableLogs: true, logFlushIntervalMs: 999_999 });
+
+        flare.logger.info('msg', {}, { 'service.name': 'user-supplied' });
+        flare.logger.flush();
+
+        const rl = api.logEnvelopes[0].resourceLogs[0];
+        // raw attributes land flat on the record, with the same partitioning rules
+        expect(rl.scopeLogs[0].logRecords[0].attributes).toContainEqual({
+            key: 'service.name',
+            value: { stringValue: 'user-supplied' },
+        });
     });
 
     it('keeps a user-supplied resource-prefixed attribute on the record, not the shared resource', () => {
@@ -26,7 +63,7 @@ describe('Flare logging integration', () => {
         flare.light('KEY');
         flare.configure({ enableLogs: true, logFlushIntervalMs: 999_999 });
 
-        flare.logger.info('hello', { 'service.name': 'user-supplied' });
+        flare.logger.info('hello', {}, { 'service.name': 'user-supplied' });
         flare.logger.flush();
 
         const rl = api.logEnvelopes[0].resourceLogs[0];
@@ -70,7 +107,7 @@ describe('Flare logging integration', () => {
         flare.light('KEY');
         flare.configure({ enableLogs: true, logFlushIntervalMs: 999_999 });
         flare.addContext('fromScope', 1);
-        flare.logger.info('x', { 'context.custom': { fromUser: 2 } });
+        flare.logger.info('x', {}, { 'context.custom': { fromUser: 2 } });
         flare.logger.flush();
 
         const attrs = api.logEnvelopes[0].resourceLogs[0].scopeLogs[0].logRecords[0].attributes;
@@ -112,7 +149,7 @@ describe('Flare logging integration', () => {
         flare.configure({ enableLogs: true, logFlushIntervalMs: 999_999 });
 
         const nested = { count: 1 };
-        flare.logger.info('x', { 'context.scenario': nested });
+        flare.logger.info('x', {}, { 'context.scenario': nested });
         nested.count = 999; // mutate AFTER capture, BEFORE flush
         flare.logger.flush();
 

--- a/packages/core/tests/loggerFlare.test.ts
+++ b/packages/core/tests/loggerFlare.test.ts
@@ -30,7 +30,6 @@ describe('Flare logging integration', () => {
         flare.logger.flush();
 
         const rl = api.logEnvelopes[0].resourceLogs[0];
-        const resourceKeys = rl.resource.attributes.map((a) => a.key);
         // user 'service.name' must NOT be promoted onto the shared resource
         expect(rl.resource.attributes).not.toContainEqual({
             key: 'service.name',
@@ -41,7 +40,6 @@ describe('Flare logging integration', () => {
             key: 'service.name',
             value: { stringValue: 'user-supplied' },
         });
-        void resourceKeys;
     });
 
     it('ships a backlog buffered before light() once the key is set', () => {

--- a/packages/js/src/browser/BrowserFlushScheduler.ts
+++ b/packages/js/src/browser/BrowserFlushScheduler.ts
@@ -1,0 +1,12 @@
+import type { FlushFn, FlushScheduler } from '@flareapp/core';
+
+export class BrowserFlushScheduler implements FlushScheduler {
+    register(flush: FlushFn): void {
+        if (typeof document === 'undefined' || !document) return;
+        document.addEventListener('visibilitychange', () => {
+            if (document.visibilityState === 'hidden') {
+                flush({ keepalive: true });
+            }
+        });
+    }
+}

--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -8,6 +8,7 @@ import {
 } from '@flareapp/core';
 
 import { catchWindowErrors } from './browser';
+import { BrowserFlushScheduler } from './browser/BrowserFlushScheduler';
 import { collectBrowser } from './browser/context/collectBrowser';
 import { FetchFileReader } from './browser/FetchFileReader';
 import { CLIENT_VERSION } from './env';
@@ -19,7 +20,7 @@ export class Flare extends CoreFlare {
         fileReader: FileReader = new FetchFileReader(),
         scopeProvider: ScopeProvider = new GlobalScopeProvider(),
     ) {
-        super(api, contextCollector, fileReader, scopeProvider);
+        super(api, contextCollector, fileReader, scopeProvider, new BrowserFlushScheduler());
         this.setSdkInfo({ name: '@flareapp/js', version: CLIENT_VERSION });
     }
 }
@@ -32,7 +33,7 @@ if (typeof window !== 'undefined' && window) {
     catchWindowErrors();
 }
 
-export { Scope, GlobalScopeProvider, NullFileReader } from '@flareapp/core';
+export { Logger, Scope, GlobalScopeProvider, NullFileReader } from '@flareapp/core';
 export type {
     AttributeValue,
     Attributes,
@@ -40,6 +41,8 @@ export type {
     ContextCollector,
     EntryPointHandler,
     FileReader,
+    FlushFn,
+    FlushScheduler,
     Framework,
     Glow,
     MessageLevel,

--- a/packages/js/tests/browserFlushScheduler.test.ts
+++ b/packages/js/tests/browserFlushScheduler.test.ts
@@ -1,0 +1,23 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { BrowserFlushScheduler } from '../src/browser/BrowserFlushScheduler';
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('BrowserFlushScheduler', () => {
+    it('flushes with keepalive when the document becomes hidden', () => {
+        const listeners: Record<string, () => void> = {};
+        vi.stubGlobal('document', {
+            addEventListener: (type: string, cb: () => void) => {
+                listeners[type] = cb;
+            },
+            visibilityState: 'hidden',
+        });
+
+        const flush = vi.fn();
+        new BrowserFlushScheduler().register(flush);
+        listeners['visibilitychange']();
+
+        expect(flush).toHaveBeenCalledWith({ keepalive: true });
+    });
+});

--- a/packages/node/src/Flare.ts
+++ b/packages/node/src/Flare.ts
@@ -3,6 +3,7 @@ import { Api, Flare as CoreFlare } from '@flareapp/core';
 import { DEFAULT_BODY_CONTENT_TYPES, DEFAULT_BODY_KEY_DENYLIST } from './context/body';
 import { makeNodeContextCollector } from './context/collectNode';
 import { DEFAULT_HEADER_DENYLIST, resolveHeaderDenylist } from './context/headers';
+import { NodeFlushScheduler } from './logging/NodeFlushScheduler';
 import { buildFatalCallbacks } from './process/fatal';
 import { ProcessHandlerManager } from './process/handlers';
 import { AsyncLocalStorageScopeProvider } from './scope/AsyncLocalStorageScopeProvider';
@@ -76,7 +77,7 @@ export class NodeFlare extends CoreFlare {
         // value) so subsequent `configureNode(...)` calls take effect on
         // future reports without reinjecting the collector.
         const collector = makeNodeContextCollector(scopeProvider, () => this.nodeOptions);
-        super(new Api(), collector, new DiskFileReader(), scopeProvider);
+        super(new Api(), collector, new DiskFileReader(), scopeProvider, new NodeFlushScheduler());
         this.nodeScopeProvider = scopeProvider;
         this.setSdkInfo({ name: NODE_SDK_NAME, version: NODE_SDK_VERSION });
 

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -4,7 +4,7 @@ export const flare = new NodeFlare();
 
 export { NodeFlare } from './Flare';
 export type { RequestContext, User, FatalMode, NodeOptions } from './types';
-export { Flare, Scope, GlobalScopeProvider, NullFileReader } from '@flareapp/core';
+export { Flare, Logger, Scope, GlobalScopeProvider, NullFileReader } from '@flareapp/core';
 export type {
     AttributeValue,
     Attributes,
@@ -12,6 +12,8 @@ export type {
     ContextCollector,
     EntryPointHandler,
     FileReader,
+    FlushFn,
+    FlushScheduler,
     Framework,
     Glow,
     MessageLevel,

--- a/packages/node/src/logging/NodeFlushScheduler.ts
+++ b/packages/node/src/logging/NodeFlushScheduler.ts
@@ -1,0 +1,7 @@
+import type { FlushFn, FlushScheduler } from '@flareapp/core';
+
+export class NodeFlushScheduler implements FlushScheduler {
+    register(flush: FlushFn): void {
+        process.on('beforeExit', () => flush());
+    }
+}

--- a/packages/node/tests/nodeFlushScheduler.test.ts
+++ b/packages/node/tests/nodeFlushScheduler.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { NodeFlushScheduler } from '../src/logging/NodeFlushScheduler';
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('NodeFlushScheduler', () => {
+    it('flushes on process beforeExit', () => {
+        const handlers: Array<() => void> = [];
+        const onSpy = vi.spyOn(process, 'on').mockImplementation(((event: string, cb: () => void) => {
+            if (event === 'beforeExit') handlers.push(cb);
+            return process;
+        }) as typeof process.on);
+
+        const flush = vi.fn();
+        new NodeFlushScheduler().register(flush);
+        handlers.forEach((h) => h());
+
+        expect(onSpy).toHaveBeenCalledWith('beforeExit', expect.any(Function));
+        expect(flush).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/node/tests/nodeLogContext.test.ts
+++ b/packages/node/tests/nodeLogContext.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { NodeFlare } from '../src/Flare';
+
+describe('Node log request context', () => {
+    it('captures request attributes into a log recorded inside runWithContext', async () => {
+        const flare = new NodeFlare();
+        flare.light('KEY');
+        flare.configure({ enableLogs: true, logFlushIntervalMs: 999_999 });
+
+        const logsSpy = vi.spyOn(flare.api, 'logs').mockResolvedValue();
+
+        // runWithContext(request: RequestContext, fn) — RequestContext fields are
+        // top-level (packages/node/src/types.ts: method/path/headers).
+        await flare.runWithContext({ method: 'GET', path: '/cart', headers: {} }, async () => {
+            flare.logger.info('in request');
+        });
+        flare.logger.flush();
+
+        expect(logsSpy).toHaveBeenCalledTimes(1);
+        const envelope = logsSpy.mock.calls[0][0];
+        const attrs = envelope.resourceLogs[0].scopeLogs[0].logRecords[0].attributes;
+        const byKey = Object.fromEntries(attrs.map((a) => [a.key, a.value]));
+        expect(byKey['http.request.method']).toEqual({ stringValue: 'GET' });
+    });
+});

--- a/playgrounds/js/src/flare.ts
+++ b/playgrounds/js/src/flare.ts
@@ -33,6 +33,10 @@ export const initFlare = (): void => {
     });
 
     flare.light(key, true);
+
+    // Expose the instance so the e2e suite can drive the logger directly (e.g. lower
+    // keepaliveMaxBytes and simulate visibilitychange:hidden). Playground-only.
+    (globalThis as { __flare?: typeof flare }).__flare = flare;
 };
 
 export { flare };

--- a/playgrounds/js/src/flare.ts
+++ b/playgrounds/js/src/flare.ts
@@ -8,11 +8,15 @@ export const initFlare = (): void => {
         flare.configure({
             ingestUrl: url,
             logsIngestUrl: url.replace('/api/reports', '/api/logs'),
-            enableLogs: true,
         });
     }
 
     flare.configure({
+        // Logging is always on in the playground so the log buttons exercise the
+        // SDK even without a fake server (manual runs POST to the default ingest
+        // and fail like the error reports do). The fake-server logsIngestUrl
+        // override above only applies under e2e (VITE_FLARE_URL set).
+        enableLogs: true,
         beforeEvaluate: (error) => {
             if (error.message === 'hook-drop-report') return null;
             return error;

--- a/playgrounds/js/src/flare.ts
+++ b/playgrounds/js/src/flare.ts
@@ -5,7 +5,11 @@ export const initFlare = (): void => {
     const key = import.meta.env.VITE_FLARE_KEY ?? 'test-key-js';
 
     if (url) {
-        flare.configure({ ingestUrl: url });
+        flare.configure({
+            ingestUrl: url,
+            logsIngestUrl: url.replace('/api/reports', '/api/logs'),
+            enableLogs: true,
+        });
     }
 
     flare.configure({

--- a/playgrounds/js/src/pages/broken.ts
+++ b/playgrounds/js/src/pages/broken.ts
@@ -1,4 +1,4 @@
-import { coverageFor } from '@flareapp/playgrounds-shared';
+import { coverageFor, fireLogScenario, logCoverageFor, logScenarioById, testIds } from '@flareapp/playgrounds-shared';
 
 import { flare } from '../flare';
 import { renderLayout } from '../layout';
@@ -42,6 +42,18 @@ const triggers: Record<string, () => void | Promise<void>> = {
 export const renderBroken: RouteHandler = (_match, root) => {
     const scenarios = coverageFor('js');
 
+    const logScenarios = logCoverageFor('js');
+    const logButtons = logScenarios
+        .map(
+            (scenario) => `
+            <button data-log-scenario="${scenario.id}" data-testid="${testIds.logTrigger(scenario.id)}" class="rounded-lg border border-surface-border bg-surface px-4 py-3 text-left text-sm hover:border-brand">
+                <div class="font-medium">${scenario.label}</div>
+                <div class="text-xs opacity-60 font-mono">${scenario.id}</div>
+            </button>
+        `,
+        )
+        .join('');
+
     const buttons = scenarios
         .map(
             (scenario) => `
@@ -59,9 +71,9 @@ export const renderBroken: RouteHandler = (_match, root) => {
             <h1 class="text-xl font-semibold mb-2">Error playground</h1>
             <p class="text-sm opacity-70 mb-6">Each button triggers a deterministic error scenario.</p>
             <div class="grid grid-cols-1 md:grid-cols-2 gap-3">${buttons}</div>
-            <button data-testid="trigger-log" class="mt-4 rounded-lg border border-surface-border bg-surface px-4 py-3 text-sm hover:border-brand">
-                Record a log
-            </button>
+            <h2 class="text-lg font-semibold mt-8 mb-2">Logging</h2>
+            <p class="text-sm opacity-70 mb-4">Each button records one or more structured logs.</p>
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-3">${logButtons}</div>
         </section>`,
     );
 
@@ -74,7 +86,10 @@ export const renderBroken: RouteHandler = (_match, root) => {
         });
     });
 
-    root.querySelector<HTMLButtonElement>('[data-testid="trigger-log"]')?.addEventListener('click', () => {
-        flare.logger.info('e2e-unload-log', { 'context.scenario': { source: 'logger' } });
+    root.querySelectorAll<HTMLButtonElement>('button[data-log-scenario]').forEach((button) => {
+        button.addEventListener('click', () => {
+            const scenario = logScenarioById(button.dataset.logScenario ?? '');
+            if (scenario) fireLogScenario(flare, scenario);
+        });
     });
 };

--- a/playgrounds/js/src/pages/broken.ts
+++ b/playgrounds/js/src/pages/broken.ts
@@ -59,6 +59,9 @@ export const renderBroken: RouteHandler = (_match, root) => {
             <h1 class="text-xl font-semibold mb-2">Error playground</h1>
             <p class="text-sm opacity-70 mb-6">Each button triggers a deterministic error scenario.</p>
             <div class="grid grid-cols-1 md:grid-cols-2 gap-3">${buttons}</div>
+            <button data-testid="trigger-log" class="mt-4 rounded-lg border border-surface-border bg-surface px-4 py-3 text-sm hover:border-brand">
+                Record a log
+            </button>
         </section>`,
     );
 
@@ -69,5 +72,9 @@ export const renderBroken: RouteHandler = (_match, root) => {
             if (!trigger) return;
             void trigger();
         });
+    });
+
+    root.querySelector<HTMLButtonElement>('[data-testid="trigger-log"]')?.addEventListener('click', () => {
+        flare.logger.info('e2e-unload-log', { 'context.scenario': { source: 'logger' } });
     });
 };

--- a/playgrounds/react/src/flare.ts
+++ b/playgrounds/react/src/flare.ts
@@ -5,7 +5,11 @@ export const initFlare = (): void => {
     const key = import.meta.env.VITE_FLARE_KEY ?? 'test-key-react';
 
     if (url) {
-        flare.configure({ ingestUrl: url });
+        flare.configure({
+            ingestUrl: url,
+            logsIngestUrl: url.replace('/api/reports', '/api/logs'),
+            enableLogs: true,
+        });
     }
 
     flare.configure({

--- a/playgrounds/react/src/flare.ts
+++ b/playgrounds/react/src/flare.ts
@@ -8,11 +8,15 @@ export const initFlare = (): void => {
         flare.configure({
             ingestUrl: url,
             logsIngestUrl: url.replace('/api/reports', '/api/logs'),
-            enableLogs: true,
         });
     }
 
     flare.configure({
+        // Logging is always on in the playground so the log buttons exercise the
+        // SDK even without a fake server (manual runs POST to the default ingest
+        // and fail like the error reports do). The fake-server logsIngestUrl
+        // override above only applies under e2e (VITE_FLARE_URL set).
+        enableLogs: true,
         beforeEvaluate: (error) => {
             if (error.message === 'hook-drop-report') return null;
             return error;

--- a/playgrounds/react/src/routes/broken.tsx
+++ b/playgrounds/react/src/routes/broken.tsx
@@ -1,4 +1,4 @@
-import { coverageFor, testIds } from '@flareapp/playgrounds-shared';
+import { coverageFor, fireLogScenario, logCoverageFor, testIds } from '@flareapp/playgrounds-shared';
 import { createRoute } from '@tanstack/react-router';
 import { useState } from 'react';
 
@@ -51,6 +51,7 @@ const eventTriggers: Record<string, () => void | Promise<void>> = {
 
 const BrokenPage = () => {
     const scenarios = coverageFor('react');
+    const logScenarios = logCoverageFor('react');
     const [renderTrigger, setRenderTrigger] = useState<RenderTrigger>(null);
 
     const onClick = (id: string) => {
@@ -74,6 +75,22 @@ const BrokenPage = () => {
                         type="button"
                         data-testid={testIds.brokenTrigger(scenario.id)}
                         onClick={() => onClick(scenario.id)}
+                        className="rounded-lg border border-surface-border bg-surface px-4 py-3 text-left text-sm hover:border-brand"
+                    >
+                        <div className="font-medium">{scenario.label}</div>
+                        <div className="text-xs opacity-60 font-mono">{scenario.id}</div>
+                    </button>
+                ))}
+            </div>
+            <h2 className="text-lg font-semibold mt-8 mb-2">Logging</h2>
+            <p className="text-sm opacity-70 mb-4">Each button records one or more structured logs.</p>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                {logScenarios.map((scenario) => (
+                    <button
+                        key={scenario.id}
+                        type="button"
+                        data-testid={testIds.logTrigger(scenario.id)}
+                        onClick={() => fireLogScenario(flare, scenario)}
                         className="rounded-lg border border-surface-border bg-surface px-4 py-3 text-left text-sm hover:border-brand"
                     >
                         <div className="font-medium">{scenario.label}</div>

--- a/playgrounds/shared/src/coverage.ts
+++ b/playgrounds/shared/src/coverage.ts
@@ -1,5 +1,6 @@
 import type { ErrorScenario } from './errorScenarios';
 import { errorScenarios } from './errorScenarios';
+import { logScenarios, type LogScenario } from './logScenarios';
 
 export type Framework = 'js' | 'react' | 'vue' | 'svelte';
 
@@ -15,3 +16,13 @@ export const coverageFor = (framework: Framework): ErrorScenario[] =>
 
 export const supportsScenario = (framework: Framework, scenarioId: string): boolean =>
     !exclude[framework].includes(scenarioId);
+
+const excludeLogs: Record<Framework, string[]> = {
+    js: [],
+    react: ['log-unload'],
+    vue: ['log-unload'],
+    svelte: ['log-unload'],
+};
+
+export const logCoverageFor = (framework: Framework): LogScenario[] =>
+    logScenarios.filter((s) => !excludeLogs[framework].includes(s.id));

--- a/playgrounds/shared/src/index.ts
+++ b/playgrounds/shared/src/index.ts
@@ -4,3 +4,5 @@ export * from './errorScenarios';
 export * from './coverage';
 export * from './testIds';
 export * from './unsplash';
+export * from './logScenarios';
+export * from './logTrigger';

--- a/playgrounds/shared/src/logScenarios.ts
+++ b/playgrounds/shared/src/logScenarios.ts
@@ -1,0 +1,70 @@
+export type LogLevel = 'debug' | 'info' | 'notice' | 'warning' | 'error' | 'critical' | 'alert' | 'emergency';
+
+// Structurally identical to @flareapp/core's `AttributeValue`, redefined here so
+// `playgrounds/shared` stays dependency-free. Because it is structurally the same,
+// `Record<string, LogAttributeValue>` is assignable to the SDK's `Attributes`, so
+// these attributes pass straight to `flare.logger.*` under strict TypeScript.
+export type LogAttributeValue =
+    | string
+    | number
+    | boolean
+    | null
+    | LogAttributeValue[]
+    | { [key: string]: LogAttributeValue };
+
+export type LogScenario = {
+    id: string;
+    label: string;
+    level: LogLevel;
+    message: string;
+    attributes?: Record<string, LogAttributeValue>;
+    count: number;
+    flushOnTrigger: boolean;
+};
+
+export const logScenarios: LogScenario[] = [
+    { id: 'log-info', label: 'Log info', level: 'info', message: 'playground-info', count: 1, flushOnTrigger: true },
+    {
+        id: 'log-warning',
+        label: 'Log warning',
+        level: 'warning',
+        message: 'playground-warning',
+        count: 1,
+        flushOnTrigger: true,
+    },
+    {
+        id: 'log-error',
+        label: 'Log error',
+        level: 'error',
+        message: 'playground-error',
+        count: 1,
+        flushOnTrigger: true,
+    },
+    {
+        id: 'log-context',
+        label: 'Log info with context',
+        level: 'info',
+        message: 'playground-context',
+        count: 1,
+        flushOnTrigger: true,
+        attributes: { 'context.scenario': { source: 'logger', userId: 'usr_42' } },
+    },
+    {
+        id: 'log-burst',
+        label: 'Log burst (5)',
+        level: 'info',
+        message: 'playground-burst',
+        count: 5,
+        flushOnTrigger: true,
+    },
+    {
+        id: 'log-unload',
+        label: 'Log then unload',
+        level: 'info',
+        message: 'e2e-unload-log',
+        count: 1,
+        flushOnTrigger: false,
+    },
+];
+
+export const logScenarioById = (id: string): LogScenario | undefined => logScenarios.find((s) => s.id === id);

--- a/playgrounds/shared/src/logScenarios.ts
+++ b/playgrounds/shared/src/logScenarios.ts
@@ -17,7 +17,7 @@ export type LogScenario = {
     label: string;
     level: LogLevel;
     message: string;
-    attributes?: Record<string, LogAttributeValue>;
+    context?: Record<string, LogAttributeValue>;
     count: number;
     flushOnTrigger: boolean;
 };
@@ -47,7 +47,7 @@ export const logScenarios: LogScenario[] = [
         message: 'playground-context',
         count: 1,
         flushOnTrigger: true,
-        attributes: { 'context.scenario': { source: 'logger', userId: 'usr_42' } },
+        context: { 'context.scenario': { source: 'logger', userId: 'usr_42' } },
     },
     {
         id: 'log-burst',

--- a/playgrounds/shared/src/logTrigger.ts
+++ b/playgrounds/shared/src/logTrigger.ts
@@ -1,0 +1,17 @@
+import type { LogAttributeValue, LogLevel, LogScenario } from './logScenarios';
+
+// Structural type so shared has no @flareapp dependency. The attribute param uses
+// `LogAttributeValue` (not `unknown`) so the real `flare` satisfies this type.
+export type PlaygroundFlare = {
+    logger: Record<LogLevel, (message: string, attributes?: Record<string, LogAttributeValue>) => void>;
+    flush: (timeoutMs?: number) => Promise<void>;
+};
+
+export function fireLogScenario(flare: PlaygroundFlare, scenario: LogScenario): void {
+    for (let i = 0; i < scenario.count; i++) {
+        flare.logger[scenario.level](scenario.message, scenario.attributes);
+    }
+    if (scenario.flushOnTrigger) {
+        void flare.flush();
+    }
+}

--- a/playgrounds/shared/src/logTrigger.ts
+++ b/playgrounds/shared/src/logTrigger.ts
@@ -1,15 +1,15 @@
 import type { LogAttributeValue, LogLevel, LogScenario } from './logScenarios';
 
-// Structural type so shared has no @flareapp dependency. The attribute param uses
+// Structural type so shared has no @flareapp dependency. The context param uses
 // `LogAttributeValue` (not `unknown`) so the real `flare` satisfies this type.
 export type PlaygroundFlare = {
-    logger: Record<LogLevel, (message: string, attributes?: Record<string, LogAttributeValue>) => void>;
+    logger: Record<LogLevel, (message: string, context?: Record<string, LogAttributeValue>) => void>;
     flush: (timeoutMs?: number) => Promise<void>;
 };
 
 export function fireLogScenario(flare: PlaygroundFlare, scenario: LogScenario): void {
     for (let i = 0; i < scenario.count; i++) {
-        flare.logger[scenario.level](scenario.message, scenario.attributes);
+        flare.logger[scenario.level](scenario.message, scenario.context);
     }
     if (scenario.flushOnTrigger) {
         void flare.flush();

--- a/playgrounds/shared/src/testIds.ts
+++ b/playgrounds/shared/src/testIds.ts
@@ -7,6 +7,7 @@ export const testIds = {
     checkoutSubmit: 'checkout-submit',
     confirmation: 'confirmation',
     brokenTrigger: (scenarioId: string) => `trigger-${scenarioId}`,
+    logTrigger: (scenarioId: string) => `log-trigger-${scenarioId}`,
     boundaryFallback: 'boundary-fallback',
     boundaryReset: 'boundary-reset',
 } as const;

--- a/playgrounds/svelte/src/lib/flare.client.ts
+++ b/playgrounds/svelte/src/lib/flare.client.ts
@@ -4,14 +4,19 @@ export const initFlareClient = (): void => {
     const url = import.meta.env.VITE_FLARE_URL;
     const key = import.meta.env.VITE_FLARE_KEY ?? 'test-key-svelte';
 
-    if (url)
+    if (url) {
         flare.configure({
             ingestUrl: url,
             logsIngestUrl: url.replace('/api/reports', '/api/logs'),
-            enableLogs: true,
         });
+    }
 
     flare.configure({
+        // Logging is always on in the playground so the log buttons exercise the
+        // SDK even without a fake server (manual runs POST to the default ingest
+        // and fail like the error reports do). The fake-server logsIngestUrl
+        // override above only applies under e2e (VITE_FLARE_URL set).
+        enableLogs: true,
         beforeEvaluate: (error) => (error.message === 'hook-drop-report' ? null : error),
         beforeSubmit: (report) => {
             if (report.message === 'hook-mutate-report') {

--- a/playgrounds/svelte/src/lib/flare.client.ts
+++ b/playgrounds/svelte/src/lib/flare.client.ts
@@ -4,7 +4,12 @@ export const initFlareClient = (): void => {
     const url = import.meta.env.VITE_FLARE_URL;
     const key = import.meta.env.VITE_FLARE_KEY ?? 'test-key-svelte';
 
-    if (url) flare.configure({ ingestUrl: url });
+    if (url)
+        flare.configure({
+            ingestUrl: url,
+            logsIngestUrl: url.replace('/api/reports', '/api/logs'),
+            enableLogs: true,
+        });
 
     flare.configure({
         beforeEvaluate: (error) => (error.message === 'hook-drop-report' ? null : error),

--- a/playgrounds/svelte/src/routes/broken/+page.svelte
+++ b/playgrounds/svelte/src/routes/broken/+page.svelte
@@ -1,12 +1,13 @@
 <script lang="ts">
     import { goto } from '$app/navigation';
     import { FlareErrorBoundary } from '@flareapp/svelte';
-    import { coverageFor, testIds } from '@flareapp/playgrounds-shared';
+    import { coverageFor, fireLogScenario, logCoverageFor, testIds } from '@flareapp/playgrounds-shared';
     import { flare } from '$lib/flare.client';
     import MaybeThrowing from '$lib/MaybeThrowing.svelte';
     import Fallback from '$lib/Fallback.svelte';
 
     const scenarios = coverageFor('svelte');
+    const logScenarios = logCoverageFor('svelte');
 
     let renderTrigger: string | null = $state(null);
 
@@ -67,6 +68,22 @@
                 type="button"
                 data-testid={testIds.brokenTrigger(scenario.id)}
                 onclick={() => run(scenario.id)}
+                class="rounded-lg border border-surface-border bg-surface px-4 py-3 text-left text-sm hover:border-brand"
+            >
+                <div class="font-medium">{scenario.label}</div>
+                <div class="text-xs opacity-60 font-mono">{scenario.id}</div>
+            </button>
+        {/each}
+    </div>
+
+    <h2 class="text-lg font-semibold mt-8 mb-2">Logging</h2>
+    <p class="text-sm opacity-70 mb-4">Each button records one or more structured logs.</p>
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+        {#each logScenarios as scenario (scenario.id)}
+            <button
+                type="button"
+                data-testid={testIds.logTrigger(scenario.id)}
+                onclick={() => fireLogScenario(flare, scenario)}
                 class="rounded-lg border border-surface-border bg-surface px-4 py-3 text-left text-sm hover:border-brand"
             >
                 <div class="font-medium">{scenario.label}</div>

--- a/playgrounds/vue/src/flare.ts
+++ b/playgrounds/vue/src/flare.ts
@@ -8,11 +8,15 @@ export const initFlare = (): void => {
         flare.configure({
             ingestUrl: url,
             logsIngestUrl: url.replace('/api/reports', '/api/logs'),
-            enableLogs: true,
         });
     }
 
     flare.configure({
+        // Logging is always on in the playground so the log buttons exercise the
+        // SDK even without a fake server (manual runs POST to the default ingest
+        // and fail like the error reports do). The fake-server logsIngestUrl
+        // override above only applies under e2e (VITE_FLARE_URL set).
+        enableLogs: true,
         beforeEvaluate: (error) => {
             if (error.message === 'hook-drop-report') return null;
             return error;

--- a/playgrounds/vue/src/flare.ts
+++ b/playgrounds/vue/src/flare.ts
@@ -5,7 +5,11 @@ export const initFlare = (): void => {
     const key = import.meta.env.VITE_FLARE_KEY ?? 'test-key-vue';
 
     if (url) {
-        flare.configure({ ingestUrl: url });
+        flare.configure({
+            ingestUrl: url,
+            logsIngestUrl: url.replace('/api/reports', '/api/logs'),
+            enableLogs: true,
+        });
     }
 
     flare.configure({

--- a/playgrounds/vue/src/pages/BrokenPage.vue
+++ b/playgrounds/vue/src/pages/BrokenPage.vue
@@ -1,11 +1,18 @@
 <script setup lang="ts">
-import { coverageFor, testIds, type ErrorScenario } from '@flareapp/playgrounds-shared';
+import {
+    coverageFor,
+    fireLogScenario,
+    logCoverageFor,
+    testIds,
+    type ErrorScenario,
+} from '@flareapp/playgrounds-shared';
 
 import { brokenTrigger } from '../brokenTrigger';
 import MaybeThrowing from '../components/MaybeThrowing.vue';
 import { flare } from '../flare';
 
 const scenarios: ErrorScenario[] = coverageFor('vue');
+const logScenarios = logCoverageFor('vue');
 
 const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -62,6 +69,21 @@ const onClick = (scenarioId: string): void => {
                 class="rounded-lg border border-surface-border bg-surface px-4 py-3 text-left text-sm hover:border-brand"
                 :data-testid="testIds.brokenTrigger(scenario.id)"
                 @click="onClick(scenario.id)"
+            >
+                <div class="font-medium">{{ scenario.label }}</div>
+                <div class="text-xs opacity-60 font-mono">{{ scenario.id }}</div>
+            </button>
+        </div>
+        <h2 class="text-lg font-semibold mt-8 mb-2">Logging</h2>
+        <p class="text-sm opacity-70 mb-4">Each button records one or more structured logs.</p>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+            <button
+                v-for="scenario in logScenarios"
+                :key="scenario.id"
+                type="button"
+                class="rounded-lg border border-surface-border bg-surface px-4 py-3 text-left text-sm hover:border-brand"
+                :data-testid="testIds.logTrigger(scenario.id)"
+                @click="fireLogScenario(flare, scenario)"
             >
                 <div class="font-medium">{{ scenario.label }}</div>
                 <div class="text-xs opacity-60 font-mono">{{ scenario.id }}</div>

--- a/scripts/seed-logs.mjs
+++ b/scripts/seed-logs.mjs
@@ -1,0 +1,94 @@
+// Throwaway script: send genuine-looking logs to a real Flare project so we can
+// grab a clean screenshot of the Logs page for the announcement post.
+//
+// Usage:
+//   FLARE_KEY=your-project-token node scripts/seed-logs.mjs
+//
+// It drives the REAL @flareapp/js SDK (from packages/js/dist) in Node by stubbing
+// a minimal browser `window`, so the logs carry a genuine WEB entry point with a
+// real-looking route per record. Sends to the production logs ingress by default.
+
+const ORIGIN = 'https://shop.acme.test';
+const HOSTNAME = 'shop.acme.test';
+
+// Minimal browser-ish globals the SDK's browser collectors read. Set BEFORE
+// importing the SDK: its module top-level checks `typeof window`.
+const noop = () => {};
+globalThis.window = {
+    location: { href: `${ORIGIN}/`, pathname: '/', search: '', origin: ORIGIN, hostname: HOSTNAME },
+    navigator: {
+        userAgent:
+            'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36',
+    },
+    document: { cookie: '', referrer: '', readyState: 'complete', visibilityState: 'visible', addEventListener: noop },
+    addEventListener: noop,
+};
+globalThis.document = globalThis.window.document;
+
+const key = process.env.FLARE_KEY;
+if (!key) {
+    console.error('Set FLARE_KEY to your Flare project token. Aborting.');
+    process.exit(1);
+}
+
+const { Flare } = await import('../packages/js/dist/index.mjs');
+
+// Custom context collector: a genuine WEB entry point for the current route, plus
+// `host.name` (resource-level, so it lands in the Logs "Hostname" column). The
+// stock browser collector does not set host.name today; this mimics what it would
+// look like if it took window.location.hostname the way the PHP SDK takes the
+// machine hostname.
+const collector = () => ({
+    'flare.entry_point.type': 'web',
+    'flare.entry_point.value': globalThis.window.location.href,
+    'flare.entry_point.handler.identifier': globalThis.window.location.pathname,
+    'flare.entry_point.handler.type': 'browser',
+    'host.name': globalThis.window.location.hostname,
+});
+
+const flare = new Flare(undefined, collector);
+flare.light(key);
+flare.configure({
+    enableLogs: true,
+    serviceName: 'acme-storefront',
+    version: '2.4.0',
+    stage: 'production',
+});
+
+// A plausible shopping session. Each entry sets the route it happened on so the
+// "Entry point" column varies like a real app. Ordered roughly as a user journey.
+const events = [
+    { level: 'info', path: '/', message: 'Product catalog loaded', attributes: { productCount: 48, durationMs: 124, cacheHit: true } },
+    { level: 'debug', path: '/', message: 'Cart restored from localStorage', attributes: { items: 2 } },
+    { level: 'info', path: '/products/wireless-headphones', message: 'Product viewed', attributes: { sku: 'WH-1000', price: 279.0, inStock: true } },
+    { level: 'warning', path: '/products/wireless-headphones', message: 'Product image failed to load, using fallback', attributes: { sku: 'WH-1000', status: 404, asset: 'wh-1000-hero.webp' } },
+    { level: 'info', path: '/cart', message: 'Item added to cart', attributes: { sku: 'WH-1000', quantity: 1, cartTotal: 279.0 } },
+    { level: 'notice', path: '/cart', message: 'Discount code applied', attributes: { code: 'SUMMER10', discount: 27.9, cartTotal: 251.1 } },
+    { level: 'info', path: '/checkout', message: 'Checkout started', attributes: { cartId: 'cart_8f21a3', itemCount: 3, total: 251.1, currency: 'EUR' } },
+    { level: 'info', path: '/checkout', message: 'Payment intent created', attributes: { provider: 'stripe', amountCents: 25110, method: 'card' } },
+    { level: 'warning', path: '/checkout', message: 'Payment requires additional authentication', attributes: { provider: 'stripe', reason: '3ds_required' } },
+    { level: 'warning', path: '/api/inventory', message: 'Slow inventory response', attributes: { endpoint: '/api/inventory', durationMs: 2143, threshold: 1000 } },
+    { level: 'error', path: '/checkout', message: 'Payment declined by issuer', attributes: { provider: 'stripe', code: 'card_declined', cartId: 'cart_8f21a3' } },
+    { level: 'info', path: '/checkout', message: 'Payment retried with new card', attributes: { provider: 'stripe', attempt: 2 } },
+    { level: 'info', path: '/checkout/confirmation', message: 'Order placed', attributes: { orderId: 'ord_4471c9', total: 251.1, currency: 'EUR', items: 3 } },
+    { level: 'notice', path: '/checkout/confirmation', message: 'Confirmation email queued', attributes: { orderId: 'ord_4471c9', template: 'order_confirmation' } },
+    { level: 'error', path: '/account', message: 'Failed to refresh session token', attributes: { status: 401, reason: 'expired' } },
+];
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+for (const e of events) {
+    globalThis.window.location.pathname = e.path;
+    globalThis.window.location.href = ORIGIN + e.path;
+    // Second arg is PHP-style context: the SDK nests it under `log.context`, which
+    // the Flare log detail panel renders as the "Context" section.
+    flare.logger[e.level](e.message, e.attributes);
+    console.log(`${e.level.toUpperCase().padEnd(8)} ${e.path.padEnd(32)} ${e.message}`);
+    // Small stagger so each row gets a distinct timestamp.
+    await sleep(200);
+}
+
+await flare.flush();
+// Give the POST time to settle before the process exits.
+await sleep(2500);
+console.log(`\nSent ${events.length} logs. Check the Logs page in Flare.`);


### PR DESCRIPTION
## Summary

Adds standalone structured logging to `@flareapp/core`, exposed through `@flareapp/js` and `@flareapp/node`, mirroring the PHP client's logging. Logs are buffered and shipped to `POST /v1/logs` as their own OpenTelemetry `resourceLogs` entity, separate from error reports.

- **Public API:** `flare.logger.{debug,info,notice,warning,error,critical,alert,emergency}(message, attributes?)`. Opt-in via `enableLogs` (default `false`).
- **Core** owns the buffer + batching policy (count cap 100, weight cap ~0.8MB, one-shot 5s timer) + the OTel envelope + `Api.logs()`. A `FlushScheduler` seam is injected per platform.
- **Browser** (`@flareapp/js`) flushes on `visibilitychange:hidden` using `fetch` `keepalive` (survives unload; `sendBeacon` can't send the `x-api-token` header).
- **Node** (`@flareapp/node`) flushes on `process.on('beforeExit')`; request-scope context (`http.*`, `enduser.*`) is captured per log record.
- Per-record attributes are **frozen at capture** (encoded to OTel `KeyValue[]` immediately); only the collector's resource-level keys go on the shared envelope resource (`process.uptime` stays record-level). API-key gate retains the buffer until `light()` sets a key; disabling clears it.

Design spec: `docs/superpowers/specs/2026-06-03-core-logging-design.md`.

## Test Plan

- [x] `npm run typescript` — passes (all packages)
- [x] `npm run test` — passes (core 163, js 25, node 81, + all other workspaces)
- [x] `npm run lint` — clean (only pre-existing `any` warnings in `node/src/process/handlers.ts`)
- [x] Cross-origin keepalive-on-unload e2e (`e2e/specs/js.spec.ts`): records a log, asserts none sent before unload, navigates away, confirms the fake server receives it with `x-api-token` — proving the real unload path
- [x] Confirm `/v1/logs` ingest accepts the envelope against a real Flare backend
- [x] Decide whether to also bump/release `@flareapp/core` + platform packages

## Notes

- `enableLogs` is opt-in; no log traffic until switched on.
- Documented limitation: `beforeExit` does not fire on `SIGTERM`/`process.exit()` — graceful shutdowns should call `flare.flush()`.