### PR TITLE
feat(react): decode minified React errors

### DIFF
--- a/docs/superpowers/plans/2026-06-08-decode-minified-react-errors.md
+++ b/docs/superpowers/plans/2026-06-08-decode-minified-react-errors.md
@@ -21,7 +21,9 @@
 - Modify: `packages/react/src/index.ts` — export `MinifiedReactError` type.
 - Create: `packages/react/tests/parseMinifiedReactError.test.ts`
 - Create: `packages/react/tests/buildReactContext.test.ts`
-- Modify: `packages/react/tests/contextToAttributes.test.ts` — add required `version`, assert forwarding.
+- Modify: `packages/react/tests/contextToAttributes.test.ts` — add `version`, assert forwarding.
+- Modify: `packages/react/tests/FlareErrorBoundary.test.tsx` — end-to-end boundary assertion.
+- Modify: `packages/react/README.md` — document the new context fields.
 
 Run all react tests with: `cd packages/react && npx vitest run`
 Type-check with: `cd packages/react && npx tsc --noEmit`
@@ -113,6 +115,20 @@ describe('parseMinifiedReactError', () => {
     test('returns null for an empty message without throwing', () => {
         expect(parseMinifiedReactError(new Error(''))).toBeNull();
     });
+
+    test('falls back to the raw arg value when percent-decoding fails', () => {
+        const error = new Error(
+            'Minified React error #418; visit https://react.dev/errors/418?args[]=%E0%A4%A&args[]=ok for the full message',
+        );
+
+        // `%E0%A4%A` is a malformed percent escape; decodeURIComponent would throw.
+        // The parser must not throw mid-error-handling and keeps the raw value instead.
+        expect(parseMinifiedReactError(error)).toEqual({
+            number: 418,
+            args: ['%E0%A4%A', 'ok'],
+            url: 'https://react.dev/errors/418?args[]=%E0%A4%A&args[]=ok',
+        });
+    });
 });
 ```
 
@@ -132,6 +148,17 @@ const NUMBER_PATTERN = /Minified React error #(\d+)/;
 const ARG_PATTERN = /args\[\]=([^&\s]*)/g;
 const URL_PATTERN = /(https?:\/\/\S+)/;
 
+// decodeURIComponent throws on malformed percent escapes (e.g. "%E0%A4%A"). This
+// runs while the boundary/handler is already processing an error, so a throw here
+// must not escape. Fall back to the raw value instead.
+function safeDecode(value: string): string {
+    try {
+        return decodeURIComponent(value);
+    } catch {
+        return value;
+    }
+}
+
 export function parseMinifiedReactError(error: Error): MinifiedReactError | null {
     const message = error?.message;
 
@@ -148,7 +175,7 @@ export function parseMinifiedReactError(error: Error): MinifiedReactError | null
     const args: string[] = [];
 
     for (const match of message.matchAll(ARG_PATTERN)) {
-        args.push(decodeURIComponent(match[1]));
+        args.push(safeDecode(match[1]));
     }
 
     const urlMatch = message.match(URL_PATTERN);
@@ -166,7 +193,7 @@ Note: `\S+` stops the URL capture at the first whitespace, so the trailing " for
 - [ ] **Step 5: Run the test to verify it passes**
 
 Run: `cd packages/react && npx vitest run tests/parseMinifiedReactError.test.ts`
-Expected: PASS (6 tests).
+Expected: PASS (7 tests).
 
 - [ ] **Step 6: Commit**
 
@@ -256,11 +283,15 @@ export type FlareReactContext = {
     react: {
         componentStack: string[];
         componentStackFrames: ComponentStackFrame[];
-        version: string;
+        version?: string;
         minifiedError?: MinifiedReactError;
     };
 };
 ```
+
+`version` is optional in the type to avoid breaking the public `beforeSubmit`/`afterSubmit`
+contracts (a required field would break consumers returning a context literal, forcing a
+major). `buildReactContext` always populates it, so it is present on every real report.
 
 - [ ] **Step 4: Create `buildReactContext.ts`**
 
@@ -460,15 +491,16 @@ git commit -m "feat(react): attach React version and minified error to report co
 
 ---
 
-## Task 3: End-to-end assertion through the handler
+## Task 3: End-to-end assertions through both error paths
 
 **Files:**
 
 - Modify: `packages/react/tests/flareReactErrorHandler.test.ts`
+- Modify: `packages/react/tests/FlareErrorBoundary.test.tsx`
 
-Lock in that a minified React error thrown through the real handler path surfaces `minifiedError` and `version` in the reported attributes. This guards the wiring, not just the unit.
+The spec scopes both React paths. Lock in that a minified React error surfaces `minifiedError` and `version` in the reported attributes through the handler AND through the boundary. This guards the wiring, not just the unit.
 
-- [ ] **Step 1: Write the failing test**
+- [ ] **Step 1: Write the handler test**
 
 Append this `describe` block inside the top-level `describe('flareReactErrorHandler', ...)` in `packages/react/tests/flareReactErrorHandler.test.ts`:
 
@@ -504,21 +536,81 @@ describe('minified React errors', () => {
 });
 ```
 
-- [ ] **Step 2: Run the test to verify it passes**
+- [ ] **Step 2: Write the boundary test**
 
-Run: `cd packages/react && npx vitest run tests/flareReactErrorHandler.test.ts`
-Expected: PASS. (The wiring already exists from Task 2, so this test confirms it rather than driving new code. If it fails, the handler is not calling `buildReactContext` with the converted error — revisit Task 2 Step 7.)
+Append this `describe` block inside the top-level `describe('FlareErrorBoundary', ...)` in `packages/react/tests/FlareErrorBoundary.test.tsx`. It reuses the file's existing `testError`/`ThrowingComponent`/`mockReport` setup (see the top of the file); reassigning `testError` before render makes `ThrowingComponent` throw the minified error.
 
-- [ ] **Step 3: Commit**
+```ts
+    describe('minified React errors', () => {
+        test('forwards minifiedError and version in the reported attributes', () => {
+            testError = new Error(
+                'Minified React error #418; visit https://react.dev/errors/418?args[]=Foo for the full message',
+            );
+
+            render(
+                <FlareErrorBoundary fallback={<div>Error</div>}>
+                    <ThrowingComponent />
+                </FlareErrorBoundary>,
+            );
+
+            const attributes = mockReport.mock.calls[0][1];
+            const react = (attributes['context.custom'] as any).react;
+
+            expect(react.minifiedError).toEqual({
+                number: 418,
+                args: ['Foo'],
+                url: 'https://react.dev/errors/418?args[]=Foo',
+            });
+            expect(typeof react.version).toBe('string');
+        });
+
+        test('omits minifiedError for a plain error', () => {
+            render(
+                <FlareErrorBoundary fallback={<div>Error</div>}>
+                    <ThrowingComponent />
+                </FlareErrorBoundary>,
+            );
+
+            const attributes = mockReport.mock.calls[0][1];
+            expect((attributes['context.custom'] as any).react).not.toHaveProperty('minifiedError');
+        });
+    });
+```
+
+- [ ] **Step 3: Run both test files to verify they pass**
+
+Run: `cd packages/react && npx vitest run tests/flareReactErrorHandler.test.ts tests/FlareErrorBoundary.test.tsx`
+Expected: PASS. (The wiring already exists from Task 2, so these tests confirm it rather than driving new code. If the handler test fails, the handler is not calling `buildReactContext` with the converted error — revisit Task 2 Step 7.)
+
+- [ ] **Step 4: Commit**
 
 ```bash
-git add packages/react/tests/flareReactErrorHandler.test.ts
-git commit -m "test(react): assert minified error reaches reported attributes end-to-end"
+git add packages/react/tests/flareReactErrorHandler.test.ts packages/react/tests/FlareErrorBoundary.test.tsx
+git commit -m "test(react): assert minified error reaches reported attributes via both paths"
 ```
 
 ---
 
-## Task 4: Full verification
+## Task 4: Document the new context fields
+
+**Files:**
+
+- Modify: `packages/react/README.md`
+
+- [ ] **Step 1: Add a README section**
+
+Add a short note to `packages/react/README.md` documenting that the client now attaches `react.version` and, for minified production errors, `react.minifiedError` (`{ number, args, url }`) to the report context, which the Flare backend uses to decode the message. Match the README's existing section style and heading level.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add packages/react/README.md
+git commit -m "docs(react): document minified error decoding context"
+```
+
+---
+
+## Task 5: Full verification
 
 **Files:** none (verification only)
 
@@ -537,21 +629,10 @@ Expected: all PASS.
 Run: `cd packages/react && npm run build`
 Expected: clean CJS + ESM + d.ts output. This confirms `import { version } from 'react'` resolves through tsdown/rollup against the React peer dependency (named CJS export interop).
 
-- [ ] **Step 4: Update the README**
-
-Add a short note to `packages/react/README.md` documenting that the client now attaches `react.version` and, for minified production errors, `react.minifiedError` (`{ number, args, url }`) to the report context, which the Flare backend uses to decode the message. Match the README's existing section style.
-
-- [ ] **Step 5: Commit**
-
-```bash
-git add packages/react/README.md
-git commit -m "docs(react): document minified error decoding context"
-```
-
 ---
 
 ## Notes for the implementer
 
 - Do not bundle React's `codes.json`. The decoding happens on the Flare backend; the client only ships the structured fields.
-- `import { version } from 'react'` relies on React's named CJS export `version`, present in all peer-supported majors (16/17/18/19). Task 4 Step 3 verifies the build resolves it.
+- `import { version } from 'react'` relies on React's named CJS export `version`, present in all peer-supported majors (16/17/18/19). Task 5 Step 3 verifies the build resolves it.
 - The global `window.onerror` path in `@flareapp/js` is intentionally out of scope. Only the boundary and handler paths get the parse.

--- a/docs/superpowers/plans/2026-06-08-decode-minified-react-errors.md
+++ b/docs/superpowers/plans/2026-06-08-decode-minified-react-errors.md
@@ -409,7 +409,7 @@ In `packages/react/src/index.ts`, update the type export line:
 export type { ComponentStackFrame, FlareReactContext, MinifiedReactError } from './types';
 ```
 
-- [ ] **Step 10: Update `contextToAttributes.test.ts` for the required `version` and forwarding**
+- [ ] **Step 10: Update `contextToAttributes.test.ts` for the `version` field and forwarding**
 
 Replace the file `packages/react/tests/contextToAttributes.test.ts` with:
 
@@ -612,12 +612,12 @@ git commit -m "test(react): assert minified error reaches reported attributes vi
 
 - [ ] **Step 1: Add a README section**
 
-In `packages/react/README.md`, insert this new `##` section between the existing `## Logging` section and the `## Documentation` section (so it sits among the feature sections, before the docs/compatibility/license tail):
+In `packages/react/README.md`, insert this new `##` section between the existing `## Logging` section and the `## Documentation` section (so it sits among the feature sections, before the docs/compatibility/license tail). The block below is shown in a four-backtick wrapper so its inner three-backtick `ts` fence renders; paste only the section content (the `## Minified production errors` heading through the final prose paragraph) into the README.
 
 ````markdown
 ## Minified production errors
 
-In production, React throws minified errors like `Minified React error #418; visit https://react.dev/errors/418?args[]=…`.
+In production, React throws minified errors like `Minified React error #418; visit https://react.dev/errors/418?args[]=Foo`.
 The client parses these into structured fields and attaches them, along with the running React version, to the report
 context:
 
@@ -631,21 +631,17 @@ react: {
     },
 }
 ```
-````
 
 Flare uses `react.minifiedError` and `react.version` on the backend to look up React's error-code map and surface the
 full, human-readable message. No error-code map is bundled into the client. Non-minified errors are reported unchanged.
-
-`````
-
-Note the inner ```` ```ts ```` block is nested inside the markdown example; when editing the README directly the outer fences are not literal — paste only the section content (heading, prose, and the single `ts` code block).
+````
 
 - [ ] **Step 2: Commit**
 
 ```bash
 git add packages/react/README.md
 git commit -m "docs(react): document minified error decoding context"
-`````
+```
 
 ---
 

--- a/docs/superpowers/plans/2026-06-08-decode-minified-react-errors.md
+++ b/docs/superpowers/plans/2026-06-08-decode-minified-react-errors.md
@@ -1,0 +1,557 @@
+# Decode minified React errors Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Tag Flare reports from `@flareapp/react` with the structured number, args, and React version of a minified React production error, so the Flare backend can decode the human-readable message.
+
+**Architecture:** A tiny pure parser (`parseMinifiedReactError`) extracts `number`/`args`/`url` from the error message via regex. A shared `buildReactContext` helper (replacing today's copy-pasted context block in the boundary and the handler) attaches the parsed `minifiedError` plus the React `version` to `context.react`. `contextToAttributes` forwards both new fields to the backend under `context.custom.react`. No code map is bundled; decoding happens server-side.
+
+**Tech Stack:** TypeScript 5.7, Vitest, tsdown, `@flareapp/react` package.
+
+---
+
+## File Structure
+
+- Create: `packages/react/src/parseMinifiedReactError.ts` — pure parser, message string to structured fields.
+- Create: `packages/react/src/buildReactContext.ts` — shared builder for `context.react`, used by both error paths.
+- Modify: `packages/react/src/types.ts` — add `MinifiedReactError` type, extend `FlareReactContext.react` with `version` + `minifiedError`.
+- Modify: `packages/react/src/FlareErrorBoundary.ts` — replace inline context block with `buildReactContext`.
+- Modify: `packages/react/src/flareReactErrorHandler.ts` — replace inline context block with `buildReactContext`.
+- Modify: `packages/react/src/contextToAttributes.ts` — forward `version` + `minifiedError`.
+- Modify: `packages/react/src/index.ts` — export `MinifiedReactError` type.
+- Create: `packages/react/tests/parseMinifiedReactError.test.ts`
+- Create: `packages/react/tests/buildReactContext.test.ts`
+- Modify: `packages/react/tests/contextToAttributes.test.ts` — add required `version`, assert forwarding.
+
+Run all react tests with: `cd packages/react && npx vitest run`
+Type-check with: `cd packages/react && npx tsc --noEmit`
+
+---
+
+## Task 1: `parseMinifiedReactError` parser
+
+**Files:**
+
+- Modify: `packages/react/src/types.ts`
+- Create: `packages/react/src/parseMinifiedReactError.ts`
+- Test: `packages/react/tests/parseMinifiedReactError.test.ts`
+
+This task is additive only (a new type alias + a new file). It does not touch `FlareReactContext`, so nothing else breaks.
+
+- [ ] **Step 1: Add the `MinifiedReactError` type to `types.ts`**
+
+Insert this block after the existing `ComponentStackFrame` type, leaving `FlareReactContext` unchanged for now:
+
+```ts
+export type MinifiedReactError = {
+    number: number;
+    args: string[];
+    url: string | null;
+};
+```
+
+- [ ] **Step 2: Write the failing test**
+
+Create `packages/react/tests/parseMinifiedReactError.test.ts`:
+
+```ts
+import { describe, expect, test } from 'vitest';
+
+import { parseMinifiedReactError } from '../src/parseMinifiedReactError';
+
+describe('parseMinifiedReactError', () => {
+    test('parses a React 18/19 message (react.dev URL)', () => {
+        const error = new Error(
+            'Minified React error #418; visit https://react.dev/errors/418?args[]=Foo&args[]=Bar for the full message',
+        );
+
+        expect(parseMinifiedReactError(error)).toEqual({
+            number: 418,
+            args: ['Foo', 'Bar'],
+            url: 'https://react.dev/errors/418?args[]=Foo&args[]=Bar',
+        });
+    });
+
+    test('parses a React 16/17 message (reactjs.org error-decoder URL)', () => {
+        const error = new Error(
+            'Minified React error #185; visit https://reactjs.org/docs/error-decoder.html?invariant=185&args[]=Foo for the full message',
+        );
+
+        expect(parseMinifiedReactError(error)).toEqual({
+            number: 185,
+            args: ['Foo'],
+            url: 'https://reactjs.org/docs/error-decoder.html?invariant=185&args[]=Foo',
+        });
+    });
+
+    test('returns null for a non-minified error message', () => {
+        expect(parseMinifiedReactError(new Error('Cannot read properties of undefined'))).toBeNull();
+    });
+
+    test('handles a minified message with no args', () => {
+        const error = new Error('Minified React error #310; visit https://react.dev/errors/310 for the full message');
+
+        expect(parseMinifiedReactError(error)).toEqual({
+            number: 310,
+            args: [],
+            url: 'https://react.dev/errors/310',
+        });
+    });
+
+    test('URL-decodes arg values', () => {
+        const error = new Error(
+            'Minified React error #418; visit https://react.dev/errors/418?args[]=%3Cdiv%3E&args[]=%20%26%20 for the full message',
+        );
+
+        expect(parseMinifiedReactError(error)).toEqual({
+            number: 418,
+            args: ['<div>', ' & '],
+            url: 'https://react.dev/errors/418?args[]=%3Cdiv%3E&args[]=%20%26%20',
+        });
+    });
+
+    test('returns null for an empty message without throwing', () => {
+        expect(parseMinifiedReactError(new Error(''))).toBeNull();
+    });
+});
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+Run: `cd packages/react && npx vitest run tests/parseMinifiedReactError.test.ts`
+Expected: FAIL — cannot resolve `../src/parseMinifiedReactError`.
+
+- [ ] **Step 4: Write the implementation**
+
+Create `packages/react/src/parseMinifiedReactError.ts`:
+
+```ts
+import type { MinifiedReactError } from './types';
+
+const NUMBER_PATTERN = /Minified React error #(\d+)/;
+const ARG_PATTERN = /args\[\]=([^&\s]*)/g;
+const URL_PATTERN = /(https?:\/\/\S+)/;
+
+export function parseMinifiedReactError(error: Error): MinifiedReactError | null {
+    const message = error?.message;
+
+    if (!message) {
+        return null;
+    }
+
+    const numberMatch = message.match(NUMBER_PATTERN);
+
+    if (!numberMatch) {
+        return null;
+    }
+
+    const args: string[] = [];
+
+    for (const match of message.matchAll(ARG_PATTERN)) {
+        args.push(decodeURIComponent(match[1]));
+    }
+
+    const urlMatch = message.match(URL_PATTERN);
+
+    return {
+        number: Number(numberMatch[1]),
+        args,
+        url: urlMatch ? urlMatch[1] : null,
+    };
+}
+```
+
+Note: `\S+` stops the URL capture at the first whitespace, so the trailing " for the full message" is excluded. `[^&\s]*` stops each arg at the next `&` or whitespace.
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `cd packages/react && npx vitest run tests/parseMinifiedReactError.test.ts`
+Expected: PASS (6 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/react/src/types.ts packages/react/src/parseMinifiedReactError.ts packages/react/tests/parseMinifiedReactError.test.ts
+git commit -m "feat(react): parse minified React errors into structured fields"
+```
+
+---
+
+## Task 2: Attach version + minifiedError to the report context
+
+**Files:**
+
+- Modify: `packages/react/src/types.ts`
+- Create: `packages/react/src/buildReactContext.ts`
+- Modify: `packages/react/src/FlareErrorBoundary.ts:44-49`
+- Modify: `packages/react/src/flareReactErrorHandler.ts:34-39`
+- Modify: `packages/react/src/contextToAttributes.ts`
+- Modify: `packages/react/src/index.ts`
+- Test: `packages/react/tests/buildReactContext.test.ts`
+- Modify: `packages/react/tests/contextToAttributes.test.ts`
+
+Making `version` a required field of `FlareReactContext.react` breaks raw context literals. The only raw literals in tests are in `contextToAttributes.test.ts`; the boundary/handler tests build context through the real code path or spread `...context.react`, so they keep compiling. This whole task is one coherent change and is committed once, green.
+
+- [ ] **Step 1: Write the failing test for `buildReactContext`**
+
+Create `packages/react/tests/buildReactContext.test.ts`:
+
+```ts
+import { describe, expect, test } from 'vitest';
+import { version as reactVersion } from 'react';
+
+import { buildReactContext } from '../src/buildReactContext';
+
+const stack = '\n    at App (http://localhost:5173/src/App.tsx:5:3)\n';
+
+describe('buildReactContext', () => {
+    test('includes the React version on every context', () => {
+        const context = buildReactContext(stack, new Error('plain error'));
+
+        expect(context.react.version).toBe(reactVersion);
+    });
+
+    test('parses component stack into componentStack and componentStackFrames', () => {
+        const context = buildReactContext(stack, new Error('plain error'));
+
+        expect(context.react.componentStack).toEqual(['at App (http://localhost:5173/src/App.tsx:5:3)']);
+        expect(context.react.componentStackFrames).toEqual([
+            { component: 'App', file: 'http://localhost:5173/src/App.tsx', line: 5, column: 3 },
+        ]);
+    });
+
+    test('omits minifiedError for a plain error', () => {
+        const context = buildReactContext(stack, new Error('plain error'));
+
+        expect(context.react.minifiedError).toBeUndefined();
+    });
+
+    test('attaches minifiedError for a minified React error', () => {
+        const error = new Error(
+            'Minified React error #418; visit https://react.dev/errors/418?args[]=Foo for the full message',
+        );
+
+        const context = buildReactContext(stack, error);
+
+        expect(context.react.minifiedError).toEqual({
+            number: 418,
+            args: ['Foo'],
+            url: 'https://react.dev/errors/418?args[]=Foo',
+        });
+    });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd packages/react && npx vitest run tests/buildReactContext.test.ts`
+Expected: FAIL — cannot resolve `../src/buildReactContext`.
+
+- [ ] **Step 3: Extend `FlareReactContext` in `types.ts`**
+
+Replace the existing `FlareReactContext` type with:
+
+```ts
+export type FlareReactContext = {
+    react: {
+        componentStack: string[];
+        componentStackFrames: ComponentStackFrame[];
+        version: string;
+        minifiedError?: MinifiedReactError;
+    };
+};
+```
+
+- [ ] **Step 4: Create `buildReactContext.ts`**
+
+Create `packages/react/src/buildReactContext.ts`:
+
+```ts
+import { version } from 'react';
+
+import { formatComponentStack } from './formatComponentStack';
+import { parseComponentStack } from './parseComponentStack';
+import { parseMinifiedReactError } from './parseMinifiedReactError';
+import type { FlareReactContext } from './types';
+
+export function buildReactContext(rawStack: string, error: Error): FlareReactContext {
+    const minifiedError = parseMinifiedReactError(error);
+
+    return {
+        react: {
+            componentStack: formatComponentStack(rawStack),
+            componentStackFrames: parseComponentStack(rawStack),
+            version,
+            ...(minifiedError ? { minifiedError } : {}),
+        },
+    };
+}
+```
+
+- [ ] **Step 5: Run the `buildReactContext` test to verify it passes**
+
+Run: `cd packages/react && npx vitest run tests/buildReactContext.test.ts`
+Expected: PASS (4 tests).
+
+- [ ] **Step 6: Use `buildReactContext` in `FlareErrorBoundary.ts`**
+
+In `packages/react/src/FlareErrorBoundary.ts`, replace the inline block in `componentDidCatch`:
+
+```ts
+const rawStack = errorInfo.componentStack ?? '';
+
+const context: FlareReactContext = {
+    react: {
+        componentStack: formatComponentStack(rawStack),
+        componentStackFrames: parseComponentStack(rawStack),
+    },
+};
+```
+
+with:
+
+```ts
+const rawStack = errorInfo.componentStack ?? '';
+
+const context = buildReactContext(rawStack, error);
+```
+
+Then update the imports at the top of the file: remove the now-unused `formatComponentStack` and `parseComponentStack` imports and add `buildReactContext`:
+
+```ts
+import { buildReactContext } from './buildReactContext';
+```
+
+Keep the `FlareReactContext` type import — it is still used in the prop type signatures.
+
+- [ ] **Step 7: Use `buildReactContext` in `flareReactErrorHandler.ts`**
+
+In `packages/react/src/flareReactErrorHandler.ts`, replace the inline block:
+
+```ts
+const rawStack = errorInfo.componentStack ?? '';
+
+const context: FlareReactContext = {
+    react: {
+        componentStack: formatComponentStack(rawStack),
+        componentStackFrames: parseComponentStack(rawStack),
+    },
+};
+```
+
+with:
+
+```ts
+const rawStack = errorInfo.componentStack ?? '';
+
+const context = buildReactContext(rawStack, errorObject);
+```
+
+Note: pass `errorObject` (the converted Error), not `error` (the raw `unknown`). Update imports: remove `formatComponentStack` and `parseComponentStack`, add `import { buildReactContext } from './buildReactContext';`. Keep the `FlareReactContext` import (used in option type signatures).
+
+- [ ] **Step 8: Forward the new fields in `contextToAttributes.ts`**
+
+Replace the body of `contextToAttributes` in `packages/react/src/contextToAttributes.ts`:
+
+```ts
+export function contextToAttributes(context: FlareReactContext): Attributes {
+    return {
+        'context.custom': {
+            react: {
+                componentStack: context.react.componentStack as AttributeValue,
+                componentStackFrames: context.react.componentStackFrames as AttributeValue,
+                version: context.react.version as AttributeValue,
+                ...(context.react.minifiedError
+                    ? { minifiedError: context.react.minifiedError as AttributeValue }
+                    : {}),
+            },
+        },
+    };
+}
+```
+
+- [ ] **Step 9: Export `MinifiedReactError` from `index.ts`**
+
+In `packages/react/src/index.ts`, update the type export line:
+
+```ts
+export type { ComponentStackFrame, FlareReactContext, MinifiedReactError } from './types';
+```
+
+- [ ] **Step 10: Update `contextToAttributes.test.ts` for the required `version` and forwarding**
+
+Replace the file `packages/react/tests/contextToAttributes.test.ts` with:
+
+```ts
+import { describe, expect, test } from 'vitest';
+
+import { contextToAttributes } from '../src/contextToAttributes';
+import { FlareReactContext } from '../src/types';
+
+describe('contextToAttributes', () => {
+    test('wraps react context (with version) under context.custom', () => {
+        const context: FlareReactContext = {
+            react: {
+                componentStack: ['at App', 'at div'],
+                componentStackFrames: [{ component: 'App', file: 'App.tsx', line: 5, column: 3 }],
+                version: '19.0.0',
+            },
+        };
+
+        const attributes = contextToAttributes(context);
+
+        expect(attributes).toEqual({
+            'context.custom': {
+                react: {
+                    componentStack: ['at App', 'at div'],
+                    componentStackFrames: [{ component: 'App', file: 'App.tsx', line: 5, column: 3 }],
+                    version: '19.0.0',
+                },
+            },
+        });
+    });
+
+    test('forwards minifiedError when present', () => {
+        const context: FlareReactContext = {
+            react: {
+                componentStack: [],
+                componentStackFrames: [],
+                version: '19.0.0',
+                minifiedError: { number: 418, args: ['Foo'], url: 'https://react.dev/errors/418?args[]=Foo' },
+            },
+        };
+
+        const attributes = contextToAttributes(context);
+
+        expect((attributes['context.custom'] as any).react.minifiedError).toEqual({
+            number: 418,
+            args: ['Foo'],
+            url: 'https://react.dev/errors/418?args[]=Foo',
+        });
+    });
+
+    test('omits minifiedError when absent', () => {
+        const context: FlareReactContext = {
+            react: {
+                componentStack: [],
+                componentStackFrames: [],
+                version: '19.0.0',
+            },
+        };
+
+        const attributes = contextToAttributes(context);
+
+        expect((attributes['context.custom'] as any).react).not.toHaveProperty('minifiedError');
+    });
+});
+```
+
+- [ ] **Step 11: Run the full react suite and type-check**
+
+Run: `cd packages/react && npx vitest run && npx tsc --noEmit`
+Expected: all tests PASS, no type errors. If `tsc` flags an unused import in `FlareErrorBoundary.ts` or `flareReactErrorHandler.ts`, remove the leftover `formatComponentStack`/`parseComponentStack` import.
+
+- [ ] **Step 12: Commit**
+
+```bash
+git add packages/react/src packages/react/tests/buildReactContext.test.ts packages/react/tests/contextToAttributes.test.ts
+git commit -m "feat(react): attach React version and minified error to report context"
+```
+
+---
+
+## Task 3: End-to-end assertion through the handler
+
+**Files:**
+
+- Modify: `packages/react/tests/flareReactErrorHandler.test.ts`
+
+Lock in that a minified React error thrown through the real handler path surfaces `minifiedError` and `version` in the reported attributes. This guards the wiring, not just the unit.
+
+- [ ] **Step 1: Write the failing test**
+
+Append this `describe` block inside the top-level `describe('flareReactErrorHandler', ...)` in `packages/react/tests/flareReactErrorHandler.test.ts`:
+
+```ts
+describe('minified React errors', () => {
+    test('forwards minifiedError and version in the reported attributes', () => {
+        const handler = flareReactErrorHandler();
+        const error = new Error(
+            'Minified React error #418; visit https://react.dev/errors/418?args[]=Foo for the full message',
+        );
+
+        handler(error, { componentStack: '    at App' });
+
+        const attributes = mockReport.mock.calls[0][1];
+        const react = (attributes['context.custom'] as any).react;
+
+        expect(react.minifiedError).toEqual({
+            number: 418,
+            args: ['Foo'],
+            url: 'https://react.dev/errors/418?args[]=Foo',
+        });
+        expect(typeof react.version).toBe('string');
+    });
+
+    test('omits minifiedError for a plain error', () => {
+        const handler = flareReactErrorHandler();
+
+        handler(new Error('plain error'), { componentStack: '    at App' });
+
+        const attributes = mockReport.mock.calls[0][1];
+        expect((attributes['context.custom'] as any).react).not.toHaveProperty('minifiedError');
+    });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it passes**
+
+Run: `cd packages/react && npx vitest run tests/flareReactErrorHandler.test.ts`
+Expected: PASS. (The wiring already exists from Task 2, so this test confirms it rather than driving new code. If it fails, the handler is not calling `buildReactContext` with the converted error — revisit Task 2 Step 7.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/react/tests/flareReactErrorHandler.test.ts
+git commit -m "test(react): assert minified error reaches reported attributes end-to-end"
+```
+
+---
+
+## Task 4: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Type-check the whole repo**
+
+Run: `npm run typescript`
+Expected: no errors.
+
+- [ ] **Step 2: Run the react package tests**
+
+Run: `cd packages/react && npx vitest run`
+Expected: all PASS.
+
+- [ ] **Step 3: Build the react package**
+
+Run: `cd packages/react && npm run build`
+Expected: clean CJS + ESM + d.ts output. This confirms `import { version } from 'react'` resolves through tsdown/rollup against the React peer dependency (named CJS export interop).
+
+- [ ] **Step 4: Update the README**
+
+Add a short note to `packages/react/README.md` documenting that the client now attaches `react.version` and, for minified production errors, `react.minifiedError` (`{ number, args, url }`) to the report context, which the Flare backend uses to decode the message. Match the README's existing section style.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/react/README.md
+git commit -m "docs(react): document minified error decoding context"
+```
+
+---
+
+## Notes for the implementer
+
+- Do not bundle React's `codes.json`. The decoding happens on the Flare backend; the client only ships the structured fields.
+- `import { version } from 'react'` relies on React's named CJS export `version`, present in all peer-supported majors (16/17/18/19). Task 4 Step 3 verifies the build resolves it.
+- The global `window.onerror` path in `@flareapp/js` is intentionally out of scope. Only the boundary and handler paths get the parse.

--- a/docs/superpowers/plans/2026-06-08-decode-minified-react-errors.md
+++ b/docs/superpowers/plans/2026-06-08-decode-minified-react-errors.md
@@ -391,7 +391,7 @@ export function contextToAttributes(context: FlareReactContext): Attributes {
             react: {
                 componentStack: context.react.componentStack as AttributeValue,
                 componentStackFrames: context.react.componentStackFrames as AttributeValue,
-                version: context.react.version as AttributeValue,
+                ...(context.react.version ? { version: context.react.version as AttributeValue } : {}),
                 ...(context.react.minifiedError
                     ? { minifiedError: context.react.minifiedError as AttributeValue }
                     : {}),
@@ -473,6 +473,19 @@ describe('contextToAttributes', () => {
         const attributes = contextToAttributes(context);
 
         expect((attributes['context.custom'] as any).react).not.toHaveProperty('minifiedError');
+    });
+
+    test('omits version when a context has none (e.g. a beforeSubmit literal)', () => {
+        const context: FlareReactContext = {
+            react: {
+                componentStack: [],
+                componentStackFrames: [],
+            },
+        };
+
+        const attributes = contextToAttributes(context);
+
+        expect((attributes['context.custom'] as any).react).not.toHaveProperty('version');
     });
 });
 ```
@@ -599,14 +612,40 @@ git commit -m "test(react): assert minified error reaches reported attributes vi
 
 - [ ] **Step 1: Add a README section**
 
-Add a short note to `packages/react/README.md` documenting that the client now attaches `react.version` and, for minified production errors, `react.minifiedError` (`{ number, args, url }`) to the report context, which the Flare backend uses to decode the message. Match the README's existing section style and heading level.
+In `packages/react/README.md`, insert this new `##` section between the existing `## Logging` section and the `## Documentation` section (so it sits among the feature sections, before the docs/compatibility/license tail):
+
+````markdown
+## Minified production errors
+
+In production, React throws minified errors like `Minified React error #418; visit https://react.dev/errors/418?args[]=…`.
+The client parses these into structured fields and attaches them, along with the running React version, to the report
+context:
+
+```ts
+react: {
+    version: '19.0.0',
+    minifiedError: {
+        number: 418,
+        args: ['Foo', 'Bar'],
+        url: 'https://react.dev/errors/418?args[]=Foo&args[]=Bar',
+    },
+}
+```
+````
+
+Flare uses `react.minifiedError` and `react.version` on the backend to look up React's error-code map and surface the
+full, human-readable message. No error-code map is bundled into the client. Non-minified errors are reported unchanged.
+
+`````
+
+Note the inner ```` ```ts ```` block is nested inside the markdown example; when editing the README directly the outer fences are not literal — paste only the section content (heading, prose, and the single `ts` code block).
 
 - [ ] **Step 2: Commit**
 
 ```bash
 git add packages/react/README.md
 git commit -m "docs(react): document minified error decoding context"
-```
+`````
 
 ---
 

--- a/docs/superpowers/specs/2026-06-08-decode-minified-react-errors-design.md
+++ b/docs/superpowers/specs/2026-06-08-decode-minified-react-errors-design.md
@@ -1,0 +1,166 @@
+# Decode minified React errors (React client)
+
+Date: 2026-06-08
+Package: `@flareapp/react`
+
+## Problem
+
+Production React throws opaque errors:
+
+```
+Minified React error #418; visit https://react.dev/errors/418?args[]=foo&args[]=bar
+for the full message or use the non-minified dev environment for full errors and
+additional helpful warnings.
+```
+
+The readable message lives in React's `codes.json` (number → template with `%s`
+slots), interpolated with the `args[]` from the URL. Today Flare reports the raw
+minified message. We want the decoded, human-readable message surfaced in Flare.
+
+## Constraints
+
+- No massive bundlesize increase. React's `codes.json` is ~500 entries
+  (~30-50KB raw); bundling it into the client is rejected.
+- Scope: `@flareapp/react` only. The two error paths that own React context
+  (`FlareErrorBoundary` + `flareReactErrorHandler`) catch render/commit errors,
+  where virtually all `Minified React error #` throws originate (hydration #418,
+  hooks #310, setState-on-unmounted #185). Global `window.onerror` in
+  `@flareapp/js` is intentionally NOT touched: keeping React-specific regex out
+  of the framework-agnostic core avoids bundle cost for non-React users.
+
+## Decision: client parses, backend looks up
+
+Split the work:
+
+- Client: cheap regex parse of the error message into structured fields. Near-zero
+  bundle cost (one pure function).
+- Backend (out of scope for this repo): on seeing the structured field, do the
+  `codes.json` lookup, pick the map by React version, interpolate the template
+  with `args`. The big map stays server-side, reused across all reports,
+  version-pinned.
+
+Client attaches to the report context:
+
+```
+react.minifiedError = {
+  number: 418,
+  args: ["foo", "bar"],
+  url: "https://react.dev/errors/418?args[]=foo&args[]=bar",
+}
+react.version = "19.0.0"
+```
+
+Backend keys off presence of `react.minifiedError` to decide when to decode.
+`react.version` lets it pick the matching `codes.json` (templates drift across
+React versions).
+
+## Components
+
+### 1. `parseMinifiedReactError.ts` (new)
+
+```ts
+export type MinifiedReactError = {
+    number: number;
+    args: string[];
+    url: string | null;
+};
+
+export function parseMinifiedReactError(error: Error): MinifiedReactError | null;
+```
+
+- Match `/Minified React error #(\d+)/` against `error.message`. No match →
+  return `null`. This is the common path (most errors are not minified React
+  errors), so it exits cheap.
+- Args: match all occurrences of `args[]=<value>` in the message, `decodeURIComponent`
+  each value. Both URL formats use `args[]=` — react.dev (React 18/19) and
+  reactjs.org/docs/error-decoder.html (React 16/17).
+- URL: extract the first `https?://\S+` substring from the message; `null` if absent.
+- Guard against a missing/undefined `error.message`.
+- Pure, side-effect free, independently testable.
+
+### 2. React version
+
+`import { version } from 'react'` at module top of the shared context builder.
+React exports `version` in all peer-supported majors (16/17/18/19). Negligible
+bundle impact — the peer dep is already loaded by the host app.
+
+### 3. `buildReactContext.ts` (new, shared helper)
+
+Today `FlareErrorBoundary.componentDidCatch` and `flareReactErrorHandler` build an
+identical `context.react` block by copy-paste. This feature adds two more fields to
+that block; folding the construction into one helper removes the drift risk.
+
+```ts
+export function buildReactContext(rawStack: string, error: Error): FlareReactContext {
+    const minifiedError = parseMinifiedReactError(error);
+    return {
+        react: {
+            componentStack: formatComponentStack(rawStack),
+            componentStackFrames: parseComponentStack(rawStack),
+            version,
+            ...(minifiedError ? { minifiedError } : {}),
+        },
+    };
+}
+```
+
+Both call sites become `const context = buildReactContext(rawStack, error);`.
+
+### 4. Type extension (`types.ts`)
+
+```ts
+export type FlareReactContext = {
+    react: {
+        componentStack: string[];
+        componentStackFrames: ComponentStackFrame[];
+        version: string; // always sent
+        minifiedError?: MinifiedReactError; // only when parse matches
+    };
+};
+```
+
+### 5. `contextToAttributes.ts`
+
+Forward the two new fields under `context.custom.react`:
+
+```ts
+react: {
+    componentStack: context.react.componentStack as AttributeValue,
+    componentStackFrames: context.react.componentStackFrames as AttributeValue,
+    version: context.react.version as AttributeValue,
+    ...(context.react.minifiedError
+        ? { minifiedError: context.react.minifiedError as AttributeValue }
+        : {}),
+},
+```
+
+## Data flow
+
+1. Error caught by `FlareErrorBoundary.componentDidCatch` or `flareReactErrorHandler`.
+2. `buildReactContext(rawStack, error)` builds `context.react`, including `version`
+   always and `minifiedError` when the message parses as a minified React error.
+3. `beforeSubmit` hook can still modify/replace the context (unchanged contract).
+4. `contextToAttributes` maps it to `context.custom.react.*`.
+5. `flare.reportSilently` sends it.
+6. Backend (out of scope): detects `react.minifiedError`, looks up `codes.json` by
+   `react.version`, interpolates `args`, surfaces the decoded message.
+
+## Testing
+
+- `parseMinifiedReactError`:
+    - React 18/19 message (react.dev URL) → correct number, decoded args, url.
+    - React 16/17 message (reactjs.org error-decoder URL) → correct number, args, url.
+    - Non-minified error message → `null`.
+    - Minified message with no args → empty `args`, number + url set.
+    - URL-encoded arg values → decoded.
+    - Missing/empty `error.message` → `null`, no throw.
+- `buildReactContext`: minified error present → `minifiedError` set + `version`
+  present; plain error → no `minifiedError`, `version` present.
+- `contextToAttributes`: new fields forwarded; `minifiedError` omitted when absent.
+- Existing boundary/handler tests still pass (context shape additive, not breaking).
+
+## Out of scope
+
+- Backend `codes.json` lookup and interpolation.
+- Global `window.onerror` path in `@flareapp/js`.
+- Bundling the codes map client-side.

--- a/docs/superpowers/specs/2026-06-08-decode-minified-react-errors-design.md
+++ b/docs/superpowers/specs/2026-06-08-decode-minified-react-errors-design.md
@@ -84,6 +84,13 @@ export function parseMinifiedReactError(error: Error): MinifiedReactError | null
 React exports `version` in all peer-supported majors (16/17/18/19). Negligible
 bundle impact — the peer dep is already loaded by the host app.
 
+**Assumption:** minified errors are thrown by `react-dom`, but we send `react`'s
+`version`. React and React DOM are released in lockstep with identical version
+numbers; mismatched installs are unsupported by React itself. We therefore treat
+`react.version` as a valid proxy for the codes-map version and do not import from
+`react-dom` (which this package does not declare as a peer dependency). If
+mismatched installs ever need supporting, add a separate `reactDom.version` signal.
+
 ### 3. `buildReactContext.ts` (new, shared helper)
 
 Today `FlareErrorBoundary.componentDidCatch` and `flareReactErrorHandler` build an
@@ -113,11 +120,16 @@ export type FlareReactContext = {
     react: {
         componentStack: string[];
         componentStackFrames: ComponentStackFrame[];
-        version: string; // always sent
+        version?: string; // optional in the type (non-breaking), always populated at runtime by buildReactContext
         minifiedError?: MinifiedReactError; // only when parse matches
     };
 };
 ```
+
+`version` is optional in the exported type on purpose. `FlareReactContext` is part
+of the public `beforeSubmit`/`afterSubmit` contracts; making the field required
+would break any consumer returning a context literal, forcing a major release.
+`buildReactContext` always sets it, so it is present on every real report.
 
 ### 5. `contextToAttributes.ts`
 

--- a/docs/superpowers/specs/2026-06-08-decode-minified-react-errors-design.md
+++ b/docs/superpowers/specs/2026-06-08-decode-minified-react-errors-design.md
@@ -71,9 +71,11 @@ export function parseMinifiedReactError(error: Error): MinifiedReactError | null
 - Match `/Minified React error #(\d+)/` against `error.message`. No match →
   return `null`. This is the common path (most errors are not minified React
   errors), so it exits cheap.
-- Args: match all occurrences of `args[]=<value>` in the message, `decodeURIComponent`
-  each value. Both URL formats use `args[]=` — react.dev (React 18/19) and
-  reactjs.org/docs/error-decoder.html (React 16/17).
+- Args: match all occurrences of `args[]=<value>` in the message and percent-decode
+  each value. Decoding is wrapped in a safe helper: a malformed escape (e.g.
+  `%E0%A4%A`) must not throw, since this runs while an error is already being
+  handled; on failure the raw value is kept. Both URL formats use `args[]=` —
+  react.dev (React 18/19) and reactjs.org/docs/error-decoder.html (React 16/17).
 - URL: extract the first `https?://\S+` substring from the message; `null` if absent.
 - Guard against a missing/undefined `error.message`.
 - Pure, side-effect free, independently testable.
@@ -139,7 +141,7 @@ Forward the two new fields under `context.custom.react`:
 react: {
     componentStack: context.react.componentStack as AttributeValue,
     componentStackFrames: context.react.componentStackFrames as AttributeValue,
-    version: context.react.version as AttributeValue,
+    ...(context.react.version ? { version: context.react.version as AttributeValue } : {}),
     ...(context.react.minifiedError
         ? { minifiedError: context.react.minifiedError as AttributeValue }
         : {}),

--- a/docs/superpowers/specs/2026-06-08-decode-minified-react-errors-design.md
+++ b/docs/superpowers/specs/2026-06-08-decode-minified-react-errors-design.md
@@ -167,10 +167,12 @@ react: {
     - Non-minified error message → `null`.
     - Minified message with no args → empty `args`, number + url set.
     - URL-encoded arg values → decoded.
+    - Malformed percent escape (e.g. `%E0%A4%A`) → raw value kept, no throw.
     - Missing/empty `error.message` → `null`, no throw.
 - `buildReactContext`: minified error present → `minifiedError` set + `version`
   present; plain error → no `minifiedError`, `version` present.
-- `contextToAttributes`: new fields forwarded; `minifiedError` omitted when absent.
+- `contextToAttributes`: new fields forwarded; `minifiedError` and `version` each
+  omitted when absent.
 - Existing boundary/handler tests still pass (context shape additive, not breaking).
 
 ## Out of scope

--- a/e2e/specs/react-prod.spec.ts
+++ b/e2e/specs/react-prod.spec.ts
@@ -1,0 +1,48 @@
+import { expect, test } from '../fixtures/fake-flare';
+import type { FakeFlareRecord } from '../fixtures/fake-flare';
+
+// This suite runs only against a PRODUCTION build of the React playground
+// (E2E_PROD=1, served via `vite preview`). A development React build emits full
+// error messages, so the minified-error decode path can only be exercised here,
+// where react-dom throws a genuine "Minified React error #NNN; visit
+// https://react.dev/errors/NNN ..." for an internal invariant.
+
+type ReactContext = {
+    version?: unknown;
+    minifiedError?: { number?: unknown; args?: unknown; url?: unknown };
+};
+
+const reactContextOf = (record: FakeFlareRecord): ReactContext | undefined => {
+    const body = record.bodyJson as { attributes?: Record<string, unknown> } | null;
+    const custom = body?.attributes?.['context.custom'] as { react?: ReactContext } | undefined;
+    return custom?.react;
+};
+
+test.describe('react playground (production build)', () => {
+    test('decodes a genuine minified React error into structured context', async ({ page, fakeFlare }) => {
+        await page.goto('/react-invariant');
+        await page.waitForLoadState('networkidle');
+
+        await page.getByTestId('trigger-react-invariant-hooks').click();
+
+        const report = await fakeFlare.waitForReport({
+            timeout: 10_000,
+            predicate: (record) => Boolean(reactContextOf(record)?.minifiedError),
+        });
+
+        const react = reactContextOf(report);
+        const minifiedError = react?.minifiedError;
+
+        // The error originated from production react-dom, not an injected message:
+        // a positive error number and the canonical react.dev errors URL.
+        expect(typeof minifiedError?.number).toBe('number');
+        expect(minifiedError?.number as number).toBeGreaterThan(0);
+        expect(String(minifiedError?.url)).toMatch(/react\.dev\/errors\/\d+/);
+        expect(Array.isArray(minifiedError?.args)).toBe(true);
+
+        // The running React version travels alongside so the backend can pick the
+        // matching error-code map.
+        expect(typeof react?.version).toBe('string');
+        expect(String(react?.version).length).toBeGreaterThan(0);
+    });
+});

--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
         "lint": "oxlint",
         "prepare": "husky",
         "test:e2e": "playwright test",
+        "pretest:e2e:prod": "npm run build --workspace=@flareapp/core --workspace=@flareapp/js --workspace=@flareapp/react",
+        "test:e2e:prod": "E2E_PROD=1 playwright test --project=react-prod",
         "pretest:e2e:node": "npm run build --workspace=@flareapp/core --workspace=@flareapp/node",
         "test:e2e:node": "playwright test -c playwright.node.config.ts",
         "typecheck:e2e": "tsc --noEmit -p e2e/tsconfig.json",

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -41,6 +41,26 @@ flare.configure({ enableLogs: true });
 flare.logger.info('Checkout started', { cartId: cart.id, total: cart.total });
 ```
 
+## Minified production errors
+
+In production, React throws minified errors like `Minified React error #418; visit https://react.dev/errors/418?args[]=Foo`.
+The client parses these into structured fields and attaches them, along with the running React version, to the report
+context:
+
+```ts
+react: {
+    version: '19.0.0',
+    minifiedError: {
+        number: 418,
+        args: ['Foo', 'Bar'],
+        url: 'https://react.dev/errors/418?args[]=Foo&args[]=Bar',
+    },
+}
+```
+
+Flare uses `react.minifiedError` and `react.version` on the backend to look up React's error-code map and surface the
+full, human-readable message. No error-code map is bundled into the client. Non-minified errors are reported unchanged.
+
 ## Documentation
 
 Full documentation on the error boundary, the React 19+ error handler, lifecycle callbacks, and more is available

--- a/packages/react/src/FlareErrorBoundary.ts
+++ b/packages/react/src/FlareErrorBoundary.ts
@@ -1,9 +1,8 @@
 import { flare } from '@flareapp/js';
 import { Component, ErrorInfo, type PropsWithChildren, type ReactNode } from 'react';
 
+import { buildReactContext } from './buildReactContext';
 import { contextToAttributes } from './contextToAttributes';
-import { formatComponentStack } from './formatComponentStack';
-import { parseComponentStack } from './parseComponentStack';
 import { FlareReactContext } from './types';
 
 export type FlareErrorBoundaryFallbackProps = {
@@ -41,12 +40,7 @@ export class FlareErrorBoundary extends Component<FlareErrorBoundaryProps, Flare
 
         const rawStack = errorInfo.componentStack ?? '';
 
-        const context: FlareReactContext = {
-            react: {
-                componentStack: formatComponentStack(rawStack),
-                componentStackFrames: parseComponentStack(rawStack),
-            },
-        };
+        const context = buildReactContext(rawStack, error);
 
         const finalContext =
             this.props.beforeSubmit?.({

--- a/packages/react/src/buildReactContext.ts
+++ b/packages/react/src/buildReactContext.ts
@@ -1,0 +1,19 @@
+import { version } from 'react';
+
+import { formatComponentStack } from './formatComponentStack';
+import { parseComponentStack } from './parseComponentStack';
+import { parseMinifiedReactError } from './parseMinifiedReactError';
+import type { FlareReactContext } from './types';
+
+export function buildReactContext(rawStack: string, error: Error): FlareReactContext {
+    const minifiedError = parseMinifiedReactError(error);
+
+    return {
+        react: {
+            componentStack: formatComponentStack(rawStack),
+            componentStackFrames: parseComponentStack(rawStack),
+            version,
+            ...(minifiedError ? { minifiedError } : {}),
+        },
+    };
+}

--- a/packages/react/src/contextToAttributes.ts
+++ b/packages/react/src/contextToAttributes.ts
@@ -8,6 +8,10 @@ export function contextToAttributes(context: FlareReactContext): Attributes {
             react: {
                 componentStack: context.react.componentStack as AttributeValue,
                 componentStackFrames: context.react.componentStackFrames as AttributeValue,
+                ...(context.react.version ? { version: context.react.version as AttributeValue } : {}),
+                ...(context.react.minifiedError
+                    ? { minifiedError: context.react.minifiedError as AttributeValue }
+                    : {}),
             },
         },
     };

--- a/packages/react/src/flareReactErrorHandler.ts
+++ b/packages/react/src/flareReactErrorHandler.ts
@@ -1,8 +1,7 @@
 import { convertToError, flare } from '@flareapp/js';
 
+import { buildReactContext } from './buildReactContext';
 import { contextToAttributes } from './contextToAttributes';
-import { formatComponentStack } from './formatComponentStack';
-import { parseComponentStack } from './parseComponentStack';
 import { FlareReactContext } from './types';
 
 export type FlareReactErrorHandlerCallback = (error: unknown, errorInfo: { componentStack?: string }) => void;
@@ -31,12 +30,7 @@ export function flareReactErrorHandler(options?: FlareReactErrorHandlerOptions):
 
         const rawStack = errorInfo.componentStack ?? '';
 
-        const context: FlareReactContext = {
-            react: {
-                componentStack: formatComponentStack(rawStack),
-                componentStackFrames: parseComponentStack(rawStack),
-            },
-        };
+        const context = buildReactContext(rawStack, errorObject);
 
         const finalContext =
             options?.beforeSubmit?.({

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -14,4 +14,4 @@ export {
     type FlareReactErrorHandlerOptions,
 } from './flareReactErrorHandler';
 
-export type { ComponentStackFrame, FlareReactContext } from './types';
+export type { ComponentStackFrame, FlareReactContext, MinifiedReactError } from './types';

--- a/packages/react/src/parseMinifiedReactError.ts
+++ b/packages/react/src/parseMinifiedReactError.ts
@@ -1,0 +1,44 @@
+import type { MinifiedReactError } from './types';
+
+const NUMBER_PATTERN = /Minified React error #(\d+)/;
+const ARG_PATTERN = /args\[\]=([^&\s]*)/g;
+const URL_PATTERN = /(https?:\/\/\S+)/;
+
+// decodeURIComponent throws on malformed percent escapes (e.g. "%E0%A4%A"). This
+// runs while the boundary/handler is already processing an error, so a throw here
+// must not escape. Fall back to the raw value instead.
+function safeDecode(value: string): string {
+    try {
+        return decodeURIComponent(value);
+    } catch {
+        return value;
+    }
+}
+
+export function parseMinifiedReactError(error: Error): MinifiedReactError | null {
+    const message = error?.message;
+
+    if (!message) {
+        return null;
+    }
+
+    const numberMatch = message.match(NUMBER_PATTERN);
+
+    if (!numberMatch) {
+        return null;
+    }
+
+    const args: string[] = [];
+
+    for (const match of message.matchAll(ARG_PATTERN)) {
+        args.push(safeDecode(match[1]));
+    }
+
+    const urlMatch = message.match(URL_PATTERN);
+
+    return {
+        number: Number(numberMatch[1]),
+        args,
+        url: urlMatch ? urlMatch[1] : null,
+    };
+}

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -5,6 +5,12 @@ export type ComponentStackFrame = {
     column: number | null;
 };
 
+export type MinifiedReactError = {
+    number: number;
+    args: string[];
+    url: string | null;
+};
+
 export type FlareReactContext = {
     react: {
         componentStack: string[];

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -15,5 +15,7 @@ export type FlareReactContext = {
     react: {
         componentStack: string[];
         componentStackFrames: ComponentStackFrame[];
+        version?: string;
+        minifiedError?: MinifiedReactError;
     };
 };

--- a/packages/react/tests/FlareErrorBoundary.test.tsx
+++ b/packages/react/tests/FlareErrorBoundary.test.tsx
@@ -491,4 +491,39 @@ describe('FlareErrorBoundary', () => {
         expect(beforeSubmit).toHaveBeenCalledTimes(2);
         expect(afterSubmit).toHaveBeenCalledTimes(2);
     });
+
+    describe('minified React errors', () => {
+        test('forwards minifiedError and version in the reported attributes', () => {
+            testError = new Error(
+                'Minified React error #418; visit https://react.dev/errors/418?args[]=Foo for the full message',
+            );
+
+            render(
+                <FlareErrorBoundary fallback={<div>Error</div>}>
+                    <ThrowingComponent />
+                </FlareErrorBoundary>,
+            );
+
+            const attributes = mockReport.mock.calls[0][1];
+            const react = (attributes['context.custom'] as any).react;
+
+            expect(react.minifiedError).toEqual({
+                number: 418,
+                args: ['Foo'],
+                url: 'https://react.dev/errors/418?args[]=Foo',
+            });
+            expect(typeof react.version).toBe('string');
+        });
+
+        test('omits minifiedError for a plain error', () => {
+            render(
+                <FlareErrorBoundary fallback={<div>Error</div>}>
+                    <ThrowingComponent />
+                </FlareErrorBoundary>,
+            );
+
+            const attributes = mockReport.mock.calls[0][1];
+            expect((attributes['context.custom'] as any).react).not.toHaveProperty('minifiedError');
+        });
+    });
 });

--- a/packages/react/tests/buildReactContext.test.ts
+++ b/packages/react/tests/buildReactContext.test.ts
@@ -1,0 +1,43 @@
+import { version as reactVersion } from 'react';
+import { describe, expect, test } from 'vitest';
+
+import { buildReactContext } from '../src/buildReactContext';
+
+const stack = '\n    at App (http://localhost:5173/src/App.tsx:5:3)\n';
+
+describe('buildReactContext', () => {
+    test('includes the React version on every context', () => {
+        const context = buildReactContext(stack, new Error('plain error'));
+
+        expect(context.react.version).toBe(reactVersion);
+    });
+
+    test('parses component stack into componentStack and componentStackFrames', () => {
+        const context = buildReactContext(stack, new Error('plain error'));
+
+        expect(context.react.componentStack).toEqual(['at App (http://localhost:5173/src/App.tsx:5:3)']);
+        expect(context.react.componentStackFrames).toEqual([
+            { component: 'App', file: 'http://localhost:5173/src/App.tsx', line: 5, column: 3 },
+        ]);
+    });
+
+    test('omits minifiedError for a plain error', () => {
+        const context = buildReactContext(stack, new Error('plain error'));
+
+        expect(context.react.minifiedError).toBeUndefined();
+    });
+
+    test('attaches minifiedError for a minified React error', () => {
+        const error = new Error(
+            'Minified React error #418; visit https://react.dev/errors/418?args[]=Foo for the full message',
+        );
+
+        const context = buildReactContext(stack, error);
+
+        expect(context.react.minifiedError).toEqual({
+            number: 418,
+            args: ['Foo'],
+            url: 'https://react.dev/errors/418?args[]=Foo',
+        });
+    });
+});

--- a/packages/react/tests/contextToAttributes.test.ts
+++ b/packages/react/tests/contextToAttributes.test.ts
@@ -4,11 +4,12 @@ import { contextToAttributes } from '../src/contextToAttributes';
 import { FlareReactContext } from '../src/types';
 
 describe('contextToAttributes', () => {
-    test('wraps react context under context.custom', () => {
+    test('wraps react context (with version) under context.custom', () => {
         const context: FlareReactContext = {
             react: {
                 componentStack: ['at App', 'at div'],
                 componentStackFrames: [{ component: 'App', file: 'App.tsx', line: 5, column: 3 }],
+                version: '19.0.0',
             },
         };
 
@@ -19,12 +20,46 @@ describe('contextToAttributes', () => {
                 react: {
                     componentStack: ['at App', 'at div'],
                     componentStackFrames: [{ component: 'App', file: 'App.tsx', line: 5, column: 3 }],
+                    version: '19.0.0',
                 },
             },
         });
     });
 
-    test('handles empty component stack', () => {
+    test('forwards minifiedError when present', () => {
+        const context: FlareReactContext = {
+            react: {
+                componentStack: [],
+                componentStackFrames: [],
+                version: '19.0.0',
+                minifiedError: { number: 418, args: ['Foo'], url: 'https://react.dev/errors/418?args[]=Foo' },
+            },
+        };
+
+        const attributes = contextToAttributes(context);
+
+        expect((attributes['context.custom'] as any).react.minifiedError).toEqual({
+            number: 418,
+            args: ['Foo'],
+            url: 'https://react.dev/errors/418?args[]=Foo',
+        });
+    });
+
+    test('omits minifiedError when absent', () => {
+        const context: FlareReactContext = {
+            react: {
+                componentStack: [],
+                componentStackFrames: [],
+                version: '19.0.0',
+            },
+        };
+
+        const attributes = contextToAttributes(context);
+
+        expect((attributes['context.custom'] as any).react).not.toHaveProperty('minifiedError');
+    });
+
+    test('omits version when a context has none (e.g. a beforeSubmit literal)', () => {
         const context: FlareReactContext = {
             react: {
                 componentStack: [],
@@ -34,11 +69,6 @@ describe('contextToAttributes', () => {
 
         const attributes = contextToAttributes(context);
 
-        expect(attributes['context.custom']).toEqual({
-            react: {
-                componentStack: [],
-                componentStackFrames: [],
-            },
-        });
+        expect((attributes['context.custom'] as any).react).not.toHaveProperty('version');
     });
 });

--- a/packages/react/tests/flareReactErrorHandler.test.ts
+++ b/packages/react/tests/flareReactErrorHandler.test.ts
@@ -348,4 +348,34 @@ describe('flareReactErrorHandler', () => {
             expect(afterSubmit.mock.calls[0][0].context.react.componentStack).toEqual(['at App']);
         });
     });
+
+    describe('minified React errors', () => {
+        test('forwards minifiedError and version in the reported attributes', () => {
+            const handler = flareReactErrorHandler();
+            const error = new Error(
+                'Minified React error #418; visit https://react.dev/errors/418?args[]=Foo for the full message',
+            );
+
+            handler(error, { componentStack: '    at App' });
+
+            const attributes = mockReport.mock.calls[0][1];
+            const react = (attributes['context.custom'] as any).react;
+
+            expect(react.minifiedError).toEqual({
+                number: 418,
+                args: ['Foo'],
+                url: 'https://react.dev/errors/418?args[]=Foo',
+            });
+            expect(typeof react.version).toBe('string');
+        });
+
+        test('omits minifiedError for a plain error', () => {
+            const handler = flareReactErrorHandler();
+
+            handler(new Error('plain error'), { componentStack: '    at App' });
+
+            const attributes = mockReport.mock.calls[0][1];
+            expect((attributes['context.custom'] as any).react).not.toHaveProperty('minifiedError');
+        });
+    });
 });

--- a/packages/react/tests/parseMinifiedReactError.test.ts
+++ b/packages/react/tests/parseMinifiedReactError.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from 'vitest';
+
+import { parseMinifiedReactError } from '../src/parseMinifiedReactError';
+
+describe('parseMinifiedReactError', () => {
+    test('parses a React 18/19 message (react.dev URL)', () => {
+        const error = new Error(
+            'Minified React error #418; visit https://react.dev/errors/418?args[]=Foo&args[]=Bar for the full message',
+        );
+
+        expect(parseMinifiedReactError(error)).toEqual({
+            number: 418,
+            args: ['Foo', 'Bar'],
+            url: 'https://react.dev/errors/418?args[]=Foo&args[]=Bar',
+        });
+    });
+
+    test('parses a React 16/17 message (reactjs.org error-decoder URL)', () => {
+        const error = new Error(
+            'Minified React error #185; visit https://reactjs.org/docs/error-decoder.html?invariant=185&args[]=Foo for the full message',
+        );
+
+        expect(parseMinifiedReactError(error)).toEqual({
+            number: 185,
+            args: ['Foo'],
+            url: 'https://reactjs.org/docs/error-decoder.html?invariant=185&args[]=Foo',
+        });
+    });
+
+    test('returns null for a non-minified error message', () => {
+        expect(parseMinifiedReactError(new Error('Cannot read properties of undefined'))).toBeNull();
+    });
+
+    test('handles a minified message with no args', () => {
+        const error = new Error('Minified React error #310; visit https://react.dev/errors/310 for the full message');
+
+        expect(parseMinifiedReactError(error)).toEqual({
+            number: 310,
+            args: [],
+            url: 'https://react.dev/errors/310',
+        });
+    });
+
+    test('URL-decodes arg values', () => {
+        const error = new Error(
+            'Minified React error #418; visit https://react.dev/errors/418?args[]=%3Cdiv%3E&args[]=%20%26%20 for the full message',
+        );
+
+        expect(parseMinifiedReactError(error)).toEqual({
+            number: 418,
+            args: ['<div>', ' & '],
+            url: 'https://react.dev/errors/418?args[]=%3Cdiv%3E&args[]=%20%26%20',
+        });
+    });
+
+    test('returns null for an empty message without throwing', () => {
+        expect(parseMinifiedReactError(new Error(''))).toBeNull();
+    });
+
+    test('falls back to the raw arg value when percent-decoding fails', () => {
+        const error = new Error(
+            'Minified React error #418; visit https://react.dev/errors/418?args[]=%E0%A4%A&args[]=ok for the full message',
+        );
+
+        // `%E0%A4%A` is a malformed percent escape; decodeURIComponent would throw.
+        // The parser must not throw mid-error-handling and keeps the raw value instead.
+        expect(parseMinifiedReactError(error)).toEqual({
+            number: 418,
+            args: ['%E0%A4%A', 'ok'],
+            url: 'https://react.dev/errors/418?args[]=%E0%A4%A&args[]=ok',
+        });
+    });
+});

--- a/playgrounds/react/src/router.tsx
+++ b/playgrounds/react/src/router.tsx
@@ -7,6 +7,7 @@ import { checkoutRoute } from './routes/checkout';
 import { confirmationRoute } from './routes/confirmation';
 import { indexRoute } from './routes/index';
 import { productRoute } from './routes/product.$id';
+import { reactInvariantRoute } from './routes/reactInvariant';
 
 const routeTree = rootRoute.addChildren([
     indexRoute,
@@ -15,6 +16,7 @@ const routeTree = rootRoute.addChildren([
     checkoutRoute,
     confirmationRoute,
     brokenRoute,
+    reactInvariantRoute,
 ]);
 
 // Disable TanStack Router's default per-route error component so render errors

--- a/playgrounds/react/src/routes/reactInvariant.tsx
+++ b/playgrounds/react/src/routes/reactInvariant.tsx
@@ -1,0 +1,49 @@
+import { createRoute } from '@tanstack/react-router';
+import { useState } from 'react';
+
+import { rootRoute } from './__root';
+
+// Triggers a genuine React hooks-order invariant during render. In a production
+// react-dom build this surfaces as "Minified React error #310; visit
+// https://react.dev/errors/310 ..." rather than the dev-mode full message, which
+// is exactly what the prod-build e2e spec needs to exercise the decode path.
+// The error bubbles to the outer FlareErrorBoundary (see main.tsx).
+const HookOrderBomb = ({ armed }: { armed: boolean }) => {
+    useState(0);
+
+    if (armed) {
+        // This second hook only runs after arming, so the hook count grows between
+        // renders: "Rendered more hooks than during the previous render."
+        useState(1);
+    }
+
+    return null;
+};
+
+const ReactInvariantPage = () => {
+    const [armed, setArmed] = useState(false);
+
+    return (
+        <section>
+            <h1 className="text-xl font-semibold mb-2">React invariant</h1>
+            <p className="text-sm opacity-70 mb-6">
+                Triggers a real React hooks-order error (minified in production builds).
+            </p>
+            <button
+                type="button"
+                data-testid="trigger-react-invariant-hooks"
+                onClick={() => setArmed(true)}
+                className="rounded-lg border border-surface-border bg-surface px-4 py-3 text-sm hover:border-brand"
+            >
+                Trigger hooks-order invariant
+            </button>
+            <HookOrderBomb armed={armed} />
+        </section>
+    );
+};
+
+export const reactInvariantRoute = createRoute({
+    getParentRoute: () => rootRoute,
+    path: '/react-invariant',
+    component: ReactInvariantPage,
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,6 +8,92 @@ const sharedEnv = {
     FAKE_FLARE_PORT,
 };
 
+// Opt-in production-build suite. The default e2e run boots each playground with
+// `vite dev` (React development build), which never emits the "Minified React
+// error #NNN" strings the decode path keys on. The prod suite instead builds the
+// React playground and serves it with `vite preview` so a genuine minified error
+// is produced. Enable with E2E_PROD=1 (see the `test:e2e:prod` npm script).
+const prod = !!process.env.E2E_PROD;
+
+const REACT_PROD_PORT = 5191;
+
+const devProjects = [
+    {
+        name: 'js',
+        testMatch: /js\.spec\.ts$/,
+        use: { baseURL: 'http://localhost:5180', browserName: 'chromium' as const },
+    },
+    {
+        name: 'react',
+        testMatch: /react\.spec\.ts$/,
+        use: { baseURL: 'http://localhost:5181', browserName: 'chromium' as const },
+    },
+    {
+        name: 'vue',
+        testMatch: /vue\.spec\.ts$/,
+        use: { baseURL: 'http://localhost:5182', browserName: 'chromium' as const },
+    },
+    {
+        name: 'svelte',
+        testMatch: /svelte\.spec\.ts$/,
+        use: { baseURL: 'http://localhost:5183', browserName: 'chromium' as const },
+    },
+];
+
+const prodProjects = [
+    {
+        name: 'react-prod',
+        testMatch: /react-prod\.spec\.ts$/,
+        use: { baseURL: `http://localhost:${REACT_PROD_PORT}`, browserName: 'chromium' as const },
+    },
+];
+
+const devWebServers = [
+    {
+        command: 'npm run dev --workspace=@flareapp/playgrounds-js',
+        url: 'http://localhost:5180',
+        reuseExistingServer: !process.env.CI,
+        timeout: 60_000,
+        env: { ...sharedEnv, VITE_FLARE_KEY: 'test-key-js' },
+    },
+    {
+        command: 'npm run dev --workspace=@flareapp/playgrounds-react',
+        url: 'http://localhost:5181',
+        reuseExistingServer: !process.env.CI,
+        timeout: 60_000,
+        env: { ...sharedEnv, VITE_FLARE_KEY: 'test-key-react' },
+    },
+    {
+        command: 'npm run dev --workspace=@flareapp/playgrounds-vue',
+        url: 'http://localhost:5182',
+        reuseExistingServer: !process.env.CI,
+        timeout: 60_000,
+        env: { ...sharedEnv, VITE_FLARE_KEY: 'test-key-vue' },
+    },
+    {
+        command: 'npm run dev --workspace=@flareapp/playgrounds-svelte',
+        url: 'http://localhost:5183',
+        reuseExistingServer: !process.env.CI,
+        timeout: 90_000,
+        env: { ...sharedEnv, VITE_FLARE_KEY: 'test-key-svelte' },
+    },
+];
+
+// VITE_FLARE_URL is inlined into the bundle at build time, so it must be present
+// for `vite build`, not just `vite preview`; the single shell command applies the
+// env to both. --strictPort fails fast if the preview port is taken.
+const prodWebServers = [
+    {
+        command:
+            `npm run build --workspace=@flareapp/playgrounds-react && ` +
+            `npm run preview --workspace=@flareapp/playgrounds-react -- --port ${REACT_PROD_PORT} --strictPort`,
+        url: `http://localhost:${REACT_PROD_PORT}`,
+        reuseExistingServer: !process.env.CI,
+        timeout: 180_000,
+        env: { ...sharedEnv, VITE_FLARE_KEY: 'test-key-react' },
+    },
+];
+
 export default defineConfig({
     testDir: './e2e/specs',
     timeout: 30_000,
@@ -20,56 +106,6 @@ export default defineConfig({
     use: {
         trace: 'retain-on-failure',
     },
-    projects: [
-        {
-            name: 'js',
-            testMatch: /js\.spec\.ts$/,
-            use: { baseURL: 'http://localhost:5180', browserName: 'chromium' },
-        },
-        {
-            name: 'react',
-            testMatch: /react\.spec\.ts$/,
-            use: { baseURL: 'http://localhost:5181', browserName: 'chromium' },
-        },
-        {
-            name: 'vue',
-            testMatch: /vue\.spec\.ts$/,
-            use: { baseURL: 'http://localhost:5182', browserName: 'chromium' },
-        },
-        {
-            name: 'svelte',
-            testMatch: /svelte\.spec\.ts$/,
-            use: { baseURL: 'http://localhost:5183', browserName: 'chromium' },
-        },
-    ],
-    webServer: [
-        {
-            command: 'npm run dev --workspace=@flareapp/playgrounds-js',
-            url: 'http://localhost:5180',
-            reuseExistingServer: !process.env.CI,
-            timeout: 60_000,
-            env: { ...sharedEnv, VITE_FLARE_KEY: 'test-key-js' },
-        },
-        {
-            command: 'npm run dev --workspace=@flareapp/playgrounds-react',
-            url: 'http://localhost:5181',
-            reuseExistingServer: !process.env.CI,
-            timeout: 60_000,
-            env: { ...sharedEnv, VITE_FLARE_KEY: 'test-key-react' },
-        },
-        {
-            command: 'npm run dev --workspace=@flareapp/playgrounds-vue',
-            url: 'http://localhost:5182',
-            reuseExistingServer: !process.env.CI,
-            timeout: 60_000,
-            env: { ...sharedEnv, VITE_FLARE_KEY: 'test-key-vue' },
-        },
-        {
-            command: 'npm run dev --workspace=@flareapp/playgrounds-svelte',
-            url: 'http://localhost:5183',
-            reuseExistingServer: !process.env.CI,
-            timeout: 90_000,
-            env: { ...sharedEnv, VITE_FLARE_KEY: 'test-key-svelte' },
-        },
-    ],
+    projects: prod ? prodProjects : devProjects,
+    webServer: prod ? prodWebServers : devWebServers,
 });


### PR DESCRIPTION
## Summary

Lets Flare decode minified React production errors (e.g. `Minified React error #418; visit https://react.dev/errors/418?args[]=Foo ...`) without bundling React's error-code map.

- New `parseMinifiedReactError` pure parser extracts `{ number, args, url }` from the error message. Percent-decoding is throw-safe (falls back to the raw value), since it runs mid-error-handling.
- New shared `buildReactContext` helper replaces the previously copy-pasted `context.react` block in `FlareErrorBoundary` and `flareReactErrorHandler`, and attaches the running React `version` (always) plus `minifiedError` (only when the error parses as minified).
- `contextToAttributes` forwards `version` and `minifiedError` under `context.custom.react`. The Flare backend keys off `react.minifiedError` to look up the codes map (by `react.version`) and surface the human-readable message. The lookup map stays server-side.
- `version` is optional in the exported `FlareReactContext` type to keep the public `beforeSubmit`/`afterSubmit` contracts non-breaking; it is always populated at runtime.
- `MinifiedReactError` is exported from the package entry.

### Scope / constraints

- No `codes.json` bundled and no new dependencies. ESM build stays ~5.4 kB (gzip ~1.7 kB).
- Decoding (codes-map lookup + interpolation) is intentionally out of scope here; it lands on the Flare backend.
- The global `window.onerror` path in `@flareapp/js` is intentionally untouched, keeping React-specific parsing out of the framework-agnostic core. The boundary + handler paths catch the render/commit errors where these throws originate.
- Assumption: minified errors come from `react-dom`, but we send `react`'s `version`. React and React DOM ship in lockstep; mismatched installs are unsupported by React. A `reactDom.version` signal can be added later if needed.

## Test Plan

- [x] `npm run typescript` (whole repo) clean
- [x] `packages/react` vitest suite green (90 tests), incl. parser unit tests and end-to-end assertions that `minifiedError` + `version` reach the reported attributes through both the boundary and the handler
- [x] `npm run build` for `@flareapp/react` clean (CJS + ESM + d.ts), confirms `import { version } from 'react'` resolves against the peer dep