### PR TITLE
feat(vue): @flareapp/vue/inject entry for Electron renderers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ package, and a Playwright-based e2e suite:
 | `packages/core`      | `@flareapp/core`               | Environment-agnostic Flare core (shared between js + node)                                  |
 | `packages/js`        | `@flareapp/js`                 | Core client — error capture, stack traces, context, API reporting                           |
 | `packages/react`     | `@flareapp/react`              | React `FlareErrorBoundary` error boundary component; `/inject` entry for Electron renderers |
-| `packages/vue`       | `@flareapp/vue`                | Vue error handler plugin (`flareVue()`)                                                     |
+| `packages/vue`       | `@flareapp/vue`                | Vue error handler plugin (`flareVue()`); `/inject` entry for Electron renderers             |
 | `packages/svelte`    | `@flareapp/svelte`             | Svelte 5 `FlareErrorBoundary` with props serialization                                      |
 | `packages/sveltekit` | `@flareapp/sveltekit`          | SvelteKit error hooks (`handleErrorWithFlare`) + route context                              |
 | `packages/vite`      | `@flareapp/vite`               | Vite build plugin for sourcemap upload with retry logic                                     |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,26 +25,26 @@ integrations for React, Vue, and Svelte, and a Vite plugin for sourcemap uploads
 npm workspaces monorepo with 8 published packages, 1 internal package, 4 framework playground apps, a shared fixture
 package, and a Playwright-based e2e suite:
 
-| Package              | npm name                       | Purpose                                                                                     |
-| -------------------- | ------------------------------ | ------------------------------------------------------------------------------------------- |
-| `packages/core`      | `@flareapp/core`               | Environment-agnostic Flare core (shared between js + node)                                  |
-| `packages/js`        | `@flareapp/js`                 | Core client — error capture, stack traces, context, API reporting                           |
-| `packages/react`     | `@flareapp/react`              | React `FlareErrorBoundary` error boundary component; `/inject` entry for Electron renderers |
-| `packages/vue`       | `@flareapp/vue`                | Vue error handler plugin (`flareVue()`); `/inject` entry for Electron renderers             |
-| `packages/svelte`    | `@flareapp/svelte`             | Svelte 5 `FlareErrorBoundary` with props serialization                                      |
-| `packages/sveltekit` | `@flareapp/sveltekit`          | SvelteKit error hooks (`handleErrorWithFlare`) + route context                              |
-| `packages/vite`      | `@flareapp/vite`               | Vite build plugin for sourcemap upload with retry logic                                     |
-| `packages/webpack`   | `@flareapp/webpack`            | Webpack 5 plugin for sourcemap upload                                                       |
-| `packages/nextjs`    | `@flareapp/nextjs`             | Next.js wrapper (`withFlareSourcemaps`) for sourcemap upload                                |
-| `packages/node`      | `@flareapp/node`               | Node.js SDK (process handlers, AsyncLocalStorage scope)                                     |
-| `packages/electron`  | `@flareapp/electron`           | Electron SDK (main + preload + renderer, IPC-unified)                                       |
-| `packages/flare-api` | `@flareapp/flare-api`          | Shared API client for sourcemap uploads (private, not published)                            |
-| `playgrounds/shared` | `@flareapp/playgrounds-shared` | Shared TS fixtures: products, scenarios, testIds, Tailwind tokens                           |
-| `playgrounds/js`     | `@flareapp/playgrounds-js`     | Vanilla TS + Vite webshop (port 5180)                                                       |
-| `playgrounds/react`  | `@flareapp/playgrounds-react`  | React 19 + TanStack Router webshop (port 5181)                                              |
-| `playgrounds/vue`    | `@flareapp/playgrounds-vue`    | Vue 3 + vue-router webshop (port 5182)                                                      |
-| `playgrounds/svelte` | `@flareapp/playgrounds-svelte` | SvelteKit (adapter-node) webshop (port 5183)                                                |
-| `e2e/`               | (not a workspace)              | Playwright specs + fake-flare-server fixture                                                |
+| Package              | npm name                       | Purpose                                                                                        |
+| -------------------- | ------------------------------ | ---------------------------------------------------------------------------------------------- |
+| `packages/core`      | `@flareapp/core`               | Environment-agnostic Flare core (shared between js + node)                                     |
+| `packages/js`        | `@flareapp/js`                 | Core client — error capture, stack traces, context, API reporting                              |
+| `packages/react`     | `@flareapp/react`              | React `FlareErrorBoundary` error boundary component; `/inject` entry for Electron renderers    |
+| `packages/vue`       | `@flareapp/vue`                | Vue error handler plugin (`flareVue()`); `/inject` entry for Electron renderers                |
+| `packages/svelte`    | `@flareapp/svelte`             | Svelte 5 `FlareErrorBoundary` with props serialization; `/inject` entry for Electron renderers |
+| `packages/sveltekit` | `@flareapp/sveltekit`          | SvelteKit error hooks (`handleErrorWithFlare`) + route context                                 |
+| `packages/vite`      | `@flareapp/vite`               | Vite build plugin for sourcemap upload with retry logic                                        |
+| `packages/webpack`   | `@flareapp/webpack`            | Webpack 5 plugin for sourcemap upload                                                          |
+| `packages/nextjs`    | `@flareapp/nextjs`             | Next.js wrapper (`withFlareSourcemaps`) for sourcemap upload                                   |
+| `packages/node`      | `@flareapp/node`               | Node.js SDK (process handlers, AsyncLocalStorage scope)                                        |
+| `packages/electron`  | `@flareapp/electron`           | Electron SDK (main + preload + renderer, IPC-unified)                                          |
+| `packages/flare-api` | `@flareapp/flare-api`          | Shared API client for sourcemap uploads (private, not published)                               |
+| `playgrounds/shared` | `@flareapp/playgrounds-shared` | Shared TS fixtures: products, scenarios, testIds, Tailwind tokens                              |
+| `playgrounds/js`     | `@flareapp/playgrounds-js`     | Vanilla TS + Vite webshop (port 5180)                                                          |
+| `playgrounds/react`  | `@flareapp/playgrounds-react`  | React 19 + TanStack Router webshop (port 5181)                                                 |
+| `playgrounds/vue`    | `@flareapp/playgrounds-vue`    | Vue 3 + vue-router webshop (port 5182)                                                         |
+| `playgrounds/svelte` | `@flareapp/playgrounds-svelte` | SvelteKit (adapter-node) webshop (port 5183)                                                   |
+| `e2e/`               | (not a workspace)              | Playwright specs + fake-flare-server fixture                                                   |
 
 ## Tech stack
 

--- a/docs/superpowers/plans/2026-06-16-vue-electron-injection.md
+++ b/docs/superpowers/plans/2026-06-16-vue-electron-injection.md
@@ -328,7 +328,13 @@ registerDefaultFlare(() => mockedRoot as any);
 
 (Adapt to whatever the existing mock binding names are; preserve what existing tests rely on. If the existing file already mocks `@flareapp/js`, extend that mock rather than duplicating it.)
 
-Add these tests (use `createApp` from `vue` and a minimal component; mirror how existing tests trigger `app.config.errorHandler`):
+The current `flareVue.test.ts` imports only `import type { ComponentPublicInstance } from 'vue';`. These tests need `createApp` (a value import), so update that line to:
+
+```ts
+import { createApp, type ComponentPublicInstance } from 'vue';
+```
+
+Add these tests (use `createApp` and a minimal component; mirror how existing tests trigger `app.config.errorHandler`):
 
 ```ts
 test('reports through an injected flare instance, not the default', () => {
@@ -415,10 +421,31 @@ import { resolveFlare } from './resolveFlare';
 import { registerVueSdkInfo, tagVueFramework } from './identify';
 ```
 
-Inside the `flareVue` install function, AFTER the `installedApps` guard and BEFORE the current `flare.setSdkInfo(...)` / `flare.setFramework(...)` lines, resolve the instance and replace the identity block:
+Reorder the top of the install function so resolution happens BEFORE the app is marked installed. The current code is:
 
 ```ts
+if (installedApps.has(app)) {
+    return;
+}
+installedApps.add(app); // <- currently here, BEFORE identity
+
+flare.setSdkInfo({ name: '@flareapp/vue', version: PACKAGE_VERSION });
+flare.setFramework({ name: 'Vue', version: app.version });
+```
+
+Change it to (resolve, THEN add):
+
+```ts
+if (installedApps.has(app)) {
+    return;
+}
+
+// Resolve BEFORE marking the app installed. resolveFlare can throw (an /inject consumer that
+// forgot the `flare` option). If we added to installedApps first, a throw would poison the
+// WeakSet: a corrected retry would hit the `has(app)` guard and silently no-op.
 const flare = resolveFlare(options?.flare);
+
+installedApps.add(app);
 
 // Web default (no injected instance): set the SDK identity on the singleton, as before.
 // Injected instance: tag the framework only — never setSdkInfo (would clobber @flareapp/electron).
@@ -428,7 +455,7 @@ if (!options?.flare) {
 tagVueFramework(flare, app.version);
 ```
 
-Delete the old `flare.setSdkInfo({ name: '@flareapp/vue', version: PACKAGE_VERSION });` and `flare.setFramework({ name: 'Vue', version: app.version });` lines (now handled above). Remove the now-unused `PACKAGE_VERSION` import from flareVue.ts IF it becomes unused (check — it may still be used elsewhere in the file; only remove if oxlint flags it unused).
+The old `flare.setSdkInfo(...)` / `flare.setFramework(...)` lines are now replaced by the block above. Remove the now-unused `PACKAGE_VERSION` import from flareVue.ts IF oxlint flags it unused (it moved into identify.ts).
 
 Every other `flare.reportSilently(...)` / `flare.reportMessage(...)` in the install closure now refers to the locally-resolved `const flare` (block-scoped), so they automatically route through the resolved instance. Confirm there are no remaining references to a module-level `flare`.
 
@@ -684,10 +711,31 @@ describe('@flareapp/vue/inject entry', () => {
             /No Flare instance available/,
         );
     });
+
+    test('a failed install does not poison installedApps: a retry with a valid flare still installs', async () => {
+        const { flareVue } = await import('../src/inject');
+        const app = createApp({ render: () => null });
+
+        // Call the plugin function DIRECTLY (not via app.use) so Vue's own plugin-dedup does not
+        // shadow our installedApps WeakSet. First call has no instance -> resolveFlare throws.
+        expect(() => (flareVue as any)(app, undefined)).toThrow(/No Flare instance available/);
+
+        // Retry with a valid instance MUST install (the failed attempt must not have added the app
+        // to installedApps — that is the resolve-before-add ordering being verified).
+        const injected = {
+            reportSilently: vi.fn(),
+            reportMessage: vi.fn(),
+            setSdkInfo: vi.fn(),
+            setFramework: vi.fn(),
+        } as any;
+        (flareVue as any)(app, { flare: injected });
+        app.config.errorHandler!(new Error('x'), null, 'render');
+        expect(injected.reportSilently).toHaveBeenCalledOnce();
+    });
 });
 ```
 
-> The two throw tests exercise the wiring-time fail-fast (Decision 5) THROUGH the `/inject` entry — the behavior the electron README promises. They pass because no default is registered in this file's isolated module registry: `flareVue`'s install and the boundary's `setup` both call `resolveFlare(undefined)`, which throws synchronously.
+> The throw tests exercise the wiring-time fail-fast (Decision 5) THROUGH the `/inject` entry — the behavior the electron README promises. They pass because no default is registered in this file's isolated module registry: `flareVue`'s install and the boundary's `setup` both call `resolveFlare(undefined)`, which throws synchronously. The retry test guards the resolve-before-`installedApps.add` ordering (Task 4 Step 4): it calls the plugin function directly because Vue's `app.use` adds the plugin to its own installed-set BEFORE calling `install`, which would otherwise mask our WeakSet behavior.
 
 - [ ] **Step 2: Run test to verify it fails**
 
@@ -723,7 +771,7 @@ export type {
 
 - [ ] **Step 4: Run test + full suite + tsc**
 
-Run: `cd packages/vue && npx vitest run tests/injectEntry.test.ts` (4 pass)
+Run: `cd packages/vue && npx vitest run tests/injectEntry.test.ts` (5 pass)
 Run: `cd packages/vue && npx vitest run` (full suite green)
 Run: `cd packages/vue && npx tsc --noEmit` (0 errors)
 

--- a/docs/superpowers/plans/2026-06-16-vue-electron-injection.md
+++ b/docs/superpowers/plans/2026-06-16-vue-electron-injection.md
@@ -403,9 +403,10 @@ In `packages/vue/src/flareVue.ts`:
 Change the import line 1 `import { type AttributeValue, type Attributes, convertToError, flare } from '@flareapp/js';` to:
 
 ```ts
-import { convertToError } from '@flareapp/core';
-import type { AttributeValue, Attributes } from '@flareapp/js/browser';
+import { convertToError, type AttributeValue, type Attributes } from '@flareapp/core';
 ```
+
+(`AttributeValue`/`Attributes` are NOT exported from `@flareapp/js/browser` — only `Flare` + browser helpers are. They live in `@flareapp/core` alongside `convertToError`, so one import line covers all three.)
 
 Add these imports (with the other local imports):
 
@@ -794,7 +795,7 @@ Run: `npm install` (repo root). Expected: the only lockfile change is vue's new 
 
 - [ ] **Step 6: Build, verify entries, type-check**
 
-Run: `cd packages/vue && npm run build` — succeeds; `ls packages/vue/dist/inject.*` shows 4 files.
+Run: `cd packages/vue && npm run build` — succeeds; `ls dist/inject.*` (from `packages/vue`) shows 4 files (`inject.mjs`, `inject.cjs`, `inject.d.mts`, `inject.d.cts`).
 Run: `cd packages/vue && npx tsc --noEmit` — 0 errors.
 
 - [ ] **Step 7: Commit**

--- a/docs/superpowers/plans/2026-06-16-vue-electron-injection.md
+++ b/docs/superpowers/plans/2026-06-16-vue-electron-injection.md
@@ -1,0 +1,1017 @@
+# Vue Electron Injection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an `@flareapp/vue/inject` entry so `flareVue` and the Vue `FlareErrorBoundary` can route reports through an injected Flare instance (Electron's `RendererFlare`) instead of the `@flareapp/js` root singleton, without breaking web consumers and without pulling the js-root side effects into the renderer.
+
+**Architecture:** Mirrors the shipped React design (`@flareapp/react/inject`, branch `feat/react-electron-injection`). Optional `flare?` resolved ONCE at wiring time (plugin install / component setup) via a shared `resolveFlare` seam. Two entries: the web entry (`@flareapp/vue`) statically imports the root and registers it as the default; the `/inject` entry is root-free. Per-instance `WeakSet` identity (framework-only when injected). **Vue-specific extra work:** Vue has FOUR root imports, two of which are utility value-imports (`resolveDenylist`, `redactFullPath`) that pull the root into the shared module graph — these must move to `@flareapp/core`. Vue also has TWO report sites (`flareVue` plugin AND a `FlareErrorBoundary` component), both needing injection.
+
+**Tech Stack:** TypeScript, tsdown (CJS+ESM+dts), Vitest, Vue 3. Reference: the completed React branch `feat/react-electron-injection` and spec `docs/superpowers/specs/2026-06-16-framework-renderer-injection-design.md`. This branch (`feat/vue-electron-injection`) is stacked on top of the React branch.
+
+---
+
+## Vue vs React: what's different (read before starting)
+
+1. **Two report sites, not one boundary + one handler.** `src/flareVue.ts` (the `app.use(flareVue)` plugin — sets `app.config.errorHandler` and optionally `warnHandler`) AND `src/FlareErrorBoundary.ts` (a `defineComponent` with `onErrorCaptured`). Both call `flare.reportSilently`; `flareVue`'s warn path also calls `flare.reportMessage`.
+2. **Four root imports.** `flareVue.ts` and `FlareErrorBoundary.ts` import `{ convertToError, flare }` from the root; `constants.ts` imports `resolveDenylist`; `getRouteContext.ts` imports `redactFullPath`. The last two are utility VALUE imports that pull the root into the shared graph — they must move to `@flareapp/core` (which exports `convertToError`, `resolveDenylist`, `redactUrlQuery`).
+3. **Identity timing differs from React.** React sets identity at import. Vue sets it inside `flareVue`'s install because `framework.version = app.version` is only known then. **Preserve that:** the web entry registers only the default provider at import; identity stays at install/setup. Do NOT move identity to import time (that would change web behavior).
+4. **Identity guard split.** React's `registerReactSdkIdentity` does sdk+framework together. Vue must split: `registerVueSdkInfo(flare)` (sdk, no version dep) and `tagVueFramework(flare, appVersion)` (framework, needs the app version). Both `WeakSet`-per-instance guarded.
+
+## Carry these four fixes from the React branch (the React plan's verbatim code had these bugs)
+
+- **A. `window` cast:** use `(window as unknown as Record<string, unknown>)`, NOT `(window as Record<string, unknown>)` (TS2352).
+- **B. No unused `@ts-expect-error`:** `delete (window as any).x` does not error under `as any`, so a `@ts-expect-error` above it is unused (TS2578). Omit it.
+- **C. "Resolves once" tests must spy `resolveFlare`,** not `setFramework` (the per-instance WeakSet masks a per-call regression on `setFramework`).
+- **D. Electron cross-package test runs in the default `node` env** (no `@vitest-environment jsdom` directive — oxfmt relocates it and it silently stops applying; the Vue path needs no DOM).
+
+## File structure
+
+- Create `packages/vue/src/resolveFlare.ts` — shared seam (same as React's).
+- Create `packages/vue/src/identify.ts` — `registerVueSdkInfo` + `tagVueFramework`, WeakSet guards.
+- Modify `packages/vue/src/constants.ts` — `resolveDenylist` import from `@flareapp/core`.
+- Modify `packages/vue/src/getRouteContext.ts` — `redactFullPath` import from `@flareapp/core`.
+- Modify `packages/vue/src/flareVue.ts` — `flare?` option, resolve at install, conditional identity, report via resolved instance, imports off root.
+- Modify `packages/vue/src/FlareErrorBoundary.ts` — `flare` prop, resolve at setup, tag framework, report via resolved instance, imports off root.
+- Modify `packages/vue/src/index.ts` — web entry: import root `flare`, register as default. Preserve all exports.
+- Create `packages/vue/src/inject.ts` — electron-safe entry, no root.
+- Modify `packages/vue/package.json` — `./inject` export, build entry, `sideEffects`, `@flareapp/core` exact dep.
+- Modify `scripts/release-all.mjs` — add vue to `CORE_REFS`.
+- Create `packages/vue/scripts/verify-inject-no-root.mjs` — chunk-graph no-root guard.
+- Create `packages/electron/tests/vueInjection.test.ts` — cross-package regression.
+- Tests: `resolveFlare.test.ts`, `identify.test.ts`, `flareVue.test.ts` (extend), `FlareErrorBoundary.test.ts` (extend), `injectEntry.test.ts`, `webEntry.test.ts`.
+
+> Lockfile note: the root `package-lock.json` was already synced on the React branch (this branch is stacked on it), so there is NO standalone lockfile catch-up task. The only lockfile change in this plan is Vue's new `@flareapp/core` dependency (Task 8) and the Vue version bump (Task 11).
+
+---
+
+## Task 1: `resolveFlare` module
+
+**Files:** Create `packages/vue/src/resolveFlare.ts`, Create `packages/vue/tests/resolveFlare.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/vue/tests/resolveFlare.test.ts
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+describe('resolveFlare', () => {
+    beforeEach(() => {
+        vi.resetModules();
+        delete (window as any).__flare;
+        vi.restoreAllMocks();
+    });
+
+    test('returns the explicit instance when provided', async () => {
+        const { resolveFlare } = await import('../src/resolveFlare');
+        const explicit = { id: 'explicit' } as any;
+        expect(resolveFlare(explicit)).toBe(explicit);
+    });
+
+    test('returns the registered default when no explicit instance', async () => {
+        const { resolveFlare, registerDefaultFlare } = await import('../src/resolveFlare');
+        const def = { id: 'default' } as any;
+        registerDefaultFlare(() => def);
+        expect(resolveFlare()).toBe(def);
+    });
+
+    test('throws a clear error when no instance and no default', async () => {
+        const { resolveFlare } = await import('../src/resolveFlare');
+        expect(() => resolveFlare()).toThrow(/No Flare instance available/);
+    });
+
+    test('registerDefaultFlare warns when the electron bridge is already present', async () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        (window as any).__flare = { report: () => {} };
+        const { registerDefaultFlare } = await import('../src/resolveFlare');
+        registerDefaultFlare(() => ({}) as any);
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining('/inject'));
+    });
+
+    test('registerDefaultFlare does NOT warn without the bridge', async () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const { registerDefaultFlare } = await import('../src/resolveFlare');
+        registerDefaultFlare(() => ({}) as any);
+        expect(warn).not.toHaveBeenCalled();
+    });
+});
+```
+
+> Note (fixes A+B): no `@ts-expect-error` above the `delete (window as any).__flare` lines (unused directive → TS2578), and the source uses `as unknown as Record` (fix A).
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/vue && npx vitest run tests/resolveFlare.test.ts`
+Expected: FAIL — Cannot find module '../src/resolveFlare'.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// packages/vue/src/resolveFlare.ts
+import type { Flare } from '@flareapp/js/browser';
+
+let defaultProvider: (() => Flare) | null = null;
+
+// Called once by the web entry (index.ts) as an import side effect.
+export function registerDefaultFlare(provider: () => Flare): void {
+    if (typeof window !== 'undefined' && (window as unknown as Record<string, unknown>).__flare) {
+        console.warn(
+            '[flare] @flareapp/js default registered while the electron bridge is present. ' +
+                'In a renderer, import @flareapp/vue/inject and pass the ' +
+                '@flareapp/electron/renderer instance instead.',
+        );
+    }
+    defaultProvider = provider;
+}
+
+// Resolve at WIRING time (plugin install / component setup), never inside a report path.
+export function resolveFlare(explicit?: Flare): Flare {
+    if (explicit) {
+        return explicit;
+    }
+    if (defaultProvider) {
+        return defaultProvider();
+    }
+    throw new Error(
+        '[flare] No Flare instance available. Pass `flare` (e.g. from ' +
+            '@flareapp/electron/renderer), or import @flareapp/vue (the package root) ' +
+            'to use the @flareapp/js default singleton.',
+    );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/vue && npx vitest run tests/resolveFlare.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/vue/src/resolveFlare.ts packages/vue/tests/resolveFlare.test.ts
+git commit -m "feat(vue): add resolveFlare default-provider seam"
+```
+
+---
+
+## Task 2: Per-instance identity
+
+**Files:** Create `packages/vue/src/identify.ts`, Create `packages/vue/tests/identify.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/vue/tests/identify.test.ts
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+function fakeFlare() {
+    return { setSdkInfo: vi.fn(), setFramework: vi.fn() } as any;
+}
+
+describe('vue identity', () => {
+    beforeEach(() => {
+        vi.resetModules();
+    });
+
+    test('registerVueSdkInfo sets sdkInfo (@flareapp/vue) only, never framework', async () => {
+        const { registerVueSdkInfo } = await import('../src/identify');
+        const flare = fakeFlare();
+        registerVueSdkInfo(flare);
+        expect(flare.setSdkInfo).toHaveBeenCalledWith(expect.objectContaining({ name: '@flareapp/vue' }));
+        expect(flare.setFramework).not.toHaveBeenCalled();
+    });
+
+    test('tagVueFramework sets framework (Vue + version) only, never sdkInfo', async () => {
+        const { tagVueFramework } = await import('../src/identify');
+        const flare = fakeFlare();
+        tagVueFramework(flare, '3.4.0');
+        expect(flare.setFramework).toHaveBeenCalledWith({ name: 'Vue', version: '3.4.0' });
+        expect(flare.setSdkInfo).not.toHaveBeenCalled();
+    });
+
+    test('each guard is per-instance: same instance tagged once, distinct instances each tagged', async () => {
+        const { tagVueFramework } = await import('../src/identify');
+        const a = fakeFlare();
+        const b = fakeFlare();
+        tagVueFramework(a, '3.4.0');
+        tagVueFramework(a, '3.4.0');
+        tagVueFramework(b, '3.4.0');
+        expect(a.setFramework).toHaveBeenCalledOnce();
+        expect(b.setFramework).toHaveBeenCalledOnce();
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/vue && npx vitest run tests/identify.test.ts`
+Expected: FAIL — module not found / exports missing.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// packages/vue/src/identify.ts
+import type { Flare } from '@flareapp/js/browser';
+
+import { PACKAGE_VERSION } from './constants';
+
+// Per-instance guards. A boolean cannot serve injection: with a singleton AND an
+// injected RendererFlare, each instance must be tagged independently.
+const sdkTagged = new WeakSet<object>();
+const frameworkTagged = new WeakSet<object>();
+
+// Web path: SDK identity on the default singleton. Split from framework because
+// the framework version (app.version) is only known at install time.
+export function registerVueSdkInfo(flare: Flare): void {
+    if (sdkTagged.has(flare)) {
+        return;
+    }
+    sdkTagged.add(flare);
+    flare.setSdkInfo({ name: '@flareapp/vue', version: PACKAGE_VERSION });
+}
+
+// Both paths tag the framework (web + injected). Never touches sdkInfo — on an
+// injected instance that would clobber the instance's own SDK name (@flareapp/electron).
+export function tagVueFramework(flare: Flare, appVersion: string | undefined): void {
+    if (frameworkTagged.has(flare)) {
+        return;
+    }
+    frameworkTagged.add(flare);
+    flare.setFramework({ name: 'Vue', version: appVersion });
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/vue && npx vitest run tests/identify.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/vue/src/identify.ts packages/vue/tests/identify.test.ts
+git commit -m "feat(vue): per-instance SDK + framework identity helpers"
+```
+
+---
+
+## Task 3: Move shared-graph utility imports off the js root
+
+The inject graph reaches `constants.ts` and `getRouteContext.ts` (both imported by `flareVue.ts` and `FlareErrorBoundary.ts`). They currently value-import from the `@flareapp/js` ROOT, which would pull the root (and its side effects) into `/inject`. `@flareapp/core` re-exports the same functions. This is a pure import-source change — zero behavior change, existing tests stay green.
+
+**Files:** Modify `packages/vue/src/constants.ts`, Modify `packages/vue/src/getRouteContext.ts`
+
+- [ ] **Step 1: Read both files** to see the exact current import lines.
+
+`constants.ts:1` is `import { resolveDenylist as baseResolveDenylist } from '@flareapp/js';`
+`getRouteContext.ts:1` is `import { redactFullPath } from '@flareapp/js';`
+
+- [ ] **Step 2: Change the import sources to `@flareapp/core`**
+
+In `constants.ts`, change line 1 to:
+
+```ts
+import { resolveDenylist as baseResolveDenylist } from '@flareapp/core';
+```
+
+In `getRouteContext.ts`, change line 1 to:
+
+```ts
+import { redactUrlQuery as redactFullPath } from '@flareapp/core';
+```
+
+(`@flareapp/core` exports `redactUrlQuery`; the root's `redactFullPath` is just its deprecated alias, so aliasing on import keeps every downstream usage of `redactFullPath` unchanged.)
+
+- [ ] **Step 3: Verify the full Vue suite stays green and types are clean**
+
+Run: `cd packages/vue && npx vitest run` — expect ALL existing tests still pass (pure refactor).
+Run: `cd packages/vue && npx tsc --noEmit` — note: `flareVue.ts`/`FlareErrorBoundary.ts` still import the root here (handled in Tasks 4-5), so tsc should be clean (the root import is still present/valid, just not in these two files). `@flareapp/core` resolves via the workspace-hoisted node_modules.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/vue/src/constants.ts packages/vue/src/getRouteContext.ts
+git commit -m "refactor(vue): import shared utils from @flareapp/core, not the js root"
+```
+
+---
+
+## Task 4: `flare` option on `flareVue` (resolve at install)
+
+**Files:** Modify `packages/vue/src/flareVue.ts`, Modify `packages/vue/src/types.ts` (add `flare?` to `FlareVueOptions`), Modify `packages/vue/tests/flareVue.test.ts`
+
+Read `packages/vue/src/flareVue.ts` and `packages/vue/tests/flareVue.test.ts` first.
+
+- [ ] **Step 1: Add tests for injection + resolve-at-install**
+
+In `flareVue.test.ts`: the existing suite installs `flareVue` and asserts reports through the mocked root. Update the top-of-file `@flareapp/js` mock so the mocked singleton exposes `setSdkInfo`+`setFramework`+`reportSilently`+`reportMessage`, and register it as the default. Match the React branch's `flareReactErrorHandler.test.ts` mock pattern:
+
+```ts
+// Top-of-file: ensure the mocked root singleton has the identity methods AND is the resolveFlare default.
+const mockReport = vi.fn();
+const mockMessage = vi.fn();
+vi.mock('@flareapp/js', () => ({
+    flare: {
+        reportSilently: (...a: unknown[]) => mockReport(...a),
+        reportMessage: (...a: unknown[]) => mockMessage(...a),
+        setSdkInfo: vi.fn(),
+        setFramework: vi.fn(),
+    },
+    // convertToError now comes from @flareapp/core in the implementation; kept here only as a
+    // self-contained safety net for the mocked '@flareapp/js' surface.
+    convertToError: (e: unknown) => (e instanceof Error ? e : new Error(String(e))),
+}));
+import * as resolveModule from '../src/resolveFlare';
+import { registerDefaultFlare } from '../src/resolveFlare';
+import { flare as mockedRoot } from '@flareapp/js';
+registerDefaultFlare(() => mockedRoot as any);
+```
+
+(Adapt to whatever the existing mock binding names are; preserve what existing tests rely on. If the existing file already mocks `@flareapp/js`, extend that mock rather than duplicating it.)
+
+Add these tests (use `createApp` from `vue` and a minimal component; mirror how existing tests trigger `app.config.errorHandler`):
+
+```ts
+test('reports through an injected flare instance, not the default', () => {
+    const injected = {
+        reportSilently: vi.fn(),
+        reportMessage: vi.fn(),
+        setSdkInfo: vi.fn(),
+        setFramework: vi.fn(),
+    } as any;
+    const app = createApp({ render: () => null });
+    app.use(flareVue, { flare: injected });
+    app.config.errorHandler!(new Error('boom'), null, 'render');
+    expect(injected.reportSilently).toHaveBeenCalledOnce();
+    expect(mockReport).not.toHaveBeenCalled();
+});
+
+test('injected instance is tagged framework-only, never sdkInfo', () => {
+    const injected = {
+        reportSilently: vi.fn(),
+        reportMessage: vi.fn(),
+        setSdkInfo: vi.fn(),
+        setFramework: vi.fn(),
+    } as any;
+    const app = createApp({ render: () => null });
+    app.use(flareVue, { flare: injected });
+    expect(injected.setFramework).toHaveBeenCalledWith(expect.objectContaining({ name: 'Vue' }));
+    expect(injected.setSdkInfo).not.toHaveBeenCalled();
+});
+
+test('resolves the instance once at install, not per reported error', () => {
+    const injected = {
+        reportSilently: vi.fn(),
+        reportMessage: vi.fn(),
+        setSdkInfo: vi.fn(),
+        setFramework: vi.fn(),
+    } as any;
+    const resolveSpy = vi.spyOn(resolveModule, 'resolveFlare');
+    const app = createApp({ render: () => null });
+    app.use(flareVue, { flare: injected });
+    app.config.errorHandler!(new Error('a'), null, 'render');
+    app.config.errorHandler!(new Error('b'), null, 'render');
+    expect(resolveSpy).toHaveBeenCalledTimes(1); // resolved at install, NOT per error (fix C)
+    resolveSpy.mockRestore();
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/vue && npx vitest run tests/flareVue.test.ts`
+Expected: FAIL — `FlareVueOptions` has no `flare`; injected instance unused.
+
+- [ ] **Step 3: Add `flare?` to `FlareVueOptions`**
+
+In `packages/vue/src/types.ts`, add `flare?: Flare;` as the first member of `FlareVueOptions`, and add the import at the top of types.ts:
+
+```ts
+import type { Flare } from '@flareapp/js/browser';
+```
+
+```ts
+export type FlareVueOptions = {
+    flare?: Flare;
+    captureWarnings?: boolean;
+    // ...rest unchanged
+};
+```
+
+- [ ] **Step 4: Rewire `flareVue.ts`**
+
+In `packages/vue/src/flareVue.ts`:
+
+Change the import line 1 `import { type AttributeValue, type Attributes, convertToError, flare } from '@flareapp/js';` to:
+
+```ts
+import { convertToError } from '@flareapp/core';
+import type { AttributeValue, Attributes } from '@flareapp/js/browser';
+```
+
+Add these imports (with the other local imports):
+
+```ts
+import { resolveFlare } from './resolveFlare';
+import { registerVueSdkInfo, tagVueFramework } from './identify';
+```
+
+Inside the `flareVue` install function, AFTER the `installedApps` guard and BEFORE the current `flare.setSdkInfo(...)` / `flare.setFramework(...)` lines, resolve the instance and replace the identity block:
+
+```ts
+const flare = resolveFlare(options?.flare);
+
+// Web default (no injected instance): set the SDK identity on the singleton, as before.
+// Injected instance: tag the framework only — never setSdkInfo (would clobber @flareapp/electron).
+if (!options?.flare) {
+    registerVueSdkInfo(flare);
+}
+tagVueFramework(flare, app.version);
+```
+
+Delete the old `flare.setSdkInfo({ name: '@flareapp/vue', version: PACKAGE_VERSION });` and `flare.setFramework({ name: 'Vue', version: app.version });` lines (now handled above). Remove the now-unused `PACKAGE_VERSION` import from flareVue.ts IF it becomes unused (check — it may still be used elsewhere in the file; only remove if oxlint flags it unused).
+
+Every other `flare.reportSilently(...)` / `flare.reportMessage(...)` in the install closure now refers to the locally-resolved `const flare` (block-scoped), so they automatically route through the resolved instance. Confirm there are no remaining references to a module-level `flare`.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd packages/vue && npx vitest run tests/flareVue.test.ts`
+Expected: PASS (existing + 3 new).
+
+- [ ] **Step 6: Type-check**
+
+Run: `cd packages/vue && npx tsc --noEmit`
+Expected: the ONLY remaining error (if any) is from `FlareErrorBoundary.ts` still importing the root `flare` — that's handled in Task 5. flareVue.ts and types.ts must add no new errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/vue/src/flareVue.ts packages/vue/src/types.ts packages/vue/tests/flareVue.test.ts
+git commit -m "feat(vue): inject optional flare instance into flareVue (resolve at install)"
+```
+
+---
+
+## Task 5: `flare` prop on the Vue `FlareErrorBoundary` (resolve at setup)
+
+**Files:** Modify `packages/vue/src/FlareErrorBoundary.ts`, Modify `packages/vue/tests/FlareErrorBoundary.test.ts`
+
+Read `packages/vue/src/FlareErrorBoundary.ts` and its test first.
+
+- [ ] **Step 1: Add tests for injection + default**
+
+Mirror Task 4's mock setup at the top of `FlareErrorBoundary.test.ts` (mocked root with identity methods + `registerDefaultFlare(() => mockedRoot)`; keep `convertToError` on the mock). Add a test that mounts the boundary with an injected `flare` prop around a throwing child and asserts the injected instance received the report (and the default did not), plus a default-path test. Use the existing test's mounting helper / throwing-component pattern. Also add a resolve-once test that spies `resolveFlare` and asserts it is called once per setup (fix C).
+
+(Write concrete tests following the existing file's harness — `@vue/test-utils` `mount` if the file uses it, or the existing manual `onErrorCaptured` trigger. Keep the assertions: injected.reportSilently called once; mockReport not called; resolveFlare spy called once.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/vue && npx vitest run tests/FlareErrorBoundary.test.ts`
+Expected: FAIL — no `flare` prop; injected instance unused.
+
+- [ ] **Step 3: Add the `flare` prop and resolve at setup**
+
+In `packages/vue/src/FlareErrorBoundary.ts`:
+
+Change import line 1 `import { convertToError, flare } from '@flareapp/js';` to:
+
+```ts
+import { convertToError } from '@flareapp/core';
+import type { Flare } from '@flareapp/js/browser';
+```
+
+Add:
+
+```ts
+import { resolveFlare } from './resolveFlare';
+import { tagVueFramework } from './identify';
+```
+
+Add a `flare` prop to the component's `props` block:
+
+```ts
+        flare: {
+            type: Object as PropType<Flare>,
+            default: undefined,
+        },
+```
+
+At the TOP of `setup(props, { slots })`, resolve once at setup (wiring time) and tag the framework:
+
+```ts
+const flareInstance = resolveFlare(props.flare);
+tagVueFramework(flareInstance, getCurrentInstance()?.appContext.app.version);
+```
+
+(`getCurrentInstance` is already imported in this file. The boundary may be used without `flareVue`, so it tags the framework itself — additive, framework-only, never sdkInfo.)
+
+In `onErrorCaptured`, change `flare.reportSilently(...)` to `flareInstance.reportSilently(...)`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/vue && npx vitest run tests/FlareErrorBoundary.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Full type-check + suite**
+
+Run: `cd packages/vue && npx tsc --noEmit` — expect ZERO errors (no file should import the root `flare` now except `index.ts` after Task 6; until Task 6, index.ts still has its current exports and no root `flare` value import, so tsc is clean).
+Run: `cd packages/vue && npx vitest run` — full suite green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/vue/src/FlareErrorBoundary.ts packages/vue/tests/FlareErrorBoundary.test.ts
+git commit -m "feat(vue): inject optional flare into Vue FlareErrorBoundary (resolve at setup)"
+```
+
+---
+
+## Task 6: Web entry registers the default
+
+**Files:** Modify `packages/vue/src/index.ts`, Create `packages/vue/tests/webEntry.test.ts`
+
+> Note: unlike React, Vue's web entry does NOT set identity at import (identity needs `app.version`, known only at install). It only registers the default provider. This preserves current web behavior.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/vue/tests/webEntry.test.ts
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+describe('@flareapp/vue web entry', () => {
+    beforeEach(() => {
+        vi.resetModules();
+    });
+
+    test('importing the root registers the js singleton as the resolveFlare default', async () => {
+        const singleton = { reportSilently: vi.fn(), setSdkInfo: vi.fn(), setFramework: vi.fn() };
+        vi.doMock('@flareapp/js', () => ({ flare: singleton }));
+
+        await import('../src/index');
+
+        const { resolveFlare } = await import('../src/resolveFlare');
+        expect(resolveFlare()).toBe(singleton);
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/vue && npx vitest run tests/webEntry.test.ts`
+Expected: FAIL — no default registered (resolveFlare throws).
+
+- [ ] **Step 3: Add the default registration to `index.ts`**
+
+Read the current `packages/vue/src/index.ts`. Add at the TOP (before the existing exports), preserving ALL existing exports exactly:
+
+```ts
+import { flare } from '@flareapp/js';
+
+import { registerDefaultFlare } from './resolveFlare';
+
+// Web entry: the js-root singleton is the default Flare for no-prop/no-option usage.
+// Importing @flareapp/js here also runs the root's own side effects (window.flare + global
+// catch) — correct for the web. Identity is set at install/setup time (needs app.version),
+// not here, preserving existing web behavior.
+registerDefaultFlare(() => flare);
+```
+
+Keep every existing `export { ... }` / `export type { ... }` line unchanged.
+
+- [ ] **Step 4: Run test + full suite + tsc**
+
+Run: `cd packages/vue && npx vitest run tests/webEntry.test.ts` (pass)
+Run: `cd packages/vue && npx vitest run` (full suite green)
+Run: `cd packages/vue && npx tsc --noEmit` (0 errors)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/vue/src/index.ts packages/vue/tests/webEntry.test.ts
+git commit -m "feat(vue): register js singleton as resolveFlare default in web entry"
+```
+
+---
+
+## Task 7: `/inject` entry (no js-root reference)
+
+**Files:** Create `packages/vue/src/inject.ts`, Create `packages/vue/tests/injectEntry.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/vue/tests/injectEntry.test.ts
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+describe('@flareapp/vue/inject entry', () => {
+    beforeEach(() => {
+        vi.resetModules();
+        delete (window as any).flare;
+    });
+
+    test('importing the inject entry does NOT evaluate @flareapp/js root', async () => {
+        const rootFactory = vi.fn(() => ({ flare: {} }));
+        vi.doMock('@flareapp/js', rootFactory);
+
+        await import('../src/inject');
+
+        expect(rootFactory).not.toHaveBeenCalled();
+        expect((window as any).flare).toBeUndefined();
+    });
+
+    test('exports flareVue and FlareErrorBoundary', async () => {
+        const mod = await import('../src/inject');
+        expect(typeof mod.flareVue).toBe('function');
+        expect(mod.FlareErrorBoundary).toBeDefined();
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/vue && npx vitest run tests/injectEntry.test.ts`
+Expected: FAIL — Cannot find module '../src/inject'.
+
+- [ ] **Step 3: Create the inject entry**
+
+Read `src/index.ts` to mirror its NON-side-effect exports. Create `src/inject.ts` with the SAME exports MINUS the root import + `registerDefaultFlare` call:
+
+```ts
+// packages/vue/src/inject.ts
+// Electron-safe entry. NO @flareapp/js root import, NO default registration. The caller MUST
+// pass `flare` (plugin option / boundary prop); resolveFlare throws at wiring time if absent.
+export { FlareErrorBoundary } from './FlareErrorBoundary';
+export { flareVue } from './flareVue';
+export { DEFAULT_PROPS_DENYLIST } from './constants';
+export type {
+    ComponentHierarchyFrame,
+    ErrorOrigin,
+    FlareErrorBoundaryFallbackProps,
+    FlareErrorBoundaryHookParams,
+    FlareVueContext,
+    FlareVueOptions,
+    FlareVueWarningContext,
+    RouteContext,
+    RouteParamValue,
+    RouteQueryValue,
+} from './types';
+```
+
+(Match the exact export list from the current `index.ts` — copy its export block verbatim, just without the new root-import lines added in Task 6.)
+
+- [ ] **Step 4: Run test + full suite + tsc**
+
+Run: `cd packages/vue && npx vitest run tests/injectEntry.test.ts` (2 pass)
+Run: `cd packages/vue && npx vitest run` (full suite green)
+Run: `cd packages/vue && npx tsc --noEmit` (0 errors)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/vue/src/inject.ts packages/vue/tests/injectEntry.test.ts
+git commit -m "feat(vue): add @flareapp/vue/inject electron-safe entry"
+```
+
+---
+
+## Task 8: Package wiring — build entry, export map, sideEffects, core dep
+
+**Files:** Modify `packages/vue/package.json`, Modify `scripts/release-all.mjs`, Modify `package-lock.json`
+
+- [ ] **Step 1: Add `src/inject.ts` to the build command**
+
+In `packages/vue/package.json`, change the `build` script to add `src/inject.ts` (preserve the existing `--env.PACKAGE_VERSION="..."` quoting exactly):
+
+```
+"build": "tsdown src/index.ts src/inject.ts --format cjs,esm --dts --env.PACKAGE_VERSION=\"$(node -p \"require('./package.json').version\")\" --clean",
+```
+
+- [ ] **Step 2: Add `sideEffects` and the `./inject` export**
+
+Add top-level `sideEffects` (only the index dist files have the registration side effect; inject is pure re-export):
+
+```json
+    "sideEffects": ["./dist/index.cjs", "./dist/index.mjs"],
+```
+
+Add `./inject` to `exports` after the `.` entry (mirror the `.` shape exactly):
+
+```json
+        "./inject": {
+            "import": { "types": "./dist/inject.d.mts", "default": "./dist/inject.mjs" },
+            "require": { "types": "./dist/inject.d.cts", "default": "./dist/inject.cjs" }
+        }
+```
+
+- [ ] **Step 3: Declare `@flareapp/core` (EXACT pin)**
+
+vue now value-imports `convertToError`/`resolveDenylist`/`redactUrlQuery` from `@flareapp/core`. Add a `dependencies` block, EXACT pin matching repo convention (verify current core version first with `node -p "require('./packages/core/package.json').version"`; use that):
+
+```json
+    "dependencies": {
+        "@flareapp/core": "2.4.0"
+    },
+```
+
+- [ ] **Step 4: Add vue to `CORE_REFS` in `scripts/release-all.mjs`**
+
+```js
+const CORE_REFS = [
+    { pkg: 'js', field: 'dependencies', dep: '@flareapp/core' },
+    { pkg: 'node', field: 'dependencies', dep: '@flareapp/core' },
+    { pkg: 'electron', field: 'dependencies', dep: '@flareapp/core' },
+    { pkg: 'react', field: 'dependencies', dep: '@flareapp/core' },
+    { pkg: 'vue', field: 'dependencies', dep: '@flareapp/core' },
+];
+```
+
+(The `react` entry is already present from the stacked React branch. Add `vue` after it.)
+
+- [ ] **Step 5: Regenerate the lockfile**
+
+Run: `npm install` (repo root). Expected: the only lockfile change is vue's new `@flareapp/core` dependency. Verify with `git --no-pager diff --stat`.
+
+- [ ] **Step 6: Build, verify entries, type-check**
+
+Run: `cd packages/vue && npm run build` — succeeds; `ls packages/vue/dist/inject.*` shows 4 files.
+Run: `cd packages/vue && npx tsc --noEmit` — 0 errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/vue/package.json scripts/release-all.mjs package-lock.json
+git commit -m "build(vue): emit /inject entry, pin core dep, export map + sideEffects"
+```
+
+---
+
+## Task 9: Static guard — inject chunk graph has no js-root specifier
+
+Use the STRENGTHENED guard from the React branch (it follows relative chunk imports transitively — tsdown emits the inject entry as a thin shim that re-exports from a shared chunk, so scanning only the entry would miss a root import in the chunk).
+
+**Files:** Create `packages/vue/scripts/verify-inject-no-root.mjs`, Modify `packages/vue/package.json` (add `verify:inject` script)
+
+- [ ] **Step 1: Write the guard (chunk-graph-following)**
+
+```js
+// packages/vue/scripts/verify-inject-no-root.mjs
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const distDir = resolve(dirname(fileURLToPath(import.meta.url)), '../dist');
+const rootSpecifier = /["']@flareapp\/js["']/;
+const relativeSpecifier = /(?:from\s*|require\(\s*)["'](\.\.?\/[^"']+)["']/g;
+
+const entries = ['inject.mjs', 'inject.cjs'];
+const scanned = new Set();
+let failed = false;
+
+function scan(absPath) {
+    if (scanned.has(absPath)) {
+        return;
+    }
+    scanned.add(absPath);
+    const src = readFileSync(absPath, 'utf8');
+    if (rootSpecifier.test(src)) {
+        console.error(
+            `[verify-inject-no-root] ${absPath} references the @flareapp/js root. The inject entry must not pull the root.`,
+        );
+        failed = true;
+    }
+    for (const match of src.matchAll(relativeSpecifier)) {
+        scan(resolve(dirname(absPath), match[1]));
+    }
+}
+
+for (const entry of entries) {
+    scan(resolve(distDir, entry));
+}
+
+if (failed) {
+    process.exit(1);
+}
+console.log(
+    `[verify-inject-no-root] OK — inject bundle (${scanned.size} files incl. chunks) has no @flareapp/js root reference.`,
+);
+```
+
+- [ ] **Step 2: Add the npm script**
+
+In `packages/vue/package.json` scripts: `"verify:inject": "node scripts/verify-inject-no-root.mjs",`
+
+- [ ] **Step 3: Run against the current build**
+
+Run: `cd packages/vue && npm run build && npm run verify:inject`
+Expected: `[verify-inject-no-root] OK — inject bundle (N files incl. chunks) ...` with N > 2 (proves it followed chunks).
+
+- [ ] **Step 4: Prove the guard bites (shared-chunk mutation)**
+
+Temporarily add `import '@flareapp/js';` to the TOP of `src/flareVue.ts` (a SHARED-chunk module, not the entry), rebuild, run the guard:
+Run: `cd packages/vue && npm run build && npm run verify:inject`
+Expected: exits NON-ZERO, naming a chunk file (e.g. `dist/flareVue-*.mjs`).
+Then REMOVE the temporary import, rebuild, confirm OK. Verify `git diff src/flareVue.ts` is empty before committing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/vue/scripts/verify-inject-no-root.mjs packages/vue/package.json
+git commit -m "test(vue): static guard that /inject chunk graph never pulls js root"
+```
+
+---
+
+## Task 10: Cross-package regression — drive `@flareapp/vue/inject` into RendererFlare
+
+Post-implementation regression test (no TDD red step). Runs in electron's default `node` env (fix D — no `@vitest-environment` directive; the Vue path needs no DOM).
+
+**Files:** Create `packages/electron/tests/vueInjection.test.ts`, Modify `packages/electron/package.json` (add `@flareapp/vue` + `vue` devDependencies), Modify `package-lock.json`
+
+Prerequisite: `@flareapp/vue` built (`dist/inject.*`).
+
+- [ ] **Step 1: Add `@flareapp/vue` + `vue` as electron devDependencies**
+
+In `packages/electron/package.json` devDependencies (preserve existing, incl. the `@flareapp/react`/`react` entries added on the React branch):
+
+```json
+        "@flareapp/vue": "file:../vue",
+        "vue": "^3.4.0",
+```
+
+Then `npm install` from repo root. Confirm churn is limited to package-lock.json + electron package.json.
+
+- [ ] **Step 2: Write the regression test**
+
+```ts
+// packages/electron/tests/vueInjection.test.ts
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { createApp } from 'vue';
+
+// The REAL published inject entry (built dist). Importing it must not pull the js root.
+// Runs in electron's default `node` env — the vue error path needs no DOM (RendererFlare
+// forwards via globalThis[FLARE_BRIDGE_KEY], not window).
+import { flareVue } from '@flareapp/vue/inject';
+
+import { FLARE_BRIDGE_KEY } from '../src/constants';
+import { RendererFlare } from '../src/renderer/RendererFlare';
+
+describe('@flareapp/vue/inject reports through an injected RendererFlare', () => {
+    let bridgeReport: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        bridgeReport = vi.fn(async () => {});
+        (globalThis as Record<string, unknown>)[FLARE_BRIDGE_KEY] = { report: bridgeReport };
+    });
+
+    afterEach(() => {
+        delete (globalThis as Record<string, unknown>)[FLARE_BRIDGE_KEY];
+    });
+
+    test('forwards a STRING payload carrying Vue context.custom over the bridge', async () => {
+        const flare = new RendererFlare();
+
+        const app = createApp({ render: () => null });
+        app.use(flareVue, { flare });
+
+        // Drive Vue's installed error handler directly.
+        app.config.errorHandler!(new Error('boom'), null, 'render function');
+
+        await flare.flush(1000);
+
+        expect(bridgeReport).toHaveBeenCalledOnce();
+        const payload = bridgeReport.mock.calls[0][0];
+        expect(typeof payload).toBe('string');
+
+        const parsed = JSON.parse(payload);
+        expect(parsed.attributes['telemetry.sdk.name']).toBe('@flareapp/electron');
+        expect(parsed.attributes['flare.framework.name']).toBe('Vue');
+        expect(parsed.attributes['context.custom'].vue).toBeDefined();
+        expect((globalThis as Record<string, unknown>).flare).toBeUndefined();
+    });
+});
+```
+
+> If an assertion path is wrong, `console.log(payload)` to inspect the REAL serialized shape and adjust ONLY the test path (never production code). Keep the intent: electron sdk preserved, framework=Vue, vue context.custom survives, payload is a string. The Vue context key is `context.custom.vue` (see `vueContextToAttributes` in `flareVue.ts`).
+
+- [ ] **Step 3: Build vue, then run**
+
+Run: `npm run build` (repo root, or `cd packages/vue && npm run build`).
+Run: `cd packages/electron && npx vitest run tests/vueInjection.test.ts` — expect PASS.
+
+- [ ] **Step 4: Full electron suite + tsc**
+
+Run: `cd packages/electron && npx vitest run` (full suite green — includes the React injection test from the stacked branch).
+Run: `cd packages/electron && npx tsc --noEmit` (0 errors).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/electron/tests/vueInjection.test.ts packages/electron/package.json package-lock.json
+git commit -m "test(electron): drive @flareapp/vue/inject through RendererFlare bridge"
+```
+
+---
+
+## Task 11: Full suite, version bump, docs
+
+**Files:** Modify `packages/vue/package.json` (version), Modify `package-lock.json`, Modify `packages/electron/README.md`, Modify `CLAUDE.md`
+
+- [ ] **Step 1: Full verification gate**
+
+Run: `cd packages/vue && npm run build && npm test && npx tsc --noEmit && npm run verify:inject` — all pass.
+Run: `cd packages/electron && npm test && npx tsc --noEmit` — all pass.
+If anything fails, STOP and report.
+
+- [ ] **Step 2: Bump `@flareapp/vue` to 2.5.0 + refresh lockfile**
+
+In `packages/vue/package.json`, `"version": "2.4.0"` → `"2.5.0"`. Then `npm install` (repo root); confirm the only lockfile change is the `packages/vue` version entry.
+
+- [ ] **Step 3: Add the Vue section to the electron README**
+
+Append to `packages/electron/README.md` (after the existing React section):
+
+````markdown
+## Using `@flareapp/vue` in the renderer
+
+Same model as the React section: the API key lives in **main**, reports travel over IPC, and the renderer injects Electron's Flare instance into Vue instead of letting it reach the `@flareapp/js` singleton.
+
+### Install
+
+```bash
+npm install @flareapp/electron @flareapp/vue
+```
+
+`@flareapp/js` comes in transitively via `@flareapp/electron` — do **not** import it in the renderer.
+
+Set up main / preload / renderer exactly as in the React section (steps 1-3): `flare.light(key)` in main, `exposeFlare()` in preload, and a renderer `flare.ts` that re-exports `flare` from `@flareapp/electron/renderer`.
+
+### Vue — inject the instance
+
+Import `flareVue` (and, if you use it, `FlareErrorBoundary`) from `@flareapp/vue/inject`, not the package root, and pass the renderer instance:
+
+```ts
+// main.ts (renderer entry)
+import { createApp } from 'vue';
+import { flareVue } from '@flareapp/vue/inject';
+import { flare } from './flare';
+import App from './App.vue';
+
+const app = createApp(App);
+app.use(flareVue, { flare });
+app.mount('#app');
+```
+
+Component boundary:
+
+```vue
+<script setup lang="ts">
+import { FlareErrorBoundary } from '@flareapp/vue/inject';
+import { flare } from './flare';
+</script>
+
+<template>
+    <FlareErrorBoundary :flare="flare">
+        <App />
+    </FlareErrorBoundary>
+</template>
+```
+
+### Rules
+
+- **Never `import { flare } from '@flareapp/js'` in the renderer.** Import the Vue SDK from `@flareapp/vue/inject`, never the package root. Importing the root prints a console warning that the default was registered while the Electron bridge is present.
+- Omitting the `flare` option/prop on the `/inject` entry throws at install / component setup (boot), not silently at error time.
+
+Reports from the renderer carry `sdk = @flareapp/electron` and `framework = Vue`. Your Vue component context (`context.custom.vue`, component hierarchy, props) rides along and survives the IPC trip intact.
+````
+
+- [ ] **Step 4: Update CLAUDE.md**
+
+In the "Monorepo structure" table, update the `@flareapp/vue` Purpose cell to mention the `/inject` entry for Electron renderers (mirror how the `@flareapp/react` row was updated on the React branch).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/vue/package.json package-lock.json packages/electron/README.md CLAUDE.md
+git commit -m "docs(vue,electron): document renderer injection; bump vue to 2.5.0"
+```
+
+---
+
+## Self-review notes (resolved against the spec + React precedent)
+
+- **Decision 1 (optional DI seam):** Tasks 4 (`flareVue` option), 5 (boundary prop).
+- **Decision 2 (separate entries, no dynamic import):** Tasks 6, 7, 8. Plus Task 3 (util migration) — Vue-specific prerequisite so the shared graph is root-free.
+- **Decision 3 (per-instance identity, framework-only when injected):** Task 2; applied in Tasks 4, 5. Vue note: identity stays at install/setup (needs `app.version`), NOT at import — preserves web behavior.
+- **Decision 4 (additive → minor):** Task 11 (vue 2.5.0).
+- **Decision 5 (resolve at wiring time, throw there):** Task 4 (install), Task 5 (setup).
+- **Decision 6 (sveltekit ordering):** N/A to Vue.
+- **Q4 (dev-warn tripwire):** Task 1.
+- **Q7 (sideEffects + regression test):** Tasks 6, 8.
+- **Q8 (no-root guard, chunk-graph):** Task 9 authoritative; Task 7 runtime check; Task 10 behavioral.
+
+**Four React-branch fixes baked in:** A (window cast) Task 1; B (no unused @ts-expect-error) Tasks 1/7; C (resolves-once via resolveFlare spy) Tasks 4/5; D (node-env electron test) Task 10.
+
+**Vue-specific risks called out:**
+
+- Vue has TWO report sites (plugin + boundary) and FOUR root imports (Task 3 migrates the two utility ones; Tasks 4/5 handle the two singleton ones).
+- The Vue boundary now tags `framework = Vue` at setup even when used without `flareVue` — additive (today it tags nothing). Acceptable for a minor; noted so a reviewer isn't surprised.
+
+**Not in this plan (sibling):** Svelte (`@flareapp/svelte/inject`) + the SvelteKit sdk-name regression (Decision 6), stacked on top of this Vue branch.

--- a/docs/superpowers/plans/2026-06-16-vue-electron-injection.md
+++ b/docs/superpowers/plans/2026-06-16-vue-electron-injection.md
@@ -303,36 +303,26 @@ Read `packages/vue/src/flareVue.ts` and `packages/vue/tests/flareVue.test.ts` fi
 
 - [ ] **Step 1: Add tests for injection + resolve-at-install**
 
-In `flareVue.test.ts`: the existing suite installs `flareVue` and asserts reports through the mocked root. Update the top-of-file `@flareapp/js` mock so the mocked singleton exposes `setSdkInfo`+`setFramework`+`reportSilently`+`reportMessage`, and register it as the default. Match the React branch's `flareReactErrorHandler.test.ts` mock pattern:
+Do NOT rewrite the existing `@flareapp/js` mock. The current `flareVue.test.ts` already mocks it via `vi.mock('@flareapp/js', async (importOriginal) => ({ ...actual, flare: { report, reportSilently: (...a) => mockReport(...a), reportMessage: (...a) => mockReportMessage(...a), setSdkInfo: vi.fn(), setFramework: vi.fn(), setEntryPoint: vi.fn() } }))` and the existing tests depend on that exact shape (`mockReport`, `mockReportMessage`, `...actual`, `setEntryPoint`). Make ONLY these three additive edits:
+
+1. **Register the mocked singleton as the resolveFlare default.** After the existing `vi.mock(...)` block, add:
 
 ```ts
-// Top-of-file: ensure the mocked root singleton has the identity methods AND is the resolveFlare default.
-const mockReport = vi.fn();
-const mockMessage = vi.fn();
-vi.mock('@flareapp/js', () => ({
-    flare: {
-        reportSilently: (...a: unknown[]) => mockReport(...a),
-        reportMessage: (...a: unknown[]) => mockMessage(...a),
-        setSdkInfo: vi.fn(),
-        setFramework: vi.fn(),
-    },
-    // convertToError now comes from @flareapp/core in the implementation; kept here only as a
-    // self-contained safety net for the mocked '@flareapp/js' surface.
-    convertToError: (e: unknown) => (e instanceof Error ? e : new Error(String(e))),
-}));
 import * as resolveModule from '../src/resolveFlare';
 import { registerDefaultFlare } from '../src/resolveFlare';
 import { flare as mockedRoot } from '@flareapp/js';
 registerDefaultFlare(() => mockedRoot as any);
 ```
 
-(Adapt to whatever the existing mock binding names are; preserve what existing tests rely on. If the existing file already mocks `@flareapp/js`, extend that mock rather than duplicating it.)
+(`mockedRoot` is the mocked `flare` object — its `reportSilently` routes to the existing `mockReport`, so the no-option/default-path tests assert against `mockReport` exactly as the existing tests do.)
 
-The current `flareVue.test.ts` imports only `import type { ComponentPublicInstance } from 'vue';`. These tests need `createApp` (a value import), so update that line to:
+2. **Add `createApp` to the vue import.** The current line is `import type { ComponentPublicInstance } from 'vue';`. Change it to:
 
 ```ts
 import { createApp, type ComponentPublicInstance } from 'vue';
 ```
+
+3. **Add the three new tests** below (they reuse the existing `mockReport` binding for the negative assertion).
 
 Add these tests (use `createApp` and a minimal component; mirror how existing tests trigger `app.config.errorHandler`):
 

--- a/docs/superpowers/plans/2026-06-16-vue-electron-injection.md
+++ b/docs/superpowers/plans/2026-06-16-vue-electron-injection.md
@@ -456,11 +456,53 @@ git commit -m "feat(vue): inject optional flare instance into flareVue (resolve 
 
 Read `packages/vue/src/FlareErrorBoundary.ts` and its test first.
 
-- [ ] **Step 1: Add tests for injection + default**
+- [ ] **Step 1: Add tests for injection + default + resolve-at-setup**
 
-Mirror Task 4's mock setup at the top of `FlareErrorBoundary.test.ts` (mocked root with identity methods + `registerDefaultFlare(() => mockedRoot)`; keep `convertToError` on the mock). Add a test that mounts the boundary with an injected `flare` prop around a throwing child and asserts the injected instance received the report (and the default did not), plus a default-path test. Use the existing test's mounting helper / throwing-component pattern. Also add a resolve-once test that spies `resolveFlare` and asserts it is called once per setup (fix C).
+The existing `FlareErrorBoundary.test.ts` uses `@vue/test-utils` `mount`, a `ThrowingComponent`, `h`, `nextTick`, and mocks `@flareapp/js` via `vi.mock('@flareapp/js', async (importOriginal) => ({ ...actual, flare: { reportSilently: (...a) => mockReport(...a), setSdkInfo: vi.fn(), setFramework: vi.fn(), ... } }))`. That mock already exposes `setSdkInfo`/`setFramework`, so the only addition is registering the mocked singleton as the resolveFlare default. After the existing `vi.mock(...)` block, add:
 
-(Write concrete tests following the existing file's harness — `@vue/test-utils` `mount` if the file uses it, or the existing manual `onErrorCaptured` trigger. Keep the assertions: injected.reportSilently called once; mockReport not called; resolveFlare spy called once.)
+```ts
+import * as resolveModule from '../src/resolveFlare';
+import { registerDefaultFlare } from '../src/resolveFlare';
+import { flare as mockedRoot } from '@flareapp/js';
+registerDefaultFlare(() => mockedRoot as any);
+```
+
+Then add these three tests (reuse the file's existing `ThrowingComponent` and `mockReport`):
+
+```ts
+test('reports through an injected flare prop, not the default', async () => {
+    const injected = { reportSilently: vi.fn(), setSdkInfo: vi.fn(), setFramework: vi.fn() } as any;
+    mount(FlareErrorBoundary, {
+        props: { flare: injected },
+        slots: { default: () => h(ThrowingComponent) },
+    });
+    await nextTick();
+    expect(injected.reportSilently).toHaveBeenCalledOnce();
+    expect(mockReport).not.toHaveBeenCalled();
+});
+
+test('falls back to the registered default when no flare prop', async () => {
+    mount(FlareErrorBoundary, {
+        slots: { default: () => h(ThrowingComponent) },
+    });
+    await nextTick();
+    expect(mockReport).toHaveBeenCalledOnce();
+});
+
+test('resolves at setup (before any error), not at capture time', () => {
+    // Zero errors thrown. If resolution happened in onErrorCaptured it would be 0; proving it
+    // is 1 here proves resolution is at setup/wiring time (fix C — and a single-error probe could
+    // not distinguish setup-time from capture-time, since both yield exactly one call).
+    const injected = { reportSilently: vi.fn(), setSdkInfo: vi.fn(), setFramework: vi.fn() } as any;
+    const resolveSpy = vi.spyOn(resolveModule, 'resolveFlare');
+    mount(FlareErrorBoundary, {
+        props: { flare: injected },
+        slots: { default: () => h('div', 'ok') }, // non-throwing child
+    });
+    expect(resolveSpy).toHaveBeenCalledTimes(1);
+    resolveSpy.mockRestore();
+});
+```
 
 - [ ] **Step 2: Run test to verify it fails**
 
@@ -599,7 +641,13 @@ git commit -m "feat(vue): register js singleton as resolveFlare default in web e
 
 ```ts
 // packages/vue/tests/injectEntry.test.ts
+import { mount } from '@vue/test-utils';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { createApp, h } from 'vue';
+
+// NOTE: this file registers NO resolveFlare default (it never imports the web entry). Vitest
+// isolates the module registry per file, so resolveFlare's defaultProvider stays null here —
+// which is exactly what lets the "throws without an instance" assertions hold.
 
 describe('@flareapp/vue/inject entry', () => {
     beforeEach(() => {
@@ -622,8 +670,23 @@ describe('@flareapp/vue/inject entry', () => {
         expect(typeof mod.flareVue).toBe('function');
         expect(mod.FlareErrorBoundary).toBeDefined();
     });
+
+    test('app.use(flareVue) from inject throws when no flare option and no default', async () => {
+        const { flareVue } = await import('../src/inject');
+        const app = createApp({ render: () => null });
+        expect(() => app.use(flareVue)).toThrow(/No Flare instance available/);
+    });
+
+    test('mounting FlareErrorBoundary from inject throws at setup when no flare prop and no default', async () => {
+        const { FlareErrorBoundary } = await import('../src/inject');
+        expect(() => mount(FlareErrorBoundary, { slots: { default: () => h('div', 'x') } })).toThrow(
+            /No Flare instance available/,
+        );
+    });
 });
 ```
+
+> The two throw tests exercise the wiring-time fail-fast (Decision 5) THROUGH the `/inject` entry — the behavior the electron README promises. They pass because no default is registered in this file's isolated module registry: `flareVue`'s install and the boundary's `setup` both call `resolveFlare(undefined)`, which throws synchronously.
 
 - [ ] **Step 2: Run test to verify it fails**
 
@@ -659,7 +722,7 @@ export type {
 
 - [ ] **Step 4: Run test + full suite + tsc**
 
-Run: `cd packages/vue && npx vitest run tests/injectEntry.test.ts` (2 pass)
+Run: `cd packages/vue && npx vitest run tests/injectEntry.test.ts` (4 pass)
 Run: `cd packages/vue && npx vitest run` (full suite green)
 Run: `cd packages/vue && npx tsc --noEmit` (0 errors)
 

--- a/docs/superpowers/plans/2026-06-17-svelte-electron-injection.md
+++ b/docs/superpowers/plans/2026-06-17-svelte-electron-injection.md
@@ -1,0 +1,1181 @@
+# Svelte Electron Injection Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add an `@flareapp/svelte/inject` entry so the Svelte SDK (`createFlareErrorHandler` and the `FlareErrorBoundary.svelte` component) can run in an Electron renderer and route reports through an injected Flare instance (Electron's `RendererFlare`) instead of the `@flareapp/js` root singleton — without breaking web consumers, without breaking SvelteKit's identity-override ordering, and without pulling the js-root side effects into the renderer.
+
+**Architecture:** Mirrors the shipped React (`@flareapp/react/inject`, PR #58) and Vue (`@flareapp/vue/inject`, PR #59) designs. Optional `flare?` resolved ONCE at wiring time (handler creation) via a shared `resolveFlare` seam. Two entries: the web entry (`@flareapp/svelte`) statically imports the root, registers it as the default, AND keeps its import-time SDK-identity registration (SvelteKit depends on that ordering); the `/inject` entry is root-free. Per-instance `WeakSet` identity (framework-only when injected). **Svelte-specific:** the `FlareErrorBoundary.svelte` component delegates to `createFlareErrorHandler` (one report site, not two — the component just forwards a `flare` prop). Build is `svelte-package` (per-file `.js` output, not bundled chunks). SvelteKit's `export * from '@flareapp/svelte'` makes svelte's import-time identity registration a hard constraint (spec Decision 6).
+
+**Tech Stack:** TypeScript, `svelte-package` (preprocess + emit dist), Vitest (jsdom + `@sveltejs/vite-plugin-svelte`), Svelte 5. Reference: the completed React branch `feat/react-electron-injection` and Vue branch `feat/vue-electron-injection` (this branch is stacked on Vue), and spec `docs/superpowers/specs/2026-06-16-framework-renderer-injection-design.md`.
+
+---
+
+## Svelte vs React/Vue: what's different (read before starting)
+
+1. **ONE report site.** `src/createFlareErrorHandler.ts` is the only thing that calls `flare.reportSilently`. `FlareErrorBoundary.svelte` does NOT touch `flare` — it internally calls `createFlareErrorHandler({ ancestor, beforeEvaluate, ... })`. So the boundary just needs a `flare` prop it forwards into that call; all resolution lives in `createFlareErrorHandler`.
+2. **THREE root imports.** `identify.ts` (`flare`), `createFlareErrorHandler.ts` (`convertToError, flare`), `contextToAttributes.ts` (type-only `AttributeValue, Attributes`). `config.ts` and `preprocessor.ts` do NOT import the root (preprocessor only emits the string `'@flareapp/svelte'` as generated code).
+3. **TWO module-load identity call sites.** `index.ts:3` calls `registerSvelteSdkIdentity()` AND `createFlareErrorHandler.ts:11` calls it at module top. The index.ts call MUST stay (import-time) for SvelteKit; the createFlareErrorHandler.ts module-top call MUST be removed (it's in the inject graph and moves into the function body, resolving per-instance).
+4. **SvelteKit ordering is a hard constraint (Decision 6).** `@flareapp/sveltekit` does `export * from '@flareapp/svelte'` and re-asserts `sdk = @flareapp/sveltekit` on every report to beat svelte's module-load identity registration. The svelte WEB entry (`index.ts`) MUST keep registering identity at import (byte-for-byte timing) so this override ordering is preserved. SvelteKit's own tests fully mock `@flareapp/js`, so they will NOT catch a regression here — guard it svelte-side (Task 6 webEntry test + Task 11).
+5. **`svelte-package` build, not tsdown.** `svelte-package -i src -o dist` compiles EVERY `src/` file to a `dist/` file (1:1, that is how `./config` already exists). Adding `src/inject.ts` needs NO build-command change — it is auto-compiled. Output is `.js` (single ESM format), and `.svelte` files are emitted preprocessed (NOT compiled to JS). Relative imports use explicit `.js` extensions.
+6. **Identity has no version.** `setFramework({ name: 'Svelte' })` takes no version (unlike Vue's `app.version`). So identity is like React: `registerSvelteSdkIdentity(flare)` sets sdk+framework together; `tagSvelteFramework(flare)` sets framework only. Both `WeakSet`-per-instance guarded.
+7. **`.js` import extensions.** All relative imports in svelte src use `.js` (e.g. `from './resolveFlare.js'`). Match this.
+
+## Carry these four fixes from the React branch (verbatim React code had these bugs)
+
+- **A. `window` cast:** `(window as unknown as Record<string, unknown>)`, NOT `(window as Record<...>)` (TS2352).
+- **B. No unused `@ts-expect-error`:** under `as any`, a `@ts-expect-error` above `delete (window as any).x` is unused (TS2578). Omit it.
+- **C. "Resolves once" tests spy `resolveFlare`,** not `setFramework` (WeakSet masks a per-call regression).
+- **D. The cross-package Electron-bridge test runs without a fragile `@vitest-environment` directive.** (For Svelte it lives in the svelte package whose vitest is already jsdom — fine; just don't add a directive.)
+
+## File structure
+
+- Create `packages/svelte/src/resolveFlare.ts` — shared seam (`.js`-extension imports).
+- Modify `packages/svelte/src/identify.ts` — `registerSvelteSdkIdentity(flare)` + `tagSvelteFramework(flare)`, WeakSet guards; no longer imports the root or self-registers.
+- Modify `packages/svelte/src/contextToAttributes.ts` — type imports from `@flareapp/core`.
+- Modify `packages/svelte/src/createFlareErrorHandler.ts` — `flare?` option, resolve at creation, tag framework, report via resolved; `convertToError` from core; REMOVE module-top `registerSvelteSdkIdentity()`.
+- Modify `packages/svelte/src/FlareErrorBoundary.svelte` — `flare?` prop forwarded into `createFlareErrorHandler`.
+- Modify `packages/svelte/src/index.ts` — web entry: import root `flare`, register default, KEEP import-time `registerSvelteSdkIdentity(flare)`. Preserve all exports.
+- Create `packages/svelte/src/inject.ts` — electron-safe entry, no root, no import-time identity.
+- Modify `packages/svelte/package.json` — `./inject` export, `sideEffects`, `@flareapp/core` exact dep, `@flareapp/electron` devDep (for the cross-package test).
+- Modify `scripts/release-all.mjs` — add svelte to `CORE_REFS`.
+- Create `packages/svelte/scripts/verify-inject-no-root.mjs` — chunk-graph no-root guard (scans `.js`).
+- Create `packages/svelte/scripts/verify-exports.mjs` — post-build `./inject` export-map check (fs-based node script, NOT a vitest test — avoids a `dist`-dependent test in the bare `vitest run` suite).
+- Create `packages/svelte/tests/electronInjection.test.ts` — cross-package regression (lives in svelte, not electron, because electron's node vitest cannot load `.svelte`).
+- Tests: `resolveFlare.test.ts`, `identify.test.ts` (rewrite), `createFlareErrorHandler.test.ts` (extend), `FlareErrorBoundary.test.ts` (extend), `injectEntry.test.ts`, `webEntry.test.ts`, plus Task 11 SvelteKit-ordering regression.
+
+> Lockfile: synced on the React branch (this branch is stacked through Vue). The only lockfile changes here are svelte's new `@flareapp/core` dep + `@flareapp/electron` devDep (Task 8/10) and the svelte version bump (Task 12).
+
+---
+
+## Task 1: `resolveFlare` module
+
+**Files:** Create `packages/svelte/src/resolveFlare.ts`, Create `packages/svelte/tests/resolveFlare.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/svelte/tests/resolveFlare.test.ts
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+describe('resolveFlare', () => {
+    beforeEach(() => {
+        vi.resetModules();
+        delete (window as any).__flare;
+        vi.restoreAllMocks();
+    });
+
+    test('returns the explicit instance when provided', async () => {
+        const { resolveFlare } = await import('../src/resolveFlare.js');
+        const explicit = { id: 'explicit' } as any;
+        expect(resolveFlare(explicit)).toBe(explicit);
+    });
+
+    test('returns the registered default when no explicit instance', async () => {
+        const { resolveFlare, registerDefaultFlare } = await import('../src/resolveFlare.js');
+        const def = { id: 'default' } as any;
+        registerDefaultFlare(() => def);
+        expect(resolveFlare()).toBe(def);
+    });
+
+    test('throws a clear error when no instance and no default', async () => {
+        const { resolveFlare } = await import('../src/resolveFlare.js');
+        expect(() => resolveFlare()).toThrow(/No Flare instance available/);
+    });
+
+    test('registerDefaultFlare warns when the electron bridge is already present', async () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        (window as any).__flare = { report: () => {} };
+        const { registerDefaultFlare } = await import('../src/resolveFlare.js');
+        registerDefaultFlare(() => ({}) as any);
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining('/inject'));
+    });
+
+    test('registerDefaultFlare does NOT warn without the bridge', async () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const { registerDefaultFlare } = await import('../src/resolveFlare.js');
+        registerDefaultFlare(() => ({}) as any);
+        expect(warn).not.toHaveBeenCalled();
+    });
+});
+```
+
+> Note (fixes A+B): no `@ts-expect-error` above the `delete` lines; source uses `as unknown as Record`. Imports use the `.js` extension (svelte ESM convention) — vitest resolves `../src/resolveFlare.js` to the `.ts` source.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/svelte && npx vitest run tests/resolveFlare.test.ts`
+Expected: FAIL — cannot resolve '../src/resolveFlare.js'.
+
+- [ ] **Step 3: Write the implementation**
+
+```ts
+// packages/svelte/src/resolveFlare.ts
+import type { Flare } from '@flareapp/js/browser';
+
+let defaultProvider: (() => Flare) | null = null;
+
+// Called once by the web entry (index.ts) as an import side effect.
+export function registerDefaultFlare(provider: () => Flare): void {
+    if (typeof window !== 'undefined' && (window as unknown as Record<string, unknown>).__flare) {
+        console.warn(
+            '[flare] @flareapp/js default registered while the electron bridge is present. ' +
+                'In a renderer, import @flareapp/svelte/inject and pass the ' +
+                '@flareapp/electron/renderer instance instead.',
+        );
+    }
+    defaultProvider = provider;
+}
+
+// Resolve at WIRING time (handler creation / component setup), never inside a report path.
+export function resolveFlare(explicit?: Flare): Flare {
+    if (explicit) {
+        return explicit;
+    }
+    if (defaultProvider) {
+        return defaultProvider();
+    }
+    throw new Error(
+        '[flare] No Flare instance available. Pass `flare` (e.g. from ' +
+            '@flareapp/electron/renderer), or import @flareapp/svelte (the package root) ' +
+            'to use the @flareapp/js default singleton.',
+    );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/svelte && npx vitest run tests/resolveFlare.test.ts`
+Expected: PASS (5 tests).
+
+- [ ] **Step 5: Type-check**
+
+Run: `cd packages/svelte && npm run typescript`
+Expected: 0 new errors from resolveFlare.ts/test.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/svelte/src/resolveFlare.ts packages/svelte/tests/resolveFlare.test.ts
+git commit -m "feat(svelte): add resolveFlare default-provider seam"
+```
+
+---
+
+## Task 2: Per-instance identity
+
+**Files:** Modify `packages/svelte/src/identify.ts`, Rewrite `packages/svelte/tests/identify.test.ts` (if it exists; else create)
+
+Current `identify.ts` imports the root `flare`, has a module-level boolean `registered`, and `registerSvelteSdkIdentity()` (no arg) sets sdk+framework on the root singleton. Rewrite to per-instance, argument-driven, root-free. Framework has NO version (`{ name: 'Svelte' }`).
+
+- [ ] **Step 1: Write/rewrite the test**
+
+```ts
+// packages/svelte/tests/identify.test.ts
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+function fakeFlare() {
+    return { setSdkInfo: vi.fn(), setFramework: vi.fn() } as any;
+}
+
+describe('svelte identity', () => {
+    beforeEach(() => {
+        vi.resetModules();
+    });
+
+    test('registerSvelteSdkIdentity sets sdkInfo (@flareapp/svelte) and framework (Svelte)', async () => {
+        const { registerSvelteSdkIdentity } = await import('../src/identify.js');
+        const flare = fakeFlare();
+        registerSvelteSdkIdentity(flare);
+        expect(flare.setSdkInfo).toHaveBeenCalledWith(expect.objectContaining({ name: '@flareapp/svelte' }));
+        expect(flare.setFramework).toHaveBeenCalledWith({ name: 'Svelte' });
+    });
+
+    test('tagSvelteFramework sets framework only, never sdkInfo', async () => {
+        const { tagSvelteFramework } = await import('../src/identify.js');
+        const flare = fakeFlare();
+        tagSvelteFramework(flare);
+        expect(flare.setFramework).toHaveBeenCalledWith({ name: 'Svelte' });
+        expect(flare.setSdkInfo).not.toHaveBeenCalled();
+    });
+
+    test('each guard is per-instance: same instance tagged once, distinct instances each tagged', async () => {
+        const { tagSvelteFramework } = await import('../src/identify.js');
+        const a = fakeFlare();
+        const b = fakeFlare();
+        tagSvelteFramework(a);
+        tagSvelteFramework(a);
+        tagSvelteFramework(b);
+        expect(a.setFramework).toHaveBeenCalledOnce();
+        expect(b.setFramework).toHaveBeenCalledOnce();
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/svelte && npx vitest run tests/identify.test.ts`
+Expected: FAIL — `tagSvelteFramework` not exported / `registerSvelteSdkIdentity` takes no argument.
+
+- [ ] **Step 3: Rewrite the implementation**
+
+```ts
+// packages/svelte/src/identify.ts
+import type { Flare } from '@flareapp/js/browser';
+
+import { PACKAGE_VERSION } from './version.js';
+
+// Per-instance guards. A boolean cannot serve injection: with a singleton AND an
+// injected RendererFlare, each instance must be tagged independently.
+const sdkTagged = new WeakSet<object>();
+const frameworkTagged = new WeakSet<object>();
+
+// Web path: full identity on the default singleton (sdk + framework). Svelte's framework has no version.
+export function registerSvelteSdkIdentity(flare: Flare): void {
+    if (!sdkTagged.has(flare)) {
+        sdkTagged.add(flare);
+        flare.setSdkInfo({ name: '@flareapp/svelte', version: PACKAGE_VERSION });
+    }
+    tagSvelteFramework(flare);
+}
+
+// Injected path: framework tag ONLY. Never touch sdkInfo — that would clobber the
+// injected instance's own SDK name (e.g. @flareapp/electron).
+export function tagSvelteFramework(flare: Flare): void {
+    if (frameworkTagged.has(flare)) {
+        return;
+    }
+    frameworkTagged.add(flare);
+    flare.setFramework({ name: 'Svelte' });
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/svelte && npx vitest run tests/identify.test.ts`
+Expected: PASS (3 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/svelte/src/identify.ts packages/svelte/tests/identify.test.ts
+git commit -m "feat(svelte): per-instance SDK identity with framework-only tag"
+```
+
+> Note: after this, `index.ts:3` (`registerSvelteSdkIdentity()` no-arg) and `createFlareErrorHandler.ts:11` (same) are STALE — fixed in Tasks 6 and 4 respectively. The package may not fully type-check until those land; only run `tests/identify.test.ts` here.
+
+---
+
+## Task 3: Move shared-graph type imports off the js root
+
+`contextToAttributes.ts` is in the inject graph (imported by `createFlareErrorHandler`). Its type-only `AttributeValue`/`Attributes` import from the root is erased at runtime, but move it to `@flareapp/core` for consistency with React/Vue and to keep the root out of the type graph too.
+
+**Files:** Modify `packages/svelte/src/contextToAttributes.ts`
+
+- [ ] **Step 1: Read the file's import line 1** (`import type { AttributeValue, Attributes } from '@flareapp/js';`).
+
+- [ ] **Step 2: Change it to `@flareapp/core`**
+
+```ts
+import type { AttributeValue, Attributes } from '@flareapp/core';
+```
+
+- [ ] **Step 3: Verify suite + types**
+
+Run: `cd packages/svelte && npx vitest run tests/identify.test.ts tests/resolveFlare.test.ts` (the tests landed so far stay green).
+Run: `cd packages/svelte && npm run typescript` — note: createFlareErrorHandler.ts / index.ts still import the root + have stale no-arg identity calls (handled in Tasks 4/6), so `tsc` may report errors THERE; contextToAttributes.ts itself must add none.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/svelte/src/contextToAttributes.ts
+git commit -m "refactor(svelte): import attribute types from @flareapp/core, not the js root"
+```
+
+---
+
+## Task 4: `flare` option on `createFlareErrorHandler` (resolve at creation)
+
+**Files:** Modify `packages/svelte/src/createFlareErrorHandler.ts`, Modify `packages/svelte/tests/createFlareErrorHandler.test.ts`
+
+Read both first. The current file imports `{ convertToError, flare }` from the root, calls `registerSvelteSdkIdentity()` at module top (line 11), and the returned handler calls `flare.reportSilently`.
+
+- [ ] **Step 1: Extend the test (do NOT rewrite the existing mock)**
+
+The existing `createFlareErrorHandler.test.ts` mocks `@flareapp/js`. Inspect its exact shape and preserve it. Make ONLY additive edits:
+
+1. Ensure the mocked `flare` exposes `reportSilently` (routed to a `mockReport` the existing tests use), `setSdkInfo`, `setFramework`. If the existing mock lacks `setSdkInfo`/`setFramework`, add them (the handler now tags the resolved instance). Keep `convertToError` on the mock (the handler imports it from core after Step 3, but keeping it harmless avoids a red-step crash).
+2. After the mock block, register the mocked singleton as the default:
+
+```ts
+import * as resolveModule from '../src/resolveFlare.js';
+import { registerDefaultFlare } from '../src/resolveFlare.js';
+import { flare as mockedRoot } from '@flareapp/js';
+registerDefaultFlare(() => mockedRoot as any);
+```
+
+3. Add these tests (the handler is async — await it):
+
+```ts
+test('reports through an injected flare instance, not the default', async () => {
+    const injected = { reportSilently: vi.fn(), setSdkInfo: vi.fn(), setFramework: vi.fn() } as any;
+    const handler = createFlareErrorHandler({ flare: injected });
+    await handler(new Error('boom'), () => {});
+    expect(injected.reportSilently).toHaveBeenCalledOnce();
+    expect(mockReport).not.toHaveBeenCalled();
+});
+
+test('injected instance tagged framework-only, never sdkInfo', () => {
+    const injected = { reportSilently: vi.fn(), setSdkInfo: vi.fn(), setFramework: vi.fn() } as any;
+    createFlareErrorHandler({ flare: injected });
+    expect(injected.setFramework).toHaveBeenCalledWith({ name: 'Svelte' });
+    expect(injected.setSdkInfo).not.toHaveBeenCalled();
+});
+
+test('resolves the instance once at creation, not per call', async () => {
+    const injected = { reportSilently: vi.fn(), setSdkInfo: vi.fn(), setFramework: vi.fn() } as any;
+    const resolveSpy = vi.spyOn(resolveModule, 'resolveFlare');
+    const handler = createFlareErrorHandler({ flare: injected });
+    await handler(new Error('a'), () => {});
+    await handler(new Error('b'), () => {});
+    expect(resolveSpy).toHaveBeenCalledTimes(1); // resolved at creation, NOT per call (fix C)
+    resolveSpy.mockRestore();
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/svelte && npx vitest run tests/createFlareErrorHandler.test.ts`
+Expected: FAIL — `FlareErrorHandlerOptions` has no `flare`; injected instance unused.
+
+- [ ] **Step 3: Rewire `createFlareErrorHandler.ts`**
+
+Change import line 1 `import { convertToError, flare } from '@flareapp/js';` to:
+
+```ts
+import { convertToError } from '@flareapp/core';
+import type { Flare } from '@flareapp/js/browser';
+```
+
+Change the identify import + REMOVE the module-top call. The current lines:
+
+```ts
+import { registerSvelteSdkIdentity } from './identify.js';
+...
+registerSvelteSdkIdentity();   // <- DELETE this module-top call
+```
+
+Change to:
+
+```ts
+import { resolveFlare } from './resolveFlare.js';
+import { tagSvelteFramework } from './identify.js';
+```
+
+(no module-top call). Add `flare?: Flare` as the first member of `FlareErrorHandlerOptions`:
+
+```ts
+export interface FlareErrorHandlerOptions {
+    flare?: Flare;
+    ancestor?: ComponentTreeNode | null;
+    beforeEvaluate?: (params: { error: Error }) => void;
+    beforeSubmit?: (params: { error: Error; context: FlareSvelteContext }) => FlareSvelteContext;
+    afterSubmit?: (params: { error: Error; context: FlareSvelteContext }) => void;
+}
+```
+
+At the TOP of `createFlareErrorHandler`, resolve once at creation and tag the framework, then report via the resolved instance:
+
+```ts
+export function createFlareErrorHandler(options?: FlareErrorHandlerOptions) {
+    const flare = resolveFlare(options?.flare);
+    tagSvelteFramework(flare);
+
+    return async (rawError: unknown, _reset: () => void) => {
+        // ...unchanged body, but the existing `flare.reportSilently(...)` now refers to the
+        // block-scoped resolved `const flare` above.
+    };
+}
+```
+
+Confirm the `flare.reportSilently(error, contextToAttributes(context))` line now uses the block-scoped `flare`. Confirm NO module-level root `flare` reference remains.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/svelte && npx vitest run tests/createFlareErrorHandler.test.ts`
+Expected: PASS (existing + 3 new).
+
+- [ ] **Step 5: Declare the `@flareapp/core` runtime dependency (it is imported now, not in Task 8)**
+
+This task introduces the first RUNTIME import from `@flareapp/core` (`convertToError`). Declare the dependency in the same commit so no intermediate commit has an undeclared runtime dep. svelte already has a `dependencies` block (`error-stack-parser`). Add `@flareapp/core` pinned EXACT to the current core version (check `node -p "require('./packages/core/package.json').version"`):
+
+```json
+    "dependencies": {
+        "@flareapp/core": "2.4.0",
+        "error-stack-parser": "^2.1.4"
+    },
+```
+
+Also add svelte to `CORE_REFS` in `scripts/release-all.mjs` (after the `vue` entry added on the stacked Vue branch):
+
+```js
+    { pkg: 'svelte', field: 'dependencies', dep: '@flareapp/core' },
+```
+
+Then `npm install` from repo root. Confirm the only lockfile change is svelte's new `@flareapp/core` dep (`git --no-pager diff --stat`).
+
+- [ ] **Step 6: Type-check**
+
+Run: `cd packages/svelte && npm run typescript`
+Expected: the ONLY remaining error (if any) is `index.ts` still calling `registerSvelteSdkIdentity()` no-arg (Task 6). createFlareErrorHandler.ts adds none.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add packages/svelte/src/createFlareErrorHandler.ts packages/svelte/tests/createFlareErrorHandler.test.ts packages/svelte/package.json scripts/release-all.mjs package-lock.json
+git commit -m "feat(svelte): inject optional flare into createFlareErrorHandler (resolve at creation); declare core dep"
+```
+
+---
+
+## Task 5: `flare` prop on `FlareErrorBoundary.svelte`
+
+**Files:** Modify `packages/svelte/src/FlareErrorBoundary.svelte`, Modify `packages/svelte/tests/fixtures/BoundaryWithBuggyChild.svelte`, Modify `packages/svelte/tests/FlareErrorBoundary.test.ts`
+
+The boundary delegates to `createFlareErrorHandler`. Add a `flare?` prop and forward it.
+
+- [ ] **Step 1a: Add a `flare` prop to the test fixture so it can be forwarded**
+
+The boundary tests render fixture wrappers (e.g. `tests/fixtures/BoundaryWithBuggyChild.svelte`) that wrap `FlareErrorBoundary` and provoke a render error. That fixture does NOT currently accept or forward a `flare` prop, so a `render(BoundaryWithBuggyChild, { props: { flare } })` would never reach the boundary. Make the fixture forward it additively (default `undefined`, so existing tests are unaffected).
+
+In `packages/svelte/tests/fixtures/BoundaryWithBuggyChild.svelte`:
+
+- Add to the `Props` interface: `flare?: import('../../src/createFlareErrorHandler').FlareErrorHandlerOptions['flare'];`
+- Add `flare` to the `$props()` destructure.
+- Forward it on the wrapped boundary: `<FlareErrorBoundary {flare} {beforeEvaluate} {beforeSubmit} {afterSubmit} {onReset} {resetKeys}>`.
+
+- [ ] **Step 1b: Add the injection tests to `FlareErrorBoundary.test.ts`**
+
+The existing mock uses `vi.mock('@flareapp/js', async (importOriginal) => ({ ...actual, flare: { report, reportSilently: (...a)=>mockReport(...a), setSdkInfo: vi.fn(), setFramework: vi.fn(), addContext: vi.fn() } }))`. Keep it. After that block, register the mocked singleton as the default:
+
+```ts
+import { registerDefaultFlare } from '../src/resolveFlare.js';
+import { flare as mockedRoot } from '@flareapp/js';
+registerDefaultFlare(() => mockedRoot as any);
+```
+
+Then add these two tests (reuse the file's `mockReport`, `render`, and the `BoundaryWithBuggyChild` fixture; existing tests wait `await new Promise((r) => setTimeout(r, 0))` after render to let the async handler run):
+
+```ts
+test('forwards an injected flare prop into the handler (reports through injected, not default)', async () => {
+    const injected = { reportSilently: vi.fn(), setSdkInfo: vi.fn(), setFramework: vi.fn() } as any;
+    render(BoundaryWithBuggyChild, { props: { flare: injected } });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(injected.reportSilently).toHaveBeenCalledOnce();
+    expect(mockReport).not.toHaveBeenCalled();
+});
+
+test('falls back to the registered default when no flare prop', async () => {
+    render(BoundaryWithBuggyChild);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(mockReport).toHaveBeenCalledOnce();
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/svelte && npx vitest run tests/FlareErrorBoundary.test.ts`
+Expected: FAIL — `FlareErrorBoundary` has no `flare` prop, so the forwarded prop is ignored and `injected.reportSilently` is never called (the default mock receives it instead).
+
+- [ ] **Step 3: Add the `flare` prop and forward it**
+
+In `FlareErrorBoundary.svelte`'s `<script>`:
+
+Add `flare` to the `Props` interface and `$props()` destructure:
+
+```ts
+interface Props {
+    children: Snippet;
+    failed?: Snippet<[error: Error, reset: () => void]>;
+    resetKeys?: unknown[];
+    flare?: FlareErrorHandlerOptions['flare'];
+    beforeEvaluate?: FlareErrorHandlerOptions['beforeEvaluate'];
+    beforeSubmit?: FlareErrorHandlerOptions['beforeSubmit'];
+    afterSubmit?: FlareErrorHandlerOptions['afterSubmit'];
+    onReset?: (error: Error | null) => void;
+}
+
+let {
+    children,
+    failed: fallbackSnippet,
+    resetKeys,
+    flare,
+    beforeEvaluate,
+    beforeSubmit,
+    afterSubmit,
+    onReset,
+}: Props = $props();
+```
+
+Forward `flare` into the handler creation:
+
+```ts
+const handler = $derived(createFlareErrorHandler({ ancestor, flare, beforeEvaluate, beforeSubmit, afterSubmit }));
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd packages/svelte && npx vitest run tests/FlareErrorBoundary.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Full type-check + suite**
+
+Run: `cd packages/svelte && npm run typescript` (expect only the index.ts stale call, fixed next task) and `npx vitest run` (full suite green).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add packages/svelte/src/FlareErrorBoundary.svelte packages/svelte/tests/fixtures/BoundaryWithBuggyChild.svelte packages/svelte/tests/FlareErrorBoundary.test.ts
+git commit -m "feat(svelte): forward optional flare prop from FlareErrorBoundary to the handler"
+```
+
+---
+
+## Task 6: Web entry — register default + KEEP import-time identity (SvelteKit constraint)
+
+**Files:** Modify `packages/svelte/src/index.ts`, Create `packages/svelte/tests/webEntry.test.ts`
+
+The current `index.ts` calls `registerSvelteSdkIdentity()` (no-arg) at module load (line 3). This import-time registration is the contract SvelteKit's `export *` depends on. Keep it at import — but now with the resolved singleton, and ALSO register the default provider.
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/svelte/tests/webEntry.test.ts
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+describe('@flareapp/svelte web entry', () => {
+    beforeEach(() => {
+        vi.resetModules();
+    });
+
+    test('importing the root sets SDK identity at import AND registers the singleton as default', async () => {
+        const setSdkInfo = vi.fn();
+        const setFramework = vi.fn();
+        const singleton = { setSdkInfo, setFramework, reportSilently: vi.fn() };
+        vi.doMock('@flareapp/js', () => ({ flare: singleton }));
+
+        await import('../src/index.js');
+
+        // SvelteKit contract: identity is set at IMPORT (module load), not deferred.
+        expect(setSdkInfo).toHaveBeenCalledWith(expect.objectContaining({ name: '@flareapp/svelte' }));
+        expect(setFramework).toHaveBeenCalledWith({ name: 'Svelte' });
+
+        // default provider registered for no-option usage
+        const { resolveFlare } = await import('../src/resolveFlare.js');
+        expect(resolveFlare()).toBe(singleton);
+    });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/svelte && npx vitest run tests/webEntry.test.ts`
+Expected: FAIL — importing `../src/index.js` throws because the stale `registerSvelteSdkIdentity()` (no-arg, after Task 2 requires a `flare`) hits `WeakSet.add(undefined)` → `TypeError: Invalid value used in weak set`.
+
+- [ ] **Step 3: Rewrite the top of `index.ts`**
+
+The current top is:
+
+```ts
+import { registerSvelteSdkIdentity } from './identify.js';
+
+registerSvelteSdkIdentity();
+```
+
+Change to (import the root singleton, register default, AND keep import-time identity with the singleton):
+
+```ts
+import { flare } from '@flareapp/js';
+
+import { registerSvelteSdkIdentity } from './identify.js';
+import { registerDefaultFlare } from './resolveFlare.js';
+
+// Web entry. Importing @flareapp/js runs the root's own side effects (window.flare + global
+// catch) — correct for the web. Register the singleton as the default Flare AND set its SDK
+// identity AT IMPORT. The import-time identity registration is a hard contract: @flareapp/sveltekit
+// does `export * from '@flareapp/svelte'` and overrides the SDK name per-report, relying on this
+// running first (spec Decision 6). Do not defer it.
+registerDefaultFlare(() => flare);
+registerSvelteSdkIdentity(flare);
+```
+
+Keep EVERY existing export line below unchanged.
+
+- [ ] **Step 4: Run test + full suite + tsc**
+
+Run: `cd packages/svelte && npx vitest run tests/webEntry.test.ts` (pass)
+Run: `cd packages/svelte && npx vitest run` (full suite green)
+Run: `cd packages/svelte && npm run typescript` (0 errors now — the stale call is fixed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/svelte/src/index.ts packages/svelte/tests/webEntry.test.ts
+git commit -m "feat(svelte): web entry registers default + keeps import-time identity (sveltekit contract)"
+```
+
+---
+
+## Task 7: `/inject` entry (no js-root reference)
+
+**Files:** Create `packages/svelte/src/inject.ts`, Create `packages/svelte/tests/injectEntry.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```ts
+// packages/svelte/tests/injectEntry.test.ts
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+describe('@flareapp/svelte/inject entry', () => {
+    beforeEach(() => {
+        vi.resetModules();
+        delete (window as any).flare;
+    });
+
+    test('importing the inject entry does NOT evaluate @flareapp/js root', async () => {
+        const rootFactory = vi.fn(() => ({ flare: {} }));
+        vi.doMock('@flareapp/js', rootFactory);
+
+        await import('../src/inject.js');
+
+        expect(rootFactory).not.toHaveBeenCalled();
+        expect((window as any).flare).toBeUndefined();
+    });
+
+    test('exports createFlareErrorHandler and FlareErrorBoundary', async () => {
+        const mod = await import('../src/inject.js');
+        expect(typeof mod.createFlareErrorHandler).toBe('function');
+        expect(mod.FlareErrorBoundary).toBeDefined();
+    });
+
+    test('createFlareErrorHandler from inject throws when no flare option and no default', async () => {
+        const { createFlareErrorHandler } = await import('../src/inject.js');
+        expect(() => createFlareErrorHandler()).toThrow(/No Flare instance available/);
+    });
+});
+```
+
+> The throw test relies on no default being registered in this file's isolated module registry (vitest isolates per file) — do NOT register one to make it pass.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd packages/svelte && npx vitest run tests/injectEntry.test.ts`
+Expected: FAIL — cannot resolve '../src/inject.js'.
+
+- [ ] **Step 3: Create the inject entry**
+
+Read `src/index.ts` and mirror its export block MINUS the root import + `registerDefaultFlare` + `registerSvelteSdkIdentity` calls. Use `.js` extensions:
+
+```ts
+// packages/svelte/src/inject.ts
+// Electron-safe entry. NO @flareapp/js root import, NO default registration, NO import-time
+// identity. The caller MUST pass `flare` (handler option / boundary prop); resolveFlare throws
+// at wiring time if absent.
+export { default as FlareErrorBoundary } from './FlareErrorBoundary.svelte';
+export { createFlareErrorHandler, type FlareErrorHandlerOptions } from './createFlareErrorHandler.js';
+export { __flareRegisterComponent, getComponentTreeContext } from './componentTree.js';
+export { withFlareConfig, type WithFlareConfigOptions } from './config.js';
+export { flarePreprocessor, type FlarePreprocessorOptions } from './preprocessor.js';
+export type { FlareSvelteContext, SvelteErrorOrigin } from './types.js';
+```
+
+(Copy the EXACT export list from the current `index.ts` minus the three side-effect lines. Confirm none of `componentTree`/`config`/`preprocessor` value-import the root — they don't, per the pre-task survey.)
+
+- [ ] **Step 4: Run test + full suite + tsc**
+
+Run: `cd packages/svelte && npx vitest run tests/injectEntry.test.ts` (3 pass)
+Run: `cd packages/svelte && npx vitest run` (full suite green)
+Run: `cd packages/svelte && npm run typescript` (0 errors)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/svelte/src/inject.ts packages/svelte/tests/injectEntry.test.ts
+git commit -m "feat(svelte): add @flareapp/svelte/inject electron-safe entry"
+```
+
+---
+
+## Task 8: Package wiring — `./inject` export map, sideEffects, export smoke test
+
+NOTE: NO build-command change — `svelte-package` auto-compiles `src/inject.ts`. The `@flareapp/core` dependency + `CORE_REFS` were already declared in Task 4 (where the runtime import lands), so they are NOT repeated here.
+
+**Files:** Modify `packages/svelte/package.json`, Create `packages/svelte/scripts/verify-exports.mjs` (this also creates the new `packages/svelte/scripts/` directory — the `Write` that creates the file will make the parent dir)
+
+- [ ] **Step 1: Add the `./inject` export**
+
+Mirror the `.` entry's shape (it has a `svelte` condition because it exports a `.svelte` component, which `/inject` also does). After the `./config` entry, add:
+
+```json
+        "./inject": {
+            "svelte": "./dist/inject.js",
+            "import": {
+                "types": "./dist/inject.d.ts",
+                "default": "./dist/inject.js"
+            }
+        }
+```
+
+- [ ] **Step 2: Add `sideEffects`**
+
+Only the index dist file has the registerDefaultFlare + import-time identity side effects:
+
+```json
+    "sideEffects": ["./dist/index.js"],
+```
+
+- [ ] **Step 3: Build and verify the entry files exist**
+
+Run: `cd packages/svelte && npm run build` — succeeds.
+Run (from packages/svelte): `ls dist/inject.js dist/inject.d.ts` — both exist.
+Run: `cd packages/svelte && npm run typescript` — 0 errors.
+
+- [ ] **Step 4: Add a post-build export-map check (a node script, NOT a vitest test)**
+
+The unit tests import `../src/inject.js` (source); nothing exercises the published `@flareapp/svelte/inject` subpath, so a wrong path in the `exports` map could ship broken. This must NOT be a vitest test: it depends on `dist`, and `packages/svelte`'s `test` script is a bare `vitest run` with no prebuild — a `dist`-dependent test would break `cd packages/svelte && npm test` on a clean checkout. It also must not statically `import '@flareapp/svelte/inject'` (a static import that fails to compile the built `.svelte` re-export aborts module load before any fallback can run). Instead use a deterministic fs-based node script (same pattern as `verify-inject-no-root.mjs` and electron's `verify-exports.mjs`).
+
+It is NOT enough to check that the leaf paths merely EXIST: if `exports["./inject"].import.default` accidentally pointed at `./dist/index.js` (the web root entry, which exists AND re-exports the same names), an existence-only check passes while the published `/inject` subpath silently pulls the root. So assert the EXACT expected target paths, derive the runtime target FROM the map, and grep that target.
+
+Create `packages/svelte/scripts/verify-exports.mjs`:
+
+```js
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const pkgDir = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const pkg = JSON.parse(readFileSync(resolve(pkgDir, 'package.json'), 'utf8'));
+
+const inject = pkg.exports?.['./inject'];
+let failed = false;
+const fail = (msg) => {
+    console.error(`[verify-exports] ${msg}`);
+    failed = true;
+};
+
+if (!inject) {
+    fail('package.json exports["./inject"] is missing');
+    process.exit(1);
+}
+
+// Assert the EXACT target for each condition. Existence alone is insufficient — a target of
+// ./dist/index.js (the web root) would exist and re-export the same names, yet pull the root.
+const expectedTargets = {
+    'svelte': './dist/inject.js',
+    'import.types': './dist/inject.d.ts',
+    'import.default': './dist/inject.js',
+};
+const actualTargets = {
+    'svelte': inject.svelte,
+    'import.types': inject.import?.types,
+    'import.default': inject.import?.default,
+};
+for (const [key, expected] of Object.entries(expectedTargets)) {
+    if (actualTargets[key] !== expected) {
+        fail(`exports["./inject"].${key} = ${actualTargets[key]} (expected ${expected})`);
+    }
+}
+
+// Every leaf path the map references must exist on disk.
+const paths = [];
+(function collect(node) {
+    if (typeof node === 'string') {
+        paths.push(node);
+    } else if (node && typeof node === 'object') {
+        for (const v of Object.values(node)) collect(v);
+    }
+})(inject);
+for (const p of paths) {
+    if (!existsSync(resolve(pkgDir, p))) {
+        fail(`exports["./inject"] points at a missing file: ${p}`);
+    }
+}
+
+// Grep the RUNTIME target the map actually resolves to (not a hardcoded path) for the surface.
+const runtimeTarget = inject.import?.default ?? inject.svelte;
+const entry = runtimeTarget ? resolve(pkgDir, runtimeTarget) : null;
+if (!entry || !existsSync(entry)) {
+    fail(`runtime target ${runtimeTarget} does not exist (build first)`);
+} else {
+    const src = readFileSync(entry, 'utf8');
+    for (const name of [
+        'createFlareErrorHandler',
+        'FlareErrorBoundary',
+        '__flareRegisterComponent',
+        'withFlareConfig',
+        'flarePreprocessor',
+    ]) {
+        if (!new RegExp(`\\b${name}\\b`).test(src)) {
+            fail(`${runtimeTarget} is missing export: ${name}`);
+        }
+    }
+}
+
+if (failed) {
+    process.exit(1);
+}
+console.log(
+    `[verify-exports] OK — exports["./inject"] targets match (${paths.length} paths) and the runtime entry exposes the expected surface.`,
+);
+```
+
+Add the npm script to `packages/svelte/package.json` (next to the build/test scripts; do NOT wire it into `test`):
+
+```json
+        "verify:exports": "node scripts/verify-exports.mjs",
+```
+
+Run: `cd packages/svelte && npm run build && npm run verify:exports`
+Expected: `[verify-exports] OK ...`. To confirm it bites on the REALISTIC failure (not just a missing file), temporarily change the `./inject` `import.default` to `./dist/index.js` (the web root — it exists and re-exports the same names, so an existence-only check would pass). Run the script: expect non-zero with `exports["./inject"].import.default = ./dist/index.js (expected ./dist/inject.js)`. Then revert and confirm OK.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/svelte/package.json packages/svelte/scripts/verify-exports.mjs
+git commit -m "build(svelte): publish /inject export + sideEffects; verify the export map"
+```
+
+---
+
+## Task 9: Static guard — inject graph has no js-root specifier (scans `.js`)
+
+`svelte-package` emits per-file `.js` (1:1, not bundled), so the inject entry re-exports from sibling `.js` files. The chunk-graph-following guard handles this — it follows relative `.js`/`.svelte` imports transitively. Adapt the React/Vue guard to scan `.js` entries.
+
+**Files:** Create `packages/svelte/scripts/verify-inject-no-root.mjs`, Modify `packages/svelte/package.json` (add `verify:inject` script)
+
+- [ ] **Step 1: Write the guard**
+
+```js
+// packages/svelte/scripts/verify-inject-no-root.mjs
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const distDir = resolve(dirname(fileURLToPath(import.meta.url)), '../dist');
+const rootSpecifier = /["']@flareapp\/js["']/;
+const relativeSpecifier = /(?:from\s*|require\(\s*)["'](\.\.?\/[^"']+)["']/g;
+
+// svelte-package emits per-file .js (ESM). The inject entry re-exports from sibling files;
+// follow the relative import graph transitively so a root import in any reachable file is caught.
+const entries = ['inject.js'];
+const scanned = new Set();
+let failed = false;
+
+function scan(absPath) {
+    if (scanned.has(absPath)) {
+        return;
+    }
+    scanned.add(absPath);
+    let src;
+    try {
+        src = readFileSync(absPath, 'utf8');
+    } catch {
+        return; // .svelte sources or type-only paths that resolved oddly — skip silently
+    }
+    if (rootSpecifier.test(src)) {
+        console.error(
+            `[verify-inject-no-root] ${absPath} references the @flareapp/js root. The inject entry must not pull the root.`,
+        );
+        failed = true;
+    }
+    for (const match of src.matchAll(relativeSpecifier)) {
+        scan(resolve(dirname(absPath), match[1]));
+    }
+}
+
+for (const entry of entries) {
+    scan(resolve(distDir, entry));
+}
+
+if (failed) {
+    process.exit(1);
+}
+console.log(`[verify-inject-no-root] OK — inject graph (${scanned.size} files) has no @flareapp/js root reference.`);
+```
+
+> `.svelte` files are emitted by svelte-package preprocessed (not `.js`); if the relative graph references a `.svelte` file the `readFileSync` of that exact path may miss (the dist file could be `FlareErrorBoundary.svelte`). The try/catch skips unreadable paths. The FlareErrorBoundary.svelte source does not import the root anyway (it delegates to createFlareErrorHandler, which IS a `.js` and IS scanned). If you want belt-and-suspenders, also add `'FlareErrorBoundary.svelte'` text scan — but the createFlareErrorHandler chain is the load-bearing path and is covered.
+
+- [ ] **Step 2: Add the npm script**
+
+`"verify:inject": "node scripts/verify-inject-no-root.mjs",`
+
+- [ ] **Step 3: Run against the current build**
+
+Run: `cd packages/svelte && npm run build && npm run verify:inject`
+Expected: `[verify-inject-no-root] OK — inject graph (N files) ...`, N > 1 (followed siblings). If it FAILS on the correct build, a reachable file pulls the root — STOP and report which.
+
+- [ ] **Step 4: Prove the guard bites**
+
+Temporarily add `import '@flareapp/js';` to the TOP of `src/createFlareErrorHandler.ts` (a reachable inject-graph module), rebuild, run the guard:
+Run: `cd packages/svelte && npm run build && npm run verify:inject`
+Expected: exits NON-ZERO naming `dist/createFlareErrorHandler.js`.
+Then REMOVE the temporary import, rebuild, confirm OK. Verify `git diff src/createFlareErrorHandler.ts` is empty before committing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/svelte/scripts/verify-inject-no-root.mjs packages/svelte/package.json
+git commit -m "test(svelte): static guard that /inject graph never pulls js root"
+```
+
+---
+
+## Task 10: Cross-package regression — drive `@flareapp/svelte/inject` into RendererFlare
+
+This test lives in the SVELTE package (NOT electron): electron's vitest is plain `node` and cannot load the `.svelte` re-export in the inject entry, whereas svelte's vitest has `@sveltejs/vite-plugin-svelte`. It drives the REAL inject handler against a real `RendererFlare`.
+
+**Files:** Create `packages/svelte/tests/electronInjection.test.ts`, Modify `packages/svelte/package.json` (add `@flareapp/electron` devDependency), Modify `package-lock.json`
+
+Prerequisite: `@flareapp/electron` is built (`@flareapp/electron/renderer` resolves to its dist).
+
+- [ ] **Step 1: Add `@flareapp/electron` as a svelte devDependency**
+
+In `packages/svelte/package.json` devDependencies, add:
+
+```json
+        "@flareapp/electron": "file:../electron",
+```
+
+Then `npm install` from repo root. Confirm churn limited to package-lock.json + svelte package.json.
+
+- [ ] **Step 2: Write the regression test**
+
+```ts
+// packages/svelte/tests/electronInjection.test.ts
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+// The REAL inject entry. Importing it must not pull the js root.
+import { createFlareErrorHandler } from '../src/inject.js';
+import { FLARE_BRIDGE_KEY, RendererFlare } from '@flareapp/electron/renderer';
+
+describe('@flareapp/svelte/inject reports through an injected RendererFlare', () => {
+    let bridgeReport: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        bridgeReport = vi.fn(async () => {});
+        (globalThis as Record<string, unknown>)[FLARE_BRIDGE_KEY] = { report: bridgeReport };
+    });
+
+    afterEach(() => {
+        delete (globalThis as Record<string, unknown>)[FLARE_BRIDGE_KEY];
+    });
+
+    test('forwards a STRING payload carrying Svelte context.custom over the bridge', async () => {
+        const flare = new RendererFlare();
+        const handler = createFlareErrorHandler({ flare });
+
+        await handler(new Error('boom'), () => {});
+        await flare.flush(1000);
+
+        expect(bridgeReport).toHaveBeenCalledOnce();
+        const payload = bridgeReport.mock.calls[0][0];
+        expect(typeof payload).toBe('string');
+
+        const parsed = JSON.parse(payload);
+        expect(parsed.attributes['telemetry.sdk.name']).toBe('@flareapp/electron');
+        expect(parsed.attributes['flare.framework.name']).toBe('Svelte');
+        expect(parsed.attributes['context.custom'].svelte).toBeDefined();
+        // NOTE: do NOT assert window.flare/globalThis.flare is undefined here. Importing the public
+        // `@flareapp/electron/renderer` entry runs renderer.ts, which legitimately assigns
+        // `window.flare` and installs the global catch — that is the renderer entry's job, not a
+        // leak from the svelte inject path. The no-root guarantee is covered by Task 9 (dist-grep)
+        // and Task 7 (runtime mock-factory check), not by this assertion.
+    });
+});
+```
+
+> If an assertion path is wrong, `console.log(payload)` and adjust ONLY the test path (never production). Keep the intent: electron sdk preserved, framework=Svelte, svelte context.custom survives, payload is a string. Svelte's context key is `context.custom.svelte` (see `contextToAttributes.ts`). `@flareapp/electron/renderer` exports `RendererFlare` + `FLARE_BRIDGE_KEY` AND has an import-time side effect (sets `window.flare`) — that is why the `globalThis.flare` assertion was removed (the React/Vue tests imported `RendererFlare` from electron SOURCE internals to dodge this, but this svelte test consumes the published electron entry, so accept the side effect and rely on Tasks 7/9 for no-root).
+
+- [ ] **Step 3: Build svelte + electron, then run**
+
+Run: `npm run build` from repo root (ensures svelte dist/inject + electron dist exist).
+Run: `cd packages/svelte && npx vitest run tests/electronInjection.test.ts` — expect PASS.
+
+- [ ] **Step 4: Full svelte suite + tsc**
+
+Run: `cd packages/svelte && npx vitest run` (full suite green).
+Run: `cd packages/svelte && npm run typescript` (0 errors).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/svelte/tests/electronInjection.test.ts packages/svelte/package.json package-lock.json
+git commit -m "test(svelte): drive @flareapp/svelte/inject through RendererFlare bridge"
+```
+
+---
+
+## Task 11: SvelteKit ordering regression (Decision 6)
+
+SvelteKit's unit tests fully mock `@flareapp/js`, so they will NOT catch a regression in svelte's import-time identity registration. Two guards: (a) confirm the full SvelteKit suite still passes against the modified svelte; (b) an explicit svelte-side assertion that importing the web entry sets SDK identity at module load (already covered by Task 6's webEntry test — here we add the SvelteKit-framed contract and verify the re-export surface).
+
+**Files:** Create `packages/svelte/tests/sveltekitContract.test.ts`
+
+- [ ] **Step 1: Confirm the SvelteKit suite is green against modified svelte**
+
+Run: `cd packages/sveltekit && npx vitest run`
+Expected: ALL pass (sveltekit code is unchanged; its tests mock the root). If anything fails, the svelte change broke sveltekit's import chain — STOP and report.
+
+- [ ] **Step 2: Write the contract test**
+
+```ts
+// packages/svelte/tests/sveltekitContract.test.ts
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+// SvelteKit does `export * from '@flareapp/svelte'` and relies on (a) the web entry registering
+// SDK identity AT IMPORT, and (b) the full export surface remaining intact so the re-export works.
+describe('@flareapp/svelte web entry — SvelteKit contract', () => {
+    beforeEach(() => {
+        vi.resetModules();
+    });
+
+    test('sets SDK identity at import (module-load), the ordering sveltekit overrides', async () => {
+        const setSdkInfo = vi.fn();
+        const singleton = { setSdkInfo, setFramework: vi.fn(), reportSilently: vi.fn() };
+        vi.doMock('@flareapp/js', () => ({ flare: singleton }));
+        await import('../src/index.js');
+        expect(setSdkInfo).toHaveBeenCalledWith(expect.objectContaining({ name: '@flareapp/svelte' }));
+    });
+
+    test('re-export surface still includes everything sveltekit `export *`s', async () => {
+        const singleton = { setSdkInfo: vi.fn(), setFramework: vi.fn(), reportSilently: vi.fn() };
+        vi.doMock('@flareapp/js', () => ({ flare: singleton }));
+        const mod = await import('../src/index.js');
+        for (const name of [
+            'FlareErrorBoundary',
+            'createFlareErrorHandler',
+            '__flareRegisterComponent',
+            'getComponentTreeContext',
+            'withFlareConfig',
+            'flarePreprocessor',
+        ]) {
+            expect(mod, `missing export: ${name}`).toHaveProperty(name);
+        }
+    });
+});
+```
+
+- [ ] **Step 3: Run it**
+
+Run: `cd packages/svelte && npx vitest run tests/sveltekitContract.test.ts` (2 pass)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/svelte/tests/sveltekitContract.test.ts
+git commit -m "test(svelte): guard the import-time identity + export surface sveltekit depends on"
+```
+
+---
+
+## Task 12: Full suite, version bump, docs
+
+**Files:** Modify `packages/svelte/package.json` (version), Modify `package-lock.json`, Modify `packages/electron/README.md`, Modify `CLAUDE.md`
+
+- [ ] **Step 1: Full verification gate**
+
+Run: `cd packages/svelte && npm run build && npm test && npm run typescript && npm run verify:inject && npm run verify:exports` — all pass.
+Run: `cd packages/sveltekit && npx vitest run` — all pass.
+Run: `cd packages/electron && npm test` — all pass (unchanged, but confirm no breakage).
+If anything fails, STOP and report.
+
+- [ ] **Step 2: Bump `@flareapp/svelte` to 2.5.0 + refresh lockfile**
+
+In `packages/svelte/package.json`, `"version": "2.4.0"` → `"2.5.0"`. Note svelte's `src/version.ts` is generated at release (`generate:version`) — do NOT hand-edit version.ts; only bump package.json. Then `npm install` (repo root); confirm the only lockfile change is the `packages/svelte` version entry.
+
+- [ ] **Step 3: Add the Svelte section to the electron README**
+
+Append to `packages/electron/README.md` (after the React + Vue sections):
+
+````markdown
+## Using `@flareapp/svelte` in the renderer
+
+Same model as the React/Vue sections: the API key lives in **main**, reports travel over IPC, and the renderer injects Electron's Flare instance into Svelte instead of letting it reach the `@flareapp/js` singleton.
+
+### Install
+
+```bash
+npm install @flareapp/electron @flareapp/svelte
+```
+
+`@flareapp/js` comes in transitively via `@flareapp/electron` — do **not** import it in the renderer.
+
+Set up main / preload / renderer exactly as in the React section (steps 1-3): `flare.light(key)` in main, `exposeFlare()` in preload, and a renderer `flare.ts` that re-exports `flare` from `@flareapp/electron/renderer`.
+
+### Svelte — inject the instance
+
+Import `FlareErrorBoundary` (and/or `createFlareErrorHandler`) from `@flareapp/svelte/inject`, not the package root, and pass the renderer instance:
+
+```svelte
+<script lang="ts">
+    import { FlareErrorBoundary } from '@flareapp/svelte/inject';
+    import { flare } from './flare';
+</script>
+
+<FlareErrorBoundary {flare}>
+    <App />
+</FlareErrorBoundary>
+```
+
+Or the handler directly (e.g. in a SvelteKit-free Svelte app's error hook):
+
+```ts
+import { createFlareErrorHandler } from '@flareapp/svelte/inject';
+import { flare } from './flare';
+
+const handleError = createFlareErrorHandler({ flare });
+```
+
+### Rules
+
+- **Never `import { flare } from '@flareapp/js'` in the renderer.** Import the Svelte SDK from `@flareapp/svelte/inject`, never the package root. Importing the root prints a console warning that the default was registered while the Electron bridge is present.
+- Omitting the `flare` prop/option on the `/inject` entry throws at handler creation / component setup (boot), not silently at error time.
+
+Reports from the renderer carry `sdk = @flareapp/electron` and `framework = Svelte`. Your Svelte component context (`context.custom.svelte`, component hierarchy) rides along and survives the IPC trip intact.
+````
+
+- [ ] **Step 4: Update CLAUDE.md**
+
+In the "Monorepo structure" table, update the `@flareapp/svelte` row's Purpose cell to mention the `/inject` entry for Electron renderers (mirror the React/Vue rows).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add packages/svelte/package.json package-lock.json packages/electron/README.md CLAUDE.md
+git commit -m "docs(svelte,electron): document renderer injection; bump svelte to 2.5.0"
+```
+
+---
+
+## Self-review notes (resolved against spec + React/Vue precedent)
+
+- **Decision 1 (optional DI seam):** Task 4 (handler option), Task 5 (boundary prop forwards it).
+- **Decision 2 (separate entries, no dynamic import):** Tasks 6, 7, 8. Task 3 (type migration) keeps the graph root-free.
+- **Decision 3 (per-instance identity, framework-only when injected):** Task 2; applied in Tasks 4, 6.
+- **Decision 4 (additive → minor):** Task 12 (svelte 2.5.0).
+- **Decision 5 (resolve at wiring time, throw there):** Task 4 (handler creation).
+- **Decision 6 (SvelteKit ordering):** Task 6 keeps import-time identity in index.ts; Task 11 guards it explicitly + verifies the sveltekit suite + re-export surface.
+- **Q4 (dev-warn tripwire):** Task 1.
+- **Q7 (sideEffects + regression):** Tasks 6, 8.
+- **Q8 (no-root guard, chunk-graph over `.js`):** Task 9 authoritative; Task 7 runtime check; Task 10 behavioral.
+
+**Four React-branch fixes baked in:** A (window cast) Task 1; B (no unused @ts-expect-error) Tasks 1/7; C (resolves-once via resolveFlare spy) Task 4; D (no fragile env directive — Task 10 lives in svelte's jsdom vitest).
+
+**Svelte-specific risks called out:**
+
+- ONE report site (handler); boundary forwards a prop — simpler than Vue.
+- SvelteKit import-time identity is a hard constraint — index.ts keeps it; sveltekit tests mock the root and CANNOT catch a regression, so Task 11 guards svelte-side.
+- `svelte-package` per-file `.js` output (no bundled chunks) — guard scans `.js` and follows the relative graph; the `.svelte` boundary delegates to a `.js` handler that IS scanned.
+- Cross-package test lives in the svelte package (svelte-aware vitest) because electron's node vitest cannot load `.svelte`.
+- `.js` import extensions throughout.
+
+**Not in this plan:** none — Svelte is the last framework. After this merges, the three-framework `/inject` set (React #58, Vue #59, Svelte) is complete.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13731,7 +13731,7 @@
         },
         "packages/vue": {
             "name": "@flareapp/vue",
-            "version": "2.4.0",
+            "version": "2.5.0",
             "license": "MIT",
             "dependencies": {
                 "@flareapp/core": "2.4.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -13731,6 +13731,9 @@
             "name": "@flareapp/vue",
             "version": "2.4.0",
             "license": "MIT",
+            "dependencies": {
+                "@flareapp/core": "2.4.0"
+            },
             "devDependencies": {
                 "@flareapp/js": "file:../js",
                 "@vue/test-utils": "^2.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13649,6 +13649,7 @@
                 "@flareapp/core": "2.4.0"
             },
             "devDependencies": {
+                "@flareapp/electron": "file:../electron",
                 "@flareapp/js": "file:../js",
                 "@testing-library/jest-dom": "^6.9.1",
                 "@testing-library/react": "^16.0.0",
@@ -13668,12 +13669,14 @@
         },
         "packages/svelte": {
             "name": "@flareapp/svelte",
-            "version": "2.4.0",
+            "version": "2.5.0",
             "license": "MIT",
             "dependencies": {
+                "@flareapp/core": "2.4.0",
                 "error-stack-parser": "^2.1.4"
             },
             "devDependencies": {
+                "@flareapp/electron": "file:../electron",
                 "@flareapp/js": "file:../js",
                 "@sveltejs/package": "^2.5.7",
                 "@sveltejs/vite-plugin-svelte": "^5.0.0",
@@ -13737,6 +13740,7 @@
                 "@flareapp/core": "2.4.0"
             },
             "devDependencies": {
+                "@flareapp/electron": "file:../electron",
                 "@flareapp/js": "file:../js",
                 "@vue/test-utils": "^2.4.0",
                 "jsdom": "^26.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13563,11 +13563,13 @@
             },
             "devDependencies": {
                 "@flareapp/react": "file:../react",
+                "@flareapp/vue": "file:../vue",
                 "electron": "^35.0.0",
                 "react": "^19.0.0",
                 "tsdown": "^0.20.3",
                 "typescript": "^5.7.0",
-                "vitest": "^4.0.18"
+                "vitest": "^4.0.18",
+                "vue": "^3.4.0"
             },
             "engines": {
                 "node": ">=22"

--- a/packages/electron/README.md
+++ b/packages/electron/README.md
@@ -254,3 +254,55 @@ createRoot(document.getElementById('root')!, {
 - Omitting the `flare` prop on the `/inject` entry throws at boundary construction (boot), not silently at error time.
 
 Reports from the renderer carry `sdk = @flareapp/electron` and `framework = React`. Your React component context (`context.custom.react`, component stack) rides along in the report attributes and survives the IPC trip intact.
+
+## Using `@flareapp/vue` in the renderer
+
+Same model as the React section: the API key lives in **main**, reports travel over IPC, and the renderer injects Electron's Flare instance into Vue instead of letting it reach the `@flareapp/js` singleton.
+
+### Install
+
+```bash
+npm install @flareapp/electron @flareapp/vue
+```
+
+`@flareapp/js` comes in transitively via `@flareapp/electron` — do **not** import it in the renderer.
+
+Set up main / preload / renderer exactly as in the React section (steps 1-3): `flare.light(key)` in main, `exposeFlare()` in preload, and a renderer `flare.ts` that re-exports `flare` from `@flareapp/electron/renderer`.
+
+### Vue — inject the instance
+
+Import `flareVue` (and, if you use it, `FlareErrorBoundary`) from `@flareapp/vue/inject`, not the package root, and pass the renderer instance:
+
+```ts
+// main.ts (renderer entry)
+import { createApp } from 'vue';
+import { flareVue } from '@flareapp/vue/inject';
+import { flare } from './flare';
+import App from './App.vue';
+
+const app = createApp(App);
+app.use(flareVue, { flare });
+app.mount('#app');
+```
+
+Component boundary:
+
+```vue
+<script setup lang="ts">
+import { FlareErrorBoundary } from '@flareapp/vue/inject';
+import { flare } from './flare';
+</script>
+
+<template>
+    <FlareErrorBoundary :flare="flare">
+        <App />
+    </FlareErrorBoundary>
+</template>
+```
+
+### Rules
+
+- **Never `import { flare } from '@flareapp/js'` in the renderer.** Import the Vue SDK from `@flareapp/vue/inject`, never the package root. Importing the root prints a console warning that the default was registered while the Electron bridge is present.
+- Omitting the `flare` option/prop on the `/inject` entry throws at install / component setup (boot), not silently at error time.
+
+Reports from the renderer carry `sdk = @flareapp/electron` and `framework = Vue`. Your Vue component context (`context.custom.vue`, component hierarchy, props) rides along and survives the IPC trip intact.

--- a/packages/electron/README.md
+++ b/packages/electron/README.md
@@ -306,3 +306,69 @@ import { flare } from './flare';
 - Omitting the `flare` option/prop on the `/inject` entry throws at install / component setup (boot), not silently at error time.
 
 Reports from the renderer carry `sdk = @flareapp/electron` and `framework = Vue`. Your Vue component context (`context.custom.vue`, component hierarchy, props) rides along and survives the IPC trip intact.
+
+## Using `@flareapp/svelte` in the renderer
+
+Same model as the React/Vue sections: the API key lives in **main**, reports travel over IPC, and the renderer injects Electron's Flare instance into Svelte instead of letting it reach the `@flareapp/js` singleton.
+
+### Install
+
+```bash
+npm install @flareapp/electron @flareapp/svelte
+```
+
+`@flareapp/js` comes in transitively via `@flareapp/electron` — do **not** import it in the renderer.
+
+Set up main / preload / renderer exactly as in the React section (steps 1-3): `flare.light(key)` in main, `exposeFlare()` in preload, and a renderer `flare.ts` that re-exports `flare` from `@flareapp/electron/renderer`.
+
+### Svelte — inject the instance
+
+Import `FlareErrorBoundary` (and/or `createFlareErrorHandler`) from `@flareapp/svelte/inject`, not the package root, and pass the renderer instance:
+
+```svelte
+<script lang="ts">
+    import { FlareErrorBoundary } from '@flareapp/svelte/inject';
+    import { flare } from './flare';
+</script>
+
+<FlareErrorBoundary {flare}>
+    <App />
+</FlareErrorBoundary>
+```
+
+Or the handler directly (e.g. in a SvelteKit-free Svelte app's error hook):
+
+```ts
+import { createFlareErrorHandler } from '@flareapp/svelte/inject';
+import { flare } from './flare';
+
+const handleError = createFlareErrorHandler({ flare });
+```
+
+### Rules
+
+- **Never `import { flare } from '@flareapp/js'` in the renderer.** Import the Svelte SDK from `@flareapp/svelte/inject`, never the package root. Importing the root prints a console warning that the default was registered while the Electron bridge is present.
+- Omitting the `flare` prop/option on the `/inject` entry throws at handler creation / component setup (boot), not silently at error time.
+
+### Component tracking (optional)
+
+If you use Flare's Svelte component tracking, point the preprocessor at the inject entry so the
+generated per-component imports stay root-free in the renderer:
+
+```js
+// svelte.config.js (renderer build)
+import { withFlareConfig } from '@flareapp/svelte/inject';
+
+export default withFlareConfig(
+    {
+        /* your svelte config */
+    },
+    { importSource: '@flareapp/svelte/inject' },
+);
+```
+
+Without `importSource`, the preprocessor emits `import ... from '@flareapp/svelte'`, which pulls the
+web singleton (and its global side effects) into the renderer. Set it to `@flareapp/svelte/inject`
+for Electron renderer builds.
+
+Reports from the renderer carry `sdk = @flareapp/electron` and `framework = Svelte`. Your Svelte component context (`context.custom.svelte`, component hierarchy) rides along and survives the IPC trip intact.

--- a/packages/electron/package.json
+++ b/packages/electron/package.json
@@ -70,11 +70,13 @@
     },
     "devDependencies": {
         "@flareapp/react": "file:../react",
+        "@flareapp/vue": "file:../vue",
         "electron": "^35.0.0",
         "react": "^19.0.0",
         "tsdown": "^0.20.3",
         "typescript": "^5.7.0",
-        "vitest": "^4.0.18"
+        "vitest": "^4.0.18",
+        "vue": "^3.4.0"
     },
     "publishConfig": {
         "access": "public"

--- a/packages/electron/tests/vueInjection.test.ts
+++ b/packages/electron/tests/vueInjection.test.ts
@@ -1,0 +1,44 @@
+// The REAL published inject entry (built dist). Importing it must not pull the js root.
+// Runs in electron's default `node` env — the vue error path needs no DOM (RendererFlare
+// forwards via globalThis[FLARE_BRIDGE_KEY], not window).
+import { flareVue } from '@flareapp/vue/inject';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { createApp } from 'vue';
+
+import { FLARE_BRIDGE_KEY } from '../src/constants';
+import { RendererFlare } from '../src/renderer/RendererFlare';
+
+describe('@flareapp/vue/inject reports through an injected RendererFlare', () => {
+    let bridgeReport: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        bridgeReport = vi.fn(async () => {});
+        (globalThis as Record<string, unknown>)[FLARE_BRIDGE_KEY] = { report: bridgeReport };
+    });
+
+    afterEach(() => {
+        delete (globalThis as Record<string, unknown>)[FLARE_BRIDGE_KEY];
+    });
+
+    test('forwards a STRING payload carrying Vue context.custom over the bridge', async () => {
+        const flare = new RendererFlare();
+
+        const app = createApp({ render: () => null });
+        app.use(flareVue, { flare });
+
+        // Drive Vue's installed error handler directly.
+        app.config.errorHandler!(new Error('boom'), null, 'render function');
+
+        await flare.flush(1000);
+
+        expect(bridgeReport).toHaveBeenCalledOnce();
+        const payload = bridgeReport.mock.calls[0][0];
+        expect(typeof payload).toBe('string');
+
+        const parsed = JSON.parse(payload);
+        expect(parsed.attributes['telemetry.sdk.name']).toBe('@flareapp/electron');
+        expect(parsed.attributes['flare.framework.name']).toBe('Vue');
+        expect(parsed.attributes['context.custom'].vue).toBeDefined();
+        expect((globalThis as Record<string, unknown>).flare).toBeUndefined();
+    });
+});

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -65,6 +65,7 @@
         "@flareapp/core": "2.4.0"
     },
     "devDependencies": {
+        "@flareapp/electron": "file:../electron",
         "@flareapp/js": "file:../js",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.0.0",

--- a/packages/react/src/FlareErrorBoundary.ts
+++ b/packages/react/src/FlareErrorBoundary.ts
@@ -35,6 +35,11 @@ export class FlareErrorBoundary extends Component<FlareErrorBoundaryProps, Flare
         super(props);
         // Resolve ONCE at construction (boot), not per error. Throws here if no
         // instance and no registered default — a wiring bug fails fast.
+        //
+        // Contract: resolved per BOUNDARY INSTANCE and cached for its lifetime. Changing the
+        // `flare` prop on an already-mounted boundary has NO effect — the instance resolved at
+        // construction keeps being used. `flare` is expected to be a stable singleton (the web
+        // default or one RendererFlare), not a value that varies across renders.
         this.flare = resolveFlare(props.flare);
         tagReactFramework(this.flare);
     }

--- a/packages/react/tests/FlareErrorBoundary.test.tsx
+++ b/packages/react/tests/FlareErrorBoundary.test.tsx
@@ -522,6 +522,31 @@ describe('FlareErrorBoundary', () => {
         expect(mockReport).toHaveBeenCalledOnce();
     });
 
+    test('resolves the flare prop ONCE at construction; a later prop change is ignored', () => {
+        // Documents the resolve-once contract: the instance is resolved at construction and cached
+        // for the boundary's lifetime, so swapping the `flare` prop on a mounted boundary has no
+        // effect. (`flare` is meant to be a stable singleton, not a per-render value.)
+        const first = { reportSilently: vi.fn(), setFramework: vi.fn(), setSdkInfo: vi.fn() } as any;
+        const second = { reportSilently: vi.fn(), setFramework: vi.fn(), setSdkInfo: vi.fn() } as any;
+        testError = new Error('boom');
+
+        const { rerender } = render(
+            <FlareErrorBoundary flare={first} fallback={<div>fallback</div>}>
+                <ThrowingComponent shouldThrow={false} />
+            </FlareErrorBoundary>,
+        );
+
+        // Same boundary instance: swap the prop, then trigger the throw.
+        rerender(
+            <FlareErrorBoundary flare={second} fallback={<div>fallback</div>}>
+                <ThrowingComponent shouldThrow={true} />
+            </FlareErrorBoundary>,
+        );
+
+        expect(first.reportSilently).toHaveBeenCalledOnce();
+        expect(second.reportSilently).not.toHaveBeenCalled();
+    });
+
     describe('minified React errors', () => {
         test('forwards minifiedError and version in the reported attributes', () => {
             testError = new Error(

--- a/packages/react/tests/electronBoundaryInjection.test.tsx
+++ b/packages/react/tests/electronBoundaryInjection.test.tsx
@@ -1,0 +1,48 @@
+import { FLARE_BRIDGE_KEY, RendererFlare } from '@flareapp/electron/renderer';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+// The REAL inject entry boundary + a real Electron RendererFlare. Drives the full path:
+// boundary resolves the injected instance -> reportSilently -> RendererFlare.sendReport -> bridge.
+// (The existing electron cross-package test covers the flareReactErrorHandler path; this closes
+// the gap for the FlareErrorBoundary component end-to-end through the bridge.)
+import { FlareErrorBoundary } from '../src/inject';
+
+function ThrowingComponent(): React.ReactElement {
+    throw new Error('boom from boundary');
+}
+
+describe('@flareapp/react/inject FlareErrorBoundary through the RendererFlare bridge', () => {
+    let bridgeReport: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        bridgeReport = vi.fn(async () => {});
+        (globalThis as Record<string, unknown>)[FLARE_BRIDGE_KEY] = { report: bridgeReport };
+    });
+
+    afterEach(() => {
+        delete (globalThis as Record<string, unknown>)[FLARE_BRIDGE_KEY];
+    });
+
+    test('forwards a STRING payload carrying React context.custom over the bridge', async () => {
+        const flare = new RendererFlare();
+
+        render(
+            <FlareErrorBoundary flare={flare} fallback={<div>fallback</div>}>
+                <ThrowingComponent />
+            </FlareErrorBoundary>,
+        );
+
+        await flare.flush(1000);
+
+        expect(bridgeReport).toHaveBeenCalledOnce();
+        const payload = bridgeReport.mock.calls[0][0];
+        expect(typeof payload).toBe('string');
+
+        const parsed = JSON.parse(payload);
+        expect(parsed.attributes['telemetry.sdk.name']).toBe('@flareapp/electron');
+        expect(parsed.attributes['flare.framework.name']).toBe('React');
+        expect(parsed.attributes['context.custom'].react).toBeDefined();
+    });
+});

--- a/packages/svelte/package.json
+++ b/packages/svelte/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@flareapp/svelte",
-    "version": "2.4.0",
+    "version": "2.5.0",
     "description": "Svelte client for flareapp.io",
     "homepage": "https://flareapp.io",
     "bugs": "https://github.com/spatie/flare-client-js/issues",
@@ -42,17 +42,30 @@
                 "types": "./dist/config.d.ts",
                 "default": "./dist/config.js"
             }
+        },
+        "./inject": {
+            "svelte": "./dist/inject.js",
+            "import": {
+                "types": "./dist/inject.d.ts",
+                "default": "./dist/inject.js"
+            }
         }
     },
+    "sideEffects": [
+        "./dist/index.js"
+    ],
     "scripts": {
         "prepublishOnly": "npm run build",
         "generate:version": "node ../../scripts/generate-version.mjs .",
         "build": "npm run generate:version && svelte-package -i src -o dist",
         "test": "vitest run",
+        "verify:exports": "node scripts/verify-exports.mjs",
+        "verify:inject": "node scripts/verify-inject-no-root.mjs",
         "typescript": "tsc --noEmit",
         "release": "release-it"
     },
     "devDependencies": {
+        "@flareapp/electron": "file:../electron",
         "@flareapp/js": "file:../js",
         "@sveltejs/package": "^2.5.7",
         "@sveltejs/vite-plugin-svelte": "^5.0.0",
@@ -70,6 +83,7 @@
         "access": "public"
     },
     "dependencies": {
+        "@flareapp/core": "2.4.0",
         "error-stack-parser": "^2.1.4"
     }
 }

--- a/packages/svelte/scripts/verify-exports.mjs
+++ b/packages/svelte/scripts/verify-exports.mjs
@@ -1,0 +1,78 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const pkgDir = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const pkg = JSON.parse(readFileSync(resolve(pkgDir, 'package.json'), 'utf8'));
+
+const inject = pkg.exports?.['./inject'];
+let failed = false;
+const fail = (msg) => {
+    console.error(`[verify-exports] ${msg}`);
+    failed = true;
+};
+
+if (!inject) {
+    fail('package.json exports["./inject"] is missing');
+    process.exit(1);
+}
+
+// Assert the EXACT target for each condition. Existence alone is insufficient — a target of
+// ./dist/index.js (the web root) would exist and re-export the same names, yet pull the root.
+const expectedTargets = {
+    svelte: './dist/inject.js',
+    'import.types': './dist/inject.d.ts',
+    'import.default': './dist/inject.js',
+};
+const actualTargets = {
+    svelte: inject.svelte,
+    'import.types': inject.import?.types,
+    'import.default': inject.import?.default,
+};
+for (const [key, expected] of Object.entries(expectedTargets)) {
+    if (actualTargets[key] !== expected) {
+        fail(`exports["./inject"].${key} = ${actualTargets[key]} (expected ${expected})`);
+    }
+}
+
+// Every leaf path the map references must exist on disk.
+const paths = [];
+(function collect(node) {
+    if (typeof node === 'string') {
+        paths.push(node);
+    } else if (node && typeof node === 'object') {
+        for (const v of Object.values(node)) collect(v);
+    }
+})(inject);
+for (const p of paths) {
+    if (!existsSync(resolve(pkgDir, p))) {
+        fail(`exports["./inject"] points at a missing file: ${p}`);
+    }
+}
+
+// Grep the RUNTIME target the map actually resolves to (not a hardcoded path) for the surface.
+const runtimeTarget = inject.import?.default ?? inject.svelte;
+const entry = runtimeTarget ? resolve(pkgDir, runtimeTarget) : null;
+if (!entry || !existsSync(entry)) {
+    fail(`runtime target ${runtimeTarget} does not exist (build first)`);
+} else {
+    const src = readFileSync(entry, 'utf8');
+    for (const name of [
+        'createFlareErrorHandler',
+        'FlareErrorBoundary',
+        '__flareRegisterComponent',
+        'withFlareConfig',
+        'flarePreprocessor',
+    ]) {
+        if (!new RegExp(`\\b${name}\\b`).test(src)) {
+            fail(`${runtimeTarget} is missing export: ${name}`);
+        }
+    }
+}
+
+if (failed) {
+    process.exit(1);
+}
+console.log(
+    `[verify-exports] OK — exports["./inject"] targets match (${paths.length} paths) and the runtime entry exposes the expected surface.`,
+);

--- a/packages/svelte/scripts/verify-inject-no-root.mjs
+++ b/packages/svelte/scripts/verify-inject-no-root.mjs
@@ -1,0 +1,46 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const distDir = resolve(dirname(fileURLToPath(import.meta.url)), '../dist');
+const rootSpecifier = /["']@flareapp\/js["']/;
+const relativeSpecifier = /(?:from\s*|require\(\s*)["'](\.\.?\/[^"']+)["']/g;
+
+// svelte-package emits per-file .js (ESM). The inject entry re-exports from sibling files;
+// follow the relative import graph transitively so a root import in any reachable file is caught.
+const entries = ['inject.js'];
+const scanned = new Set();
+let failed = false;
+
+function scan(absPath) {
+    if (scanned.has(absPath)) {
+        return;
+    }
+    scanned.add(absPath);
+    let src;
+    try {
+        src = readFileSync(absPath, 'utf8');
+    } catch {
+        return; // .svelte sources or paths that resolved oddly — skip silently
+    }
+    if (rootSpecifier.test(src)) {
+        console.error(
+            `[verify-inject-no-root] ${absPath} references the @flareapp/js root. The inject entry must not pull the root.`,
+        );
+        failed = true;
+    }
+    for (const match of src.matchAll(relativeSpecifier)) {
+        scan(resolve(dirname(absPath), match[1]));
+    }
+}
+
+for (const entry of entries) {
+    scan(resolve(distDir, entry));
+}
+
+if (failed) {
+    process.exit(1);
+}
+console.log(
+    `[verify-inject-no-root] OK — inject graph (${scanned.size} files) has no @flareapp/js root reference.`,
+);

--- a/packages/svelte/src/FlareErrorBoundary.svelte
+++ b/packages/svelte/src/FlareErrorBoundary.svelte
@@ -8,6 +8,7 @@
         children: Snippet;
         failed?: Snippet<[error: Error, reset: () => void]>;
         resetKeys?: unknown[];
+        flare?: FlareErrorHandlerOptions['flare'];
         beforeEvaluate?: FlareErrorHandlerOptions['beforeEvaluate'];
         beforeSubmit?: FlareErrorHandlerOptions['beforeSubmit'];
         afterSubmit?: FlareErrorHandlerOptions['afterSubmit'];
@@ -18,6 +19,7 @@
         children,
         failed: fallbackSnippet,
         resetKeys,
+        flare,
         beforeEvaluate,
         beforeSubmit,
         afterSubmit,
@@ -55,7 +57,7 @@
     const ancestor = __flareRegisterComponent('FlareErrorBoundary', '@flareapp/svelte/FlareErrorBoundary.svelte');
 
     const handler = $derived(
-        createFlareErrorHandler({ ancestor, beforeEvaluate, beforeSubmit, afterSubmit }),
+        createFlareErrorHandler({ ancestor, flare, beforeEvaluate, beforeSubmit, afterSubmit }),
     );
 
     function onerror(rawError: unknown, reset: () => void) {

--- a/packages/svelte/src/config.ts
+++ b/packages/svelte/src/config.ts
@@ -15,10 +15,11 @@ interface FlarePreprocessorGroupWithId extends PreprocessorGroup {
 export interface WithFlareConfigOptions {
     componentTracking?: boolean;
     exclude?: FlarePreprocessorOptions['exclude'];
+    importSource?: string;
 }
 
 export function withFlareConfig(config: SvelteConfig, options?: WithFlareConfigOptions): SvelteConfig {
-    const { componentTracking = true, exclude } = options ?? {};
+    const { componentTracking = true, exclude, importSource } = options ?? {};
 
     if (!componentTracking) {
         return config;
@@ -30,7 +31,7 @@ export function withFlareConfig(config: SvelteConfig, options?: WithFlareConfigO
         return config;
     }
 
-    const preprocessor = flarePreprocessor({ exclude }) as FlarePreprocessorGroupWithId;
+    const preprocessor = flarePreprocessor({ exclude, importSource }) as FlarePreprocessorGroupWithId;
     preprocessor.__flareId = true;
 
     return {

--- a/packages/svelte/src/contextToAttributes.ts
+++ b/packages/svelte/src/contextToAttributes.ts
@@ -1,4 +1,4 @@
-import type { AttributeValue, Attributes } from '@flareapp/js';
+import type { AttributeValue, Attributes } from '@flareapp/core';
 
 import type { FlareSvelteContext } from './types.js';
 

--- a/packages/svelte/src/createFlareErrorHandler.ts
+++ b/packages/svelte/src/createFlareErrorHandler.ts
@@ -1,16 +1,17 @@
-import { convertToError, flare } from '@flareapp/js';
+import { convertToError } from '@flareapp/core';
+import type { Flare } from '@flareapp/js/browser';
 import ErrorStackParser from 'error-stack-parser';
 
 import type { ComponentTreeNode } from './componentTree.js';
 import { contextToAttributes } from './contextToAttributes.js';
 import { extractComponentInfo } from './extractComponentInfo.js';
 import { getErrorOrigin } from './getErrorOrigin.js';
-import { registerSvelteSdkIdentity } from './identify.js';
+import { tagSvelteFramework } from './identify.js';
+import { resolveFlare } from './resolveFlare.js';
 import type { FlareSvelteContext } from './types.js';
 
-registerSvelteSdkIdentity();
-
 export interface FlareErrorHandlerOptions {
+    flare?: Flare;
     ancestor?: ComponentTreeNode | null;
     beforeEvaluate?: (params: { error: Error }) => void;
     beforeSubmit?: (params: { error: Error; context: FlareSvelteContext }) => FlareSvelteContext;
@@ -18,6 +19,9 @@ export interface FlareErrorHandlerOptions {
 }
 
 export function createFlareErrorHandler(options?: FlareErrorHandlerOptions) {
+    const flare = resolveFlare(options?.flare);
+    tagSvelteFramework(flare);
+
     return async (rawError: unknown, _reset: () => void) => {
         const error = convertToError(rawError);
 

--- a/packages/svelte/src/identify.ts
+++ b/packages/svelte/src/identify.ts
@@ -1,13 +1,27 @@
-import { flare } from '@flareapp/js';
+import type { Flare } from '@flareapp/js/browser';
 
 import { PACKAGE_VERSION } from './version.js';
 
-let registered = false;
+// Per-instance guards. A boolean cannot serve injection: with a singleton AND an
+// injected RendererFlare, each instance must be tagged independently.
+const sdkTagged = new WeakSet<object>();
+const frameworkTagged = new WeakSet<object>();
 
-export function registerSvelteSdkIdentity(): void {
-    if (registered) return;
-    registered = true;
+// Web path: full identity on the default singleton (sdk + framework). Svelte's framework has no version.
+export function registerSvelteSdkIdentity(flare: Flare): void {
+    if (!sdkTagged.has(flare)) {
+        sdkTagged.add(flare);
+        flare.setSdkInfo({ name: '@flareapp/svelte', version: PACKAGE_VERSION });
+    }
+    tagSvelteFramework(flare);
+}
 
-    flare.setSdkInfo({ name: '@flareapp/svelte', version: PACKAGE_VERSION });
+// Injected path: framework tag ONLY. Never touch sdkInfo — that would clobber the
+// injected instance's own SDK name (e.g. @flareapp/electron).
+export function tagSvelteFramework(flare: Flare): void {
+    if (frameworkTagged.has(flare)) {
+        return;
+    }
+    frameworkTagged.add(flare);
     flare.setFramework({ name: 'Svelte' });
 }

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -1,6 +1,15 @@
-import { registerSvelteSdkIdentity } from './identify.js';
+import { flare } from '@flareapp/js';
 
-registerSvelteSdkIdentity();
+import { registerSvelteSdkIdentity } from './identify.js';
+import { registerDefaultFlare } from './resolveFlare.js';
+
+// Web entry. Importing @flareapp/js runs the root's own side effects (window.flare + global
+// catch) — correct for the web. Register the singleton as the default Flare AND set its SDK
+// identity AT IMPORT. The import-time identity registration is a hard contract: @flareapp/sveltekit
+// does `export * from '@flareapp/svelte'` and overrides the SDK name per-report, relying on this
+// running first (spec Decision 6). Do not defer it.
+registerDefaultFlare(() => flare);
+registerSvelteSdkIdentity(flare);
 
 export { default as FlareErrorBoundary } from './FlareErrorBoundary.svelte';
 

--- a/packages/svelte/src/inject.ts
+++ b/packages/svelte/src/inject.ts
@@ -1,0 +1,14 @@
+// Electron-safe entry. NO @flareapp/js root import, NO default registration, NO import-time
+// identity. The caller MUST pass `flare` (handler option / boundary prop); resolveFlare throws
+// at wiring time if absent.
+export { default as FlareErrorBoundary } from './FlareErrorBoundary.svelte';
+
+export { createFlareErrorHandler, type FlareErrorHandlerOptions } from './createFlareErrorHandler.js';
+
+export { __flareRegisterComponent, getComponentTreeContext } from './componentTree.js';
+
+export { withFlareConfig, type WithFlareConfigOptions } from './config.js';
+
+export { flarePreprocessor, type FlarePreprocessorOptions } from './preprocessor.js';
+
+export type { FlareSvelteContext, SvelteErrorOrigin } from './types.js';

--- a/packages/svelte/src/preprocessor.ts
+++ b/packages/svelte/src/preprocessor.ts
@@ -2,10 +2,12 @@ import type { PreprocessorGroup } from 'svelte/compiler';
 
 export interface FlarePreprocessorOptions {
     exclude?: RegExp;
+    importSource?: string;
 }
 
 export function flarePreprocessor(options?: FlarePreprocessorOptions): PreprocessorGroup {
     const exclude = options?.exclude;
+    const importSource = options?.importSource ?? '@flareapp/svelte';
 
     return {
         name: 'flare-component-tree',
@@ -30,7 +32,7 @@ export function flarePreprocessor(options?: FlarePreprocessorOptions): Preproces
 
             const injection =
                 `<script>\n` +
-                `import { __flareRegisterComponent as __flare_reg__ } from '@flareapp/svelte';\n` +
+                `import { __flareRegisterComponent as __flare_reg__ } from '${importSource}';\n` +
                 `const __flare_node__ = __flare_reg__('${componentName}', '${escapedFile}');\n` +
                 `</script>\n`;
 
@@ -52,11 +54,20 @@ export function flarePreprocessor(options?: FlarePreprocessorOptions): Preproces
                 return;
             }
 
+            // Skip a script the markup hook already injected. For a scriptless component the markup
+            // hook adds a `<script>` with our registration; Svelte then runs THIS script hook over
+            // that injected block within the same preprocessor pass. Without this guard we inject a
+            // second time, producing a duplicate `const __flare_node__` -> "already been declared"
+            // compile error.
+            if (content.includes('__flare_node__')) {
+                return;
+            }
+
             const componentName = extractComponentName(filename);
             const escapedFile = escapeString(filename);
 
             const injection =
-                `import { __flareRegisterComponent as __flare_reg__ } from '@flareapp/svelte';\n` +
+                `import { __flareRegisterComponent as __flare_reg__ } from '${importSource}';\n` +
                 `const __flare_node__ = __flare_reg__('${componentName}', '${escapedFile}');\n`;
 
             return {

--- a/packages/svelte/src/resolveFlare.ts
+++ b/packages/svelte/src/resolveFlare.ts
@@ -14,18 +14,17 @@ function isDevMode(): boolean {
     }
 }
 
-// Called once by the web entry (index.ts) as an import side effect. Registers the
-// js-root singleton as the fallback used when no instance is injected.
+// Called once by the web entry (index.ts) as an import side effect.
 export function registerDefaultFlare(provider: () => Flare): void {
-    // Tripwire: registering a web default while the Electron bridge exists means a renderer
-    // pulled the package root (e.g. importing @flareapp/react instead of @flareapp/react/inject,
-    // or component-tracking codegen emitting the root specifier). That drags the keyed @flareapp/js
-    // singleton and its global side effects into the renderer.
+    // Tripwire: a web default registering while the Electron bridge exists means a renderer pulled
+    // the package root — directly, or via component-tracking codegen emitting the root specifier
+    // (set the preprocessor's importSource to '@flareapp/svelte/inject' to avoid that). It drags
+    // the keyed @flareapp/js singleton and its global side effects into the renderer.
     if (typeof window !== 'undefined' && (window as unknown as Record<string, unknown>).__flare) {
         const message =
-            '[flare] @flareapp/react (web root) was imported in a renderer where the Electron ' +
+            '[flare] @flareapp/svelte (web root) was imported in a renderer where the Electron ' +
             'bridge is present, pulling the keyed @flareapp/js singleton into the renderer. ' +
-            'Import @flareapp/react/inject and pass the @flareapp/electron/renderer instance instead.';
+            "Import @flareapp/svelte/inject (and set the preprocessor importSource to '@flareapp/svelte/inject') instead.";
         // Dev: throw so the misconfiguration is impossible to miss. Production: warn instead, so a
         // shipped app isn't crashed by a (recoverable) reporting-setup mistake.
         if (isDevMode()) {
@@ -36,8 +35,7 @@ export function registerDefaultFlare(provider: () => Flare): void {
     defaultProvider = provider;
 }
 
-// Resolve at WIRING time (boundary construct / handler creation), never inside a
-// report path. Throws here so a missing instance fails fast at boot.
+// Resolve at WIRING time (handler creation / component setup), never inside a report path.
 export function resolveFlare(explicit?: Flare): Flare {
     if (explicit) {
         return explicit;
@@ -47,7 +45,7 @@ export function resolveFlare(explicit?: Flare): Flare {
     }
     throw new Error(
         '[flare] No Flare instance available. Pass `flare` (e.g. from ' +
-            '@flareapp/electron/renderer), or import @flareapp/react (the package root) ' +
+            '@flareapp/electron/renderer), or import @flareapp/svelte (the package root) ' +
             'to use the @flareapp/js default singleton.',
     );
 }

--- a/packages/svelte/tests/FlareErrorBoundary.test.ts
+++ b/packages/svelte/tests/FlareErrorBoundary.test.ts
@@ -1,7 +1,9 @@
+import { flare as mockedRoot } from '@flareapp/js';
 import { cleanup, render } from '@testing-library/svelte';
 import { tick } from 'svelte';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
+import { registerDefaultFlare } from '../src/resolveFlare.js';
 import type { FlareSvelteContext } from '../src/types';
 import BoundaryWithBuggyChild from './fixtures/BoundaryWithBuggyChild.svelte';
 import BoundaryWithChildren from './fixtures/BoundaryWithChildren.svelte';
@@ -22,6 +24,8 @@ vi.mock('@flareapp/js', async (importOriginal) => {
         },
     };
 });
+
+registerDefaultFlare(() => mockedRoot as any);
 
 afterEach(() => {
     cleanup();
@@ -176,5 +180,19 @@ describe('FlareErrorBoundary', () => {
         await tick();
         expect(onReset).not.toHaveBeenCalled();
         expect(getByText('Child rendered successfully')).toBeTruthy();
+    });
+
+    test('forwards an injected flare prop into the handler (reports through injected, not default)', async () => {
+        const injected = { reportSilently: vi.fn(), setSdkInfo: vi.fn(), setFramework: vi.fn() } as any;
+        render(BoundaryWithBuggyChild, { props: { flare: injected } });
+        await new Promise((r) => setTimeout(r, 0));
+        expect(injected.reportSilently).toHaveBeenCalledOnce();
+        expect(mockReport).not.toHaveBeenCalled();
+    });
+
+    test('falls back to the registered default when no flare prop', async () => {
+        render(BoundaryWithBuggyChild);
+        await new Promise((r) => setTimeout(r, 0));
+        expect(mockReport).toHaveBeenCalledOnce();
     });
 });

--- a/packages/svelte/tests/createFlareErrorHandler.test.ts
+++ b/packages/svelte/tests/createFlareErrorHandler.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 import { createFlareErrorHandler } from '../src/createFlareErrorHandler';
+import * as resolveModule from '../src/resolveFlare.js';
+import { registerDefaultFlare } from '../src/resolveFlare.js';
 import type { FlareSvelteContext } from '../src/types';
 
 const mockReport = vi.fn();
@@ -15,6 +17,9 @@ vi.mock('@flareapp/js', () => ({
         addContext: vi.fn(),
     },
 }));
+
+import { flare as mockedRoot } from '@flareapp/js';
+registerDefaultFlare(() => mockedRoot as any);
 
 beforeEach(() => {
     mockReport.mockClear();
@@ -146,5 +151,30 @@ describe('createFlareErrorHandler', () => {
         await handler(new Error('test'), () => {});
 
         await new Promise((r) => setTimeout(r, 0));
+    });
+
+    test('reports through an injected flare instance, not the default', async () => {
+        const injected = { reportSilently: vi.fn(), setSdkInfo: vi.fn(), setFramework: vi.fn() } as any;
+        const handler = createFlareErrorHandler({ flare: injected });
+        await handler(new Error('boom'), () => {});
+        expect(injected.reportSilently).toHaveBeenCalledOnce();
+        expect(mockReport).not.toHaveBeenCalled();
+    });
+
+    test('injected instance tagged framework-only, never sdkInfo', () => {
+        const injected = { reportSilently: vi.fn(), setSdkInfo: vi.fn(), setFramework: vi.fn() } as any;
+        createFlareErrorHandler({ flare: injected });
+        expect(injected.setFramework).toHaveBeenCalledWith({ name: 'Svelte' });
+        expect(injected.setSdkInfo).not.toHaveBeenCalled();
+    });
+
+    test('resolves the instance once at creation, not per call', async () => {
+        const injected = { reportSilently: vi.fn(), setSdkInfo: vi.fn(), setFramework: vi.fn() } as any;
+        const resolveSpy = vi.spyOn(resolveModule, 'resolveFlare');
+        const handler = createFlareErrorHandler({ flare: injected });
+        await handler(new Error('a'), () => {});
+        await handler(new Error('b'), () => {});
+        expect(resolveSpy).toHaveBeenCalledTimes(1); // resolved at creation, NOT per call
+        resolveSpy.mockRestore();
     });
 });

--- a/packages/svelte/tests/electronInjection.test.ts
+++ b/packages/svelte/tests/electronInjection.test.ts
@@ -1,0 +1,38 @@
+import { FLARE_BRIDGE_KEY, RendererFlare } from '@flareapp/electron/renderer';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+// The REAL inject entry. Importing it must not pull the js root.
+import { createFlareErrorHandler } from '../src/inject.js';
+
+describe('@flareapp/svelte/inject reports through an injected RendererFlare', () => {
+    let bridgeReport: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        bridgeReport = vi.fn(async () => {});
+        (globalThis as Record<string, unknown>)[FLARE_BRIDGE_KEY] = { report: bridgeReport };
+    });
+
+    afterEach(() => {
+        delete (globalThis as Record<string, unknown>)[FLARE_BRIDGE_KEY];
+    });
+
+    test('forwards a STRING payload carrying Svelte context.custom over the bridge', async () => {
+        const flare = new RendererFlare();
+        const handler = createFlareErrorHandler({ flare });
+
+        await handler(new Error('boom'), () => {});
+        await flare.flush(1000);
+
+        expect(bridgeReport).toHaveBeenCalledOnce();
+        const payload = bridgeReport.mock.calls[0][0];
+        expect(typeof payload).toBe('string');
+
+        const parsed = JSON.parse(payload);
+        expect(parsed.attributes['telemetry.sdk.name']).toBe('@flareapp/electron');
+        expect(parsed.attributes['flare.framework.name']).toBe('Svelte');
+        expect(parsed.attributes['context.custom'].svelte).toBeDefined();
+        // NOTE: do NOT assert window.flare/globalThis.flare is undefined — importing
+        // @flareapp/electron/renderer legitimately sets window.flare (renderer.ts side effect).
+        // No-root is covered by Task 9 (dist-grep) + Task 7 (runtime mock-factory check).
+    });
+});

--- a/packages/svelte/tests/fixtures/BoundaryWithBuggyChild.svelte
+++ b/packages/svelte/tests/fixtures/BoundaryWithBuggyChild.svelte
@@ -4,6 +4,7 @@
 
     interface Props {
         shouldThrow?: boolean;
+        flare?: import('../../src/createFlareErrorHandler').FlareErrorHandlerOptions['flare'];
         beforeEvaluate?: (params: { error: Error }) => void;
         beforeSubmit?: (params: { error: Error; context: FlareSvelteContext }) => FlareSvelteContext;
         afterSubmit?: (params: { error: Error; context: FlareSvelteContext }) => void;
@@ -13,6 +14,7 @@
 
     let {
         shouldThrow = true,
+        flare,
         beforeEvaluate,
         beforeSubmit,
         afterSubmit,
@@ -22,6 +24,7 @@
 </script>
 
 <FlareErrorBoundary
+    {flare}
     {beforeEvaluate}
     {beforeSubmit}
     {afterSubmit}

--- a/packages/svelte/tests/identify.test.ts
+++ b/packages/svelte/tests/identify.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+function fakeFlare() {
+    return { setSdkInfo: vi.fn(), setFramework: vi.fn() } as any;
+}
+
+describe('svelte identity', () => {
+    beforeEach(() => {
+        vi.resetModules();
+    });
+
+    test('registerSvelteSdkIdentity sets sdkInfo (@flareapp/svelte) and framework (Svelte)', async () => {
+        const { registerSvelteSdkIdentity } = await import('../src/identify.js');
+        const flare = fakeFlare();
+        registerSvelteSdkIdentity(flare);
+        expect(flare.setSdkInfo).toHaveBeenCalledWith(expect.objectContaining({ name: '@flareapp/svelte' }));
+        expect(flare.setFramework).toHaveBeenCalledWith({ name: 'Svelte' });
+    });
+
+    test('tagSvelteFramework sets framework only, never sdkInfo', async () => {
+        const { tagSvelteFramework } = await import('../src/identify.js');
+        const flare = fakeFlare();
+        tagSvelteFramework(flare);
+        expect(flare.setFramework).toHaveBeenCalledWith({ name: 'Svelte' });
+        expect(flare.setSdkInfo).not.toHaveBeenCalled();
+    });
+
+    test('each guard is per-instance: same instance tagged once, distinct instances each tagged', async () => {
+        const { tagSvelteFramework } = await import('../src/identify.js');
+        const a = fakeFlare();
+        const b = fakeFlare();
+        tagSvelteFramework(a);
+        tagSvelteFramework(a);
+        tagSvelteFramework(b);
+        expect(a.setFramework).toHaveBeenCalledOnce();
+        expect(b.setFramework).toHaveBeenCalledOnce();
+    });
+});

--- a/packages/svelte/tests/injectEntry.test.ts
+++ b/packages/svelte/tests/injectEntry.test.ts
@@ -1,0 +1,29 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+describe('@flareapp/svelte/inject entry', () => {
+    beforeEach(() => {
+        vi.resetModules();
+        delete (window as any).flare;
+    });
+
+    test('importing the inject entry does NOT evaluate @flareapp/js root', async () => {
+        const rootFactory = vi.fn(() => ({ flare: {} }));
+        vi.doMock('@flareapp/js', rootFactory);
+
+        await import('../src/inject.js');
+
+        expect(rootFactory).not.toHaveBeenCalled();
+        expect((window as any).flare).toBeUndefined();
+    });
+
+    test('exports createFlareErrorHandler and FlareErrorBoundary', async () => {
+        const mod = await import('../src/inject.js');
+        expect(typeof mod.createFlareErrorHandler).toBe('function');
+        expect(mod.FlareErrorBoundary).toBeDefined();
+    });
+
+    test('createFlareErrorHandler from inject throws when no flare option and no default', async () => {
+        const { createFlareErrorHandler } = await import('../src/inject.js');
+        expect(() => createFlareErrorHandler()).toThrow(/No Flare instance available/);
+    });
+});

--- a/packages/svelte/tests/preprocessor.test.ts
+++ b/packages/svelte/tests/preprocessor.test.ts
@@ -1,0 +1,109 @@
+import { compile, preprocess } from 'svelte/compiler';
+import { describe, expect, test } from 'vitest';
+
+import { withFlareConfig } from '../src/config.js';
+import { flarePreprocessor } from '../src/preprocessor.js';
+
+const FAKE_FILE = '/app/src/Button.svelte';
+const SCRIPT_ATTRS = { lang: undefined };
+
+// Helper: run the script hook (component with <script>)
+function runScriptHook(pp: ReturnType<typeof flarePreprocessor>, filename = FAKE_FILE) {
+    const result = (pp as any).script({ content: 'console.log("hi");', filename, attributes: SCRIPT_ATTRS });
+    return result;
+}
+
+// Helper: run the markup hook (no <script> tag — scriptless component)
+function runMarkupHook(pp: ReturnType<typeof flarePreprocessor>, filename = FAKE_FILE) {
+    const result = (pp as any).markup({ content: '<p>hello</p>', filename });
+    return result;
+}
+
+describe('flarePreprocessor — importSource option', () => {
+    describe('script branch (component with <script>)', () => {
+        test('defaults to importing from @flareapp/svelte (web)', () => {
+            const pp = flarePreprocessor();
+            const out = runScriptHook(pp);
+            expect(out.code).toContain("from '@flareapp/svelte'");
+            expect(out.code).not.toContain("from '@flareapp/svelte/inject'");
+        });
+
+        test('emits the inject specifier when importSource is @flareapp/svelte/inject', () => {
+            const pp = flarePreprocessor({ importSource: '@flareapp/svelte/inject' });
+            const out = runScriptHook(pp);
+            expect(out.code).toContain("from '@flareapp/svelte/inject'");
+            expect(out.code).not.toContain("from '@flareapp/svelte'");
+        });
+    });
+
+    describe('markup branch (scriptless component)', () => {
+        test('defaults to importing from @flareapp/svelte (web)', () => {
+            const pp = flarePreprocessor();
+            const out = runMarkupHook(pp);
+            expect(out.code).toContain("from '@flareapp/svelte'");
+            expect(out.code).not.toContain("from '@flareapp/svelte/inject'");
+        });
+
+        test('emits the inject specifier when importSource is @flareapp/svelte/inject', () => {
+            const pp = flarePreprocessor({ importSource: '@flareapp/svelte/inject' });
+            const out = runMarkupHook(pp);
+            expect(out.code).toContain("from '@flareapp/svelte/inject'");
+            expect(out.code).not.toContain("from '@flareapp/svelte'");
+        });
+    });
+});
+
+describe('withFlareConfig — importSource option', () => {
+    test('threads importSource through to the preprocessor (script branch)', () => {
+        const cfg = withFlareConfig({}, { importSource: '@flareapp/svelte/inject' });
+        const preprocessors = Array.isArray(cfg.preprocess) ? cfg.preprocess : [cfg.preprocess!];
+        const pp = preprocessors[0];
+        const out = (pp as any).script({ content: 'let x = 1;', filename: FAKE_FILE, attributes: SCRIPT_ATTRS });
+        expect(out.code).toContain("from '@flareapp/svelte/inject'");
+    });
+
+    test('threads importSource through to the preprocessor (markup branch)', () => {
+        const cfg = withFlareConfig({}, { importSource: '@flareapp/svelte/inject' });
+        const preprocessors = Array.isArray(cfg.preprocess) ? cfg.preprocess : [cfg.preprocess!];
+        const pp = preprocessors[0];
+        const out = (pp as any).markup({ content: '<p>hello</p>', filename: FAKE_FILE });
+        expect(out.code).toContain("from '@flareapp/svelte/inject'");
+    });
+
+    test('default (no importSource) still emits @flareapp/svelte', () => {
+        const cfg = withFlareConfig({});
+        const preprocessors = Array.isArray(cfg.preprocess) ? cfg.preprocess : [cfg.preprocess!];
+        const pp = preprocessors[0];
+        const out = (pp as any).script({ content: 'let x = 1;', filename: FAKE_FILE, attributes: SCRIPT_ATTRS });
+        expect(out.code).toContain("from '@flareapp/svelte'");
+        expect(out.code).not.toContain("from '@flareapp/svelte/inject'");
+    });
+});
+
+// Run the preprocessor through Svelte's REAL pipeline (markup -> script in one pass), not the hooks
+// in isolation. This is the only way to catch the markup hook injecting a <script> that the script
+// hook then re-processes (double injection -> duplicate `__flare_node__` -> compile error).
+describe('flarePreprocessor — full preprocess() + compile() pipeline', () => {
+    test('a scriptless component injects exactly once and compiles', async () => {
+        const out = await preprocess('<p>hello</p>', flarePreprocessor(), { filename: FAKE_FILE });
+        expect((out.code.match(/__flare_node__/g) || []).length).toBe(1);
+        // Must compile — a duplicate `const __flare_node__` throws "already been declared".
+        expect(() => compile(out.code, { filename: FAKE_FILE })).not.toThrow();
+    });
+
+    test('a component WITH a <script> injects exactly once and compiles', async () => {
+        const out = await preprocess('<script>let x = 1;</script>\n<p>{x}</p>', flarePreprocessor(), {
+            filename: FAKE_FILE,
+        });
+        expect((out.code.match(/__flare_node__/g) || []).length).toBe(1);
+        expect(() => compile(out.code, { filename: FAKE_FILE })).not.toThrow();
+    });
+
+    test('scriptless component honors importSource end-to-end', async () => {
+        const out = await preprocess('<p>hello</p>', flarePreprocessor({ importSource: '@flareapp/svelte/inject' }), {
+            filename: FAKE_FILE,
+        });
+        expect(out.code).toContain("from '@flareapp/svelte/inject'");
+        expect((out.code.match(/__flare_node__/g) || []).length).toBe(1);
+    });
+});

--- a/packages/svelte/tests/resolveFlare.test.ts
+++ b/packages/svelte/tests/resolveFlare.test.ts
@@ -17,27 +17,27 @@ describe('resolveFlare', () => {
     });
 
     test('returns the explicit instance when provided', async () => {
-        const { resolveFlare } = await import('../src/resolveFlare');
+        const { resolveFlare } = await import('../src/resolveFlare.js');
         const explicit = { id: 'explicit' } as any;
         expect(resolveFlare(explicit)).toBe(explicit);
     });
 
     test('returns the registered default when no explicit instance', async () => {
-        const { resolveFlare, registerDefaultFlare } = await import('../src/resolveFlare');
+        const { resolveFlare, registerDefaultFlare } = await import('../src/resolveFlare.js');
         const def = { id: 'default' } as any;
         registerDefaultFlare(() => def);
         expect(resolveFlare()).toBe(def);
     });
 
     test('throws a clear error when no instance and no default', async () => {
-        const { resolveFlare } = await import('../src/resolveFlare');
+        const { resolveFlare } = await import('../src/resolveFlare.js');
         expect(() => resolveFlare()).toThrow(/No Flare instance available/);
     });
 
     test('registerDefaultFlare THROWS in dev when the electron bridge is already present', async () => {
         procEnv.NODE_ENV = 'development';
         (window as any).__flare = { report: () => {} };
-        const { registerDefaultFlare } = await import('../src/resolveFlare');
+        const { registerDefaultFlare } = await import('../src/resolveFlare.js');
         expect(() => registerDefaultFlare(() => ({}) as any)).toThrow(/\/inject/);
     });
 
@@ -45,7 +45,7 @@ describe('resolveFlare', () => {
         procEnv.NODE_ENV = 'production';
         const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
         (window as any).__flare = { report: () => {} };
-        const { registerDefaultFlare } = await import('../src/resolveFlare');
+        const { registerDefaultFlare } = await import('../src/resolveFlare.js');
         expect(() => registerDefaultFlare(() => ({}) as any)).not.toThrow();
         expect(warn).toHaveBeenCalledWith(expect.stringContaining('/inject'));
     });
@@ -53,7 +53,7 @@ describe('resolveFlare', () => {
     test('registerDefaultFlare does NOT throw or warn without the bridge', async () => {
         procEnv.NODE_ENV = 'development';
         const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-        const { registerDefaultFlare } = await import('../src/resolveFlare');
+        const { registerDefaultFlare } = await import('../src/resolveFlare.js');
         expect(() => registerDefaultFlare(() => ({}) as any)).not.toThrow();
         expect(warn).not.toHaveBeenCalled();
     });

--- a/packages/svelte/tests/sveltekitContract.test.ts
+++ b/packages/svelte/tests/sveltekitContract.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+// SvelteKit does `export * from '@flareapp/svelte'` and relies on (a) the web entry registering
+// SDK identity AT IMPORT, and (b) the full export surface remaining intact so the re-export works.
+describe('@flareapp/svelte web entry — SvelteKit contract', () => {
+    beforeEach(() => {
+        vi.resetModules();
+    });
+
+    test('sets SDK identity at import (module-load), the ordering sveltekit overrides', async () => {
+        const setSdkInfo = vi.fn();
+        const singleton = { setSdkInfo, setFramework: vi.fn(), reportSilently: vi.fn() };
+        vi.doMock('@flareapp/js', () => ({ flare: singleton }));
+        await import('../src/index.js');
+        expect(setSdkInfo).toHaveBeenCalledWith(expect.objectContaining({ name: '@flareapp/svelte' }));
+    });
+
+    test('re-export surface still includes everything sveltekit `export *`s', async () => {
+        const singleton = { setSdkInfo: vi.fn(), setFramework: vi.fn(), reportSilently: vi.fn() };
+        vi.doMock('@flareapp/js', () => ({ flare: singleton }));
+        const mod = await import('../src/index.js');
+        for (const name of [
+            'FlareErrorBoundary',
+            'createFlareErrorHandler',
+            '__flareRegisterComponent',
+            'getComponentTreeContext',
+            'withFlareConfig',
+            'flarePreprocessor',
+        ]) {
+            expect(mod, `missing export: ${name}`).toHaveProperty(name);
+        }
+    });
+});

--- a/packages/svelte/tests/webEntry.test.ts
+++ b/packages/svelte/tests/webEntry.test.ts
@@ -1,0 +1,24 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+describe('@flareapp/svelte web entry', () => {
+    beforeEach(() => {
+        vi.resetModules();
+    });
+
+    test('importing the root sets SDK identity at import AND registers the singleton as default', async () => {
+        const setSdkInfo = vi.fn();
+        const setFramework = vi.fn();
+        const singleton = { setSdkInfo, setFramework, reportSilently: vi.fn() };
+        vi.doMock('@flareapp/js', () => ({ flare: singleton }));
+
+        await import('../src/index.js');
+
+        // SvelteKit contract: identity is set at IMPORT (module load), not deferred.
+        expect(setSdkInfo).toHaveBeenCalledWith(expect.objectContaining({ name: '@flareapp/svelte' }));
+        expect(setFramework).toHaveBeenCalledWith({ name: 'Svelte' });
+
+        // default provider registered for no-option usage
+        const { resolveFlare } = await import('../src/resolveFlare.js');
+        expect(resolveFlare()).toBe(singleton);
+    });
+});

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -24,6 +24,10 @@
     "files": [
         "dist"
     ],
+    "sideEffects": [
+        "./dist/index.cjs",
+        "./dist/index.mjs"
+    ],
     "main": "./dist/index.cjs",
     "module": "./dist/index.mjs",
     "types": "./dist/index.d.cts",
@@ -37,14 +41,27 @@
                 "types": "./dist/index.d.cts",
                 "default": "./dist/index.cjs"
             }
+        },
+        "./inject": {
+            "import": {
+                "types": "./dist/inject.d.mts",
+                "default": "./dist/inject.mjs"
+            },
+            "require": {
+                "types": "./dist/inject.d.cts",
+                "default": "./dist/inject.cjs"
+            }
         }
     },
     "scripts": {
         "prepublishOnly": "npm run build",
-        "build": "tsdown src/index.ts --format cjs,esm --dts --env.PACKAGE_VERSION=\"$(node -p \"require('./package.json').version\")\" --clean",
+        "build": "tsdown src/index.ts src/inject.ts --format cjs,esm --dts --env.PACKAGE_VERSION=\"$(node -p \"require('./package.json').version\")\" --clean",
         "typescript": "tsc --noEmit",
         "release": "release-it",
         "test": "vitest run"
+    },
+    "dependencies": {
+        "@flareapp/core": "2.4.0"
     },
     "devDependencies": {
         "@flareapp/js": "file:../js",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -65,6 +65,7 @@
         "@flareapp/core": "2.4.0"
     },
     "devDependencies": {
+        "@flareapp/electron": "file:../electron",
         "@flareapp/js": "file:../js",
         "@vue/test-utils": "^2.4.0",
         "jsdom": "^26.1.0",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@flareapp/vue",
-    "version": "2.4.0",
+    "version": "2.5.0",
     "description": "Vue client for flareapp.io",
     "homepage": "https://flareapp.io",
     "bugs": "https://github.com/spatie/flare-client-js/issues",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -58,7 +58,8 @@
         "build": "tsdown src/index.ts src/inject.ts --format cjs,esm --dts --env.PACKAGE_VERSION=\"$(node -p \"require('./package.json').version\")\" --clean",
         "typescript": "tsc --noEmit",
         "release": "release-it",
-        "test": "vitest run"
+        "test": "vitest run",
+        "verify:inject": "node scripts/verify-inject-no-root.mjs"
     },
     "dependencies": {
         "@flareapp/core": "2.4.0"

--- a/packages/vue/scripts/verify-inject-no-root.mjs
+++ b/packages/vue/scripts/verify-inject-no-root.mjs
@@ -1,0 +1,39 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const distDir = resolve(dirname(fileURLToPath(import.meta.url)), '../dist');
+const rootSpecifier = /["']@flareapp\/js["']/;
+const relativeSpecifier = /(?:from\s*|require\(\s*)["'](\.\.?\/[^"']+)["']/g;
+
+const entries = ['inject.mjs', 'inject.cjs'];
+const scanned = new Set();
+let failed = false;
+
+function scan(absPath) {
+    if (scanned.has(absPath)) {
+        return;
+    }
+    scanned.add(absPath);
+    const src = readFileSync(absPath, 'utf8');
+    if (rootSpecifier.test(src)) {
+        console.error(
+            `[verify-inject-no-root] ${absPath} references the @flareapp/js root. The inject entry must not pull the root.`,
+        );
+        failed = true;
+    }
+    for (const match of src.matchAll(relativeSpecifier)) {
+        scan(resolve(dirname(absPath), match[1]));
+    }
+}
+
+for (const entry of entries) {
+    scan(resolve(distDir, entry));
+}
+
+if (failed) {
+    process.exit(1);
+}
+console.log(
+    `[verify-inject-no-root] OK — inject bundle (${scanned.size} files incl. chunks) has no @flareapp/js root reference.`,
+);

--- a/packages/vue/src/FlareErrorBoundary.ts
+++ b/packages/vue/src/FlareErrorBoundary.ts
@@ -1,4 +1,5 @@
-import { convertToError, flare } from '@flareapp/js';
+import { convertToError } from '@flareapp/core';
+import type { Flare } from '@flareapp/js/browser';
 import type { ComponentPublicInstance, PropType } from 'vue';
 import { defineComponent, getCurrentInstance, onErrorCaptured, ref, watch } from 'vue';
 
@@ -9,6 +10,8 @@ import { vueContextToAttributes } from './flareVue';
 import { getComponentName } from './getComponentName';
 import { getErrorOrigin } from './getErrorOrigin';
 import { getRouteContext } from './getRouteContext';
+import { tagVueFramework } from './identify';
+import { resolveFlare } from './resolveFlare';
 import { serializeProps } from './serializeProps';
 import { ComponentHierarchyFrame, FlareErrorBoundaryHookParams, FlareVueContext } from './types';
 
@@ -16,6 +19,10 @@ export const FlareErrorBoundary = defineComponent({
     name: 'FlareErrorBoundary',
 
     props: {
+        flare: {
+            type: Object as PropType<Flare>,
+            default: undefined,
+        },
         beforeEvaluate: {
             type: Function as PropType<(params: FlareErrorBoundaryHookParams) => void>,
             default: undefined,
@@ -57,6 +64,9 @@ export const FlareErrorBoundary = defineComponent({
     },
 
     setup(props, { slots }) {
+        const flareInstance = resolveFlare(props.flare);
+        tagVueFramework(flareInstance, getCurrentInstance()?.appContext.app.version);
+
         const currentInstance = getCurrentInstance();
         const error = ref<Error | null>(null);
         const componentProps = ref<Record<string, unknown> | undefined>(undefined);
@@ -134,7 +144,7 @@ export const FlareErrorBoundary = defineComponent({
             componentHierarchy.value = finalContext.vue.componentHierarchy;
             componentHierarchyFrames.value = finalContext.vue.componentHierarchyFrames;
 
-            flare.reportSilently(errorToReport, vueContextToAttributes(finalContext));
+            flareInstance.reportSilently(errorToReport, vueContextToAttributes(finalContext));
 
             props.afterSubmit?.({ error: errorToReport, instance, info, context: finalContext });
 

--- a/packages/vue/src/constants.ts
+++ b/packages/vue/src/constants.ts
@@ -1,4 +1,4 @@
-import { resolveDenylist as baseResolveDenylist } from '@flareapp/js';
+import { resolveDenylist as baseResolveDenylist } from '@flareapp/core';
 
 import type { ErrorOrigin } from './types';
 

--- a/packages/vue/src/flareVue.ts
+++ b/packages/vue/src/flareVue.ts
@@ -1,12 +1,14 @@
-import { type AttributeValue, type Attributes, convertToError, flare } from '@flareapp/js';
+import { convertToError, type AttributeValue, type Attributes } from '@flareapp/core';
 import type { App, ComponentPublicInstance, Plugin } from 'vue';
 
 import { buildComponentHierarchy } from './buildComponentHierarchy';
 import { buildComponentHierarchyFrames } from './buildComponentHierarchyFrames';
-import { PACKAGE_VERSION, resolveDenylist } from './constants';
+import { resolveDenylist } from './constants';
 import { getComponentName } from './getComponentName';
 import { getErrorOrigin } from './getErrorOrigin';
 import { getRouteContext } from './getRouteContext';
+import { registerVueSdkInfo, tagVueFramework } from './identify';
+import { resolveFlare } from './resolveFlare';
 import { serializeProps } from './serializeProps';
 import { FlareVueContext, FlareVueOptions, FlareVueWarningContext } from './types';
 
@@ -53,10 +55,20 @@ export const flareVue: Plugin<[FlareVueOptions?]> = (app: App, options?: FlareVu
     if (installedApps.has(app)) {
         return;
     }
+
+    // Resolve BEFORE marking the app installed. resolveFlare can throw (an /inject consumer that
+    // forgot the `flare` option). If we added to installedApps first, a throw would poison the
+    // WeakSet: a corrected retry would hit the `has(app)` guard and silently no-op.
+    const flare = resolveFlare(options?.flare);
+
     installedApps.add(app);
 
-    flare.setSdkInfo({ name: '@flareapp/vue', version: PACKAGE_VERSION });
-    flare.setFramework({ name: 'Vue', version: app.version });
+    // Web default (no injected instance): set the SDK identity on the singleton, as before.
+    // Injected instance: tag framework only — never setSdkInfo (would clobber @flareapp/electron).
+    if (!options?.flare) {
+        registerVueSdkInfo(flare);
+    }
+    tagVueFramework(flare, app.version);
 
     const attachProps = options?.attachProps ?? false;
     const propsMaxDepth = options?.propsMaxDepth ?? 2;

--- a/packages/vue/src/flareVue.ts
+++ b/packages/vue/src/flareVue.ts
@@ -56,9 +56,12 @@ export const flareVue: Plugin<[FlareVueOptions?]> = (app: App, options?: FlareVu
         return;
     }
 
-    // Resolve BEFORE marking the app installed. resolveFlare can throw (an /inject consumer that
-    // forgot the `flare` option). If we added to installedApps first, a throw would poison the
-    // WeakSet: a corrected retry would hit the `has(app)` guard and silently no-op.
+    // Resolve BEFORE marking the app installed, so a throw (an /inject consumer that forgot the
+    // `flare` option) doesn't leave the app recorded in installedApps. NOTE: this only enables a
+    // retry when the plugin is invoked DIRECTLY (`flareVue(app, opts)`). Via the public
+    // `app.use(flareVue)` API a retry is blocked regardless — Vue adds the plugin to its own
+    // installed-set BEFORE calling install, so a failed `app.use` cannot be re-applied to the same
+    // app. The ordering here is still correct/defensive; it just isn't reachable through `app.use`.
     const flare = resolveFlare(options?.flare);
 
     installedApps.add(app);

--- a/packages/vue/src/getRouteContext.ts
+++ b/packages/vue/src/getRouteContext.ts
@@ -1,4 +1,4 @@
-import { redactFullPath } from '@flareapp/js';
+import { redactUrlQuery as redactFullPath } from '@flareapp/core';
 
 import { DEFAULT_PROPS_DENYLIST } from './constants';
 import { serializeProps } from './serializeProps';

--- a/packages/vue/src/identify.ts
+++ b/packages/vue/src/identify.ts
@@ -1,0 +1,28 @@
+import type { Flare } from '@flareapp/js/browser';
+
+import { PACKAGE_VERSION } from './constants';
+
+// Per-instance guards. A boolean cannot serve injection: with a singleton AND an
+// injected RendererFlare, each instance must be tagged independently.
+const sdkTagged = new WeakSet<object>();
+const frameworkTagged = new WeakSet<object>();
+
+// Web path: SDK identity on the default singleton. Split from framework because
+// the framework version (app.version) is only known at install time.
+export function registerVueSdkInfo(flare: Flare): void {
+    if (sdkTagged.has(flare)) {
+        return;
+    }
+    sdkTagged.add(flare);
+    flare.setSdkInfo({ name: '@flareapp/vue', version: PACKAGE_VERSION });
+}
+
+// Both paths tag the framework (web + injected). Never touches sdkInfo — on an
+// injected instance that would clobber the instance's own SDK name (@flareapp/electron).
+export function tagVueFramework(flare: Flare, appVersion: string | undefined): void {
+    if (frameworkTagged.has(flare)) {
+        return;
+    }
+    frameworkTagged.add(flare);
+    flare.setFramework({ name: 'Vue', version: appVersion });
+}

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -1,3 +1,13 @@
+import { flare } from '@flareapp/js';
+
+import { registerDefaultFlare } from './resolveFlare';
+
+// Web entry: the js-root singleton is the default Flare for no-prop/no-option usage.
+// Importing @flareapp/js here also runs the root's own side effects (window.flare + global
+// catch) — correct for the web. Identity is set at install/setup time (needs app.version),
+// not here, preserving existing web behavior.
+registerDefaultFlare(() => flare);
+
 export { FlareErrorBoundary } from './FlareErrorBoundary';
 export { flareVue } from './flareVue';
 export { DEFAULT_PROPS_DENYLIST } from './constants';

--- a/packages/vue/src/inject.ts
+++ b/packages/vue/src/inject.ts
@@ -1,0 +1,17 @@
+// Electron-safe entry. NO @flareapp/js root import, NO default registration. The caller MUST
+// pass `flare` (plugin option / boundary prop); resolveFlare throws at wiring time if absent.
+export { FlareErrorBoundary } from './FlareErrorBoundary';
+export { flareVue } from './flareVue';
+export { DEFAULT_PROPS_DENYLIST } from './constants';
+export type {
+    ComponentHierarchyFrame,
+    ErrorOrigin,
+    FlareErrorBoundaryFallbackProps,
+    FlareErrorBoundaryHookParams,
+    FlareVueContext,
+    FlareVueOptions,
+    FlareVueWarningContext,
+    RouteContext,
+    RouteParamValue,
+    RouteQueryValue,
+} from './types';

--- a/packages/vue/src/resolveFlare.ts
+++ b/packages/vue/src/resolveFlare.ts
@@ -1,15 +1,35 @@
 import type { Flare } from '@flareapp/js/browser';
 
+declare const process: { env: Record<string, string | undefined> };
+
 let defaultProvider: (() => Flare) | null = null;
+
+// `process.env.NODE_ENV` is replaced inline by bundlers (vite/webpack). The try/catch keeps a
+// process-less environment safe: treat "undetermined" as production (warn, never crash).
+function isDevMode(): boolean {
+    try {
+        return process.env.NODE_ENV !== 'production';
+    } catch {
+        return false;
+    }
+}
 
 // Called once by the web entry (index.ts) as an import side effect.
 export function registerDefaultFlare(provider: () => Flare): void {
+    // Tripwire: a web default registering while the Electron bridge exists means a renderer pulled
+    // the package root (e.g. importing @flareapp/vue instead of @flareapp/vue/inject). That drags
+    // the keyed @flareapp/js singleton and its global side effects into the renderer.
     if (typeof window !== 'undefined' && (window as unknown as Record<string, unknown>).__flare) {
-        console.warn(
-            '[flare] @flareapp/js default registered while the electron bridge is present. ' +
-                'In a renderer, import @flareapp/vue/inject and pass the ' +
-                '@flareapp/electron/renderer instance instead.',
-        );
+        const message =
+            '[flare] @flareapp/vue (web root) was imported in a renderer where the Electron ' +
+            'bridge is present, pulling the keyed @flareapp/js singleton into the renderer. ' +
+            'Import @flareapp/vue/inject and pass the @flareapp/electron/renderer instance instead.';
+        // Dev: throw so the misconfiguration is impossible to miss. Production: warn instead, so a
+        // shipped app isn't crashed by a (recoverable) reporting-setup mistake.
+        if (isDevMode()) {
+            throw new Error(message);
+        }
+        console.warn(message);
     }
     defaultProvider = provider;
 }

--- a/packages/vue/src/resolveFlare.ts
+++ b/packages/vue/src/resolveFlare.ts
@@ -1,0 +1,30 @@
+import type { Flare } from '@flareapp/js/browser';
+
+let defaultProvider: (() => Flare) | null = null;
+
+// Called once by the web entry (index.ts) as an import side effect.
+export function registerDefaultFlare(provider: () => Flare): void {
+    if (typeof window !== 'undefined' && (window as unknown as Record<string, unknown>).__flare) {
+        console.warn(
+            '[flare] @flareapp/js default registered while the electron bridge is present. ' +
+                'In a renderer, import @flareapp/vue/inject and pass the ' +
+                '@flareapp/electron/renderer instance instead.',
+        );
+    }
+    defaultProvider = provider;
+}
+
+// Resolve at WIRING time (plugin install / component setup), never inside a report path.
+export function resolveFlare(explicit?: Flare): Flare {
+    if (explicit) {
+        return explicit;
+    }
+    if (defaultProvider) {
+        return defaultProvider();
+    }
+    throw new Error(
+        '[flare] No Flare instance available. Pass `flare` (e.g. from ' +
+            '@flareapp/electron/renderer), or import @flareapp/vue (the package root) ' +
+            'to use the @flareapp/js default singleton.',
+    );
+}

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -1,3 +1,4 @@
+import type { Flare } from '@flareapp/js/browser';
 import type { ComponentPublicInstance } from 'vue';
 
 export type ErrorOrigin = 'setup' | 'render' | 'lifecycle' | 'event' | 'watcher' | 'unknown';
@@ -51,6 +52,7 @@ export type FlareErrorBoundaryHookParams = {
 };
 
 export type FlareVueOptions = {
+    flare?: Flare;
     captureWarnings?: boolean;
     attachProps?: boolean;
     propsMaxDepth?: number;

--- a/packages/vue/tests/FlareErrorBoundary.test.ts
+++ b/packages/vue/tests/FlareErrorBoundary.test.ts
@@ -22,6 +22,12 @@ vi.mock('@flareapp/js', async (importOriginal) => {
     };
 });
 
+import { flare as mockedRoot } from '@flareapp/js';
+
+import * as resolveModule from '../src/resolveFlare';
+import { registerDefaultFlare } from '../src/resolveFlare';
+registerDefaultFlare(() => mockedRoot as any);
+
 function getReportedVue(callIndex = 0): FlareVueContext['vue'] {
     const custom = ((mockReport.mock.calls[callIndex] ?? [])[1] as Attributes)['context.custom'] as Record<
         string,
@@ -1247,5 +1253,38 @@ describe('FlareErrorBoundary', () => {
 
             expect(slotProps?.componentProps).toEqual({ userId: 7 });
         });
+    });
+
+    test('reports through an injected flare prop, not the default', async () => {
+        const injected = { reportSilently: vi.fn(), setSdkInfo: vi.fn(), setFramework: vi.fn() } as any;
+        mount(FlareErrorBoundary, {
+            props: { flare: injected },
+            slots: { default: () => h(ThrowingComponent) },
+        });
+        await nextTick();
+        expect(injected.reportSilently).toHaveBeenCalledOnce();
+        expect(mockReport).not.toHaveBeenCalled();
+    });
+
+    test('falls back to the registered default when no flare prop', async () => {
+        mount(FlareErrorBoundary, {
+            slots: { default: () => h(ThrowingComponent) },
+        });
+        await nextTick();
+        expect(mockReport).toHaveBeenCalledOnce();
+    });
+
+    test('resolves at setup (before any error), not at capture time', () => {
+        // Zero errors thrown. If resolution happened in onErrorCaptured it would be 0; proving it
+        // is 1 here proves resolution is at setup/wiring time. A single-error probe could not
+        // distinguish setup-time from capture-time (both yield one call).
+        const injected = { reportSilently: vi.fn(), setSdkInfo: vi.fn(), setFramework: vi.fn() } as any;
+        const resolveSpy = vi.spyOn(resolveModule, 'resolveFlare');
+        mount(FlareErrorBoundary, {
+            props: { flare: injected },
+            slots: { default: () => h('div', 'ok') }, // non-throwing child
+        });
+        expect(resolveSpy).toHaveBeenCalledTimes(1);
+        resolveSpy.mockRestore();
     });
 });

--- a/packages/vue/tests/electronBoundaryInjection.test.ts
+++ b/packages/vue/tests/electronBoundaryInjection.test.ts
@@ -1,0 +1,50 @@
+import { FLARE_BRIDGE_KEY, RendererFlare } from '@flareapp/electron/renderer';
+import { mount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { defineComponent, h } from 'vue';
+
+// The REAL inject entry boundary + a real Electron RendererFlare. Drives the full path:
+// boundary resolves the injected instance at setup -> reportSilently -> RendererFlare.sendReport
+// -> bridge. (The existing electron cross-package test covers the flareVue plugin path; this closes
+// the gap for the FlareErrorBoundary component end-to-end through the bridge.)
+import { FlareErrorBoundary } from '../src/inject';
+
+const ThrowingChild = defineComponent({
+    setup() {
+        throw new Error('boom from boundary');
+    },
+    render: () => null,
+});
+
+describe('@flareapp/vue/inject FlareErrorBoundary through the RendererFlare bridge', () => {
+    let bridgeReport: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        bridgeReport = vi.fn(async () => {});
+        (globalThis as Record<string, unknown>)[FLARE_BRIDGE_KEY] = { report: bridgeReport };
+    });
+
+    afterEach(() => {
+        delete (globalThis as Record<string, unknown>)[FLARE_BRIDGE_KEY];
+    });
+
+    test('forwards a STRING payload carrying Vue context.custom over the bridge', async () => {
+        const flare = new RendererFlare();
+
+        mount(FlareErrorBoundary, {
+            props: { flare: flare as never },
+            slots: { default: () => h(ThrowingChild) },
+        });
+
+        await flare.flush(1000);
+
+        expect(bridgeReport).toHaveBeenCalledOnce();
+        const payload = bridgeReport.mock.calls[0][0];
+        expect(typeof payload).toBe('string');
+
+        const parsed = JSON.parse(payload);
+        expect(parsed.attributes['telemetry.sdk.name']).toBe('@flareapp/electron');
+        expect(parsed.attributes['flare.framework.name']).toBe('Vue');
+        expect(parsed.attributes['context.custom'].vue).toBeDefined();
+    });
+});

--- a/packages/vue/tests/flareVue.test.ts
+++ b/packages/vue/tests/flareVue.test.ts
@@ -857,6 +857,23 @@ describe('flareVue captureWarnings', () => {
         expect(context.vue.info).toBe('Missing required prop');
     });
 
+    test('warnings route through an injected flare instance, not the default', () => {
+        const injected = {
+            reportSilently: vi.fn(),
+            reportMessage: vi.fn(),
+            setSdkInfo: vi.fn(),
+            setFramework: vi.fn(),
+        } as any;
+        const app = createMockApp();
+        (flareVue as Function)(app, { flare: injected, captureWarnings: true } satisfies FlareVueOptions);
+
+        app.config.warnHandler!('Invalid prop type', createMockInstance('Counter'), 'found in\n---> <Counter>');
+
+        expect(injected.reportMessage).toHaveBeenCalledOnce();
+        expect(injected.reportMessage).toHaveBeenCalledWith('Invalid prop type', 'warning', expect.anything());
+        expect(mockReportMessage).not.toHaveBeenCalled();
+    });
+
     test('uses AnonymousComponent when instance is null', () => {
         const app = createMockApp();
         (flareVue as Function)(app, { captureWarnings: true } satisfies FlareVueOptions);

--- a/packages/vue/tests/flareVue.test.ts
+++ b/packages/vue/tests/flareVue.test.ts
@@ -1,6 +1,6 @@
 import type { Attributes } from '@flareapp/js';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
-import type { ComponentPublicInstance } from 'vue';
+import { createApp, type ComponentPublicInstance } from 'vue';
 
 import { flareVue } from '../src/flareVue';
 import type { FlareVueContext, FlareVueOptions, FlareVueWarningContext } from '../src/types';
@@ -22,6 +22,12 @@ vi.mock('@flareapp/js', async (importOriginal) => {
         },
     };
 });
+
+import { flare as mockedRoot } from '@flareapp/js';
+
+import * as resolveModule from '../src/resolveFlare';
+import { registerDefaultFlare } from '../src/resolveFlare';
+registerDefaultFlare(() => mockedRoot as any);
 
 function getReportedVue(callIndex = 0): FlareVueContext['vue'] {
     const custom = ((mockReport.mock.calls[callIndex] ?? [])[1] as Attributes)['context.custom'] as Record<
@@ -744,6 +750,49 @@ describe('flareVue', () => {
             const context = { vue: getReportedVue(0) };
             expect(context.vue.componentProps).toEqual({ ssn: '[redacted]', password: 'now-leaked', id: 1 });
         });
+    });
+
+    test('reports through an injected flare instance, not the default', () => {
+        const injected = {
+            reportSilently: vi.fn(),
+            reportMessage: vi.fn(),
+            setSdkInfo: vi.fn(),
+            setFramework: vi.fn(),
+        } as any;
+        const app = createApp({ render: () => null });
+        app.use(flareVue, { flare: injected });
+        app.config.errorHandler!(new Error('boom'), null, 'render');
+        expect(injected.reportSilently).toHaveBeenCalledOnce();
+        expect(mockReport).not.toHaveBeenCalled();
+    });
+
+    test('injected instance is tagged framework-only, never sdkInfo', () => {
+        const injected = {
+            reportSilently: vi.fn(),
+            reportMessage: vi.fn(),
+            setSdkInfo: vi.fn(),
+            setFramework: vi.fn(),
+        } as any;
+        const app = createApp({ render: () => null });
+        app.use(flareVue, { flare: injected });
+        expect(injected.setFramework).toHaveBeenCalledWith(expect.objectContaining({ name: 'Vue' }));
+        expect(injected.setSdkInfo).not.toHaveBeenCalled();
+    });
+
+    test('resolves the instance once at install, not per reported error', () => {
+        const injected = {
+            reportSilently: vi.fn(),
+            reportMessage: vi.fn(),
+            setSdkInfo: vi.fn(),
+            setFramework: vi.fn(),
+        } as any;
+        const resolveSpy = vi.spyOn(resolveModule, 'resolveFlare');
+        const app = createApp({ render: () => null });
+        app.use(flareVue, { flare: injected });
+        app.config.errorHandler!(new Error('a'), null, 'render');
+        app.config.errorHandler!(new Error('b'), null, 'render');
+        expect(resolveSpy).toHaveBeenCalledTimes(1); // resolved at install, NOT per error
+        resolveSpy.mockRestore();
     });
 });
 

--- a/packages/vue/tests/identify.test.ts
+++ b/packages/vue/tests/identify.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+function fakeFlare() {
+    return { setSdkInfo: vi.fn(), setFramework: vi.fn() } as any;
+}
+
+describe('vue identity', () => {
+    beforeEach(() => {
+        vi.resetModules();
+    });
+
+    test('registerVueSdkInfo sets sdkInfo (@flareapp/vue) only, never framework', async () => {
+        const { registerVueSdkInfo } = await import('../src/identify');
+        const flare = fakeFlare();
+        registerVueSdkInfo(flare);
+        expect(flare.setSdkInfo).toHaveBeenCalledWith(expect.objectContaining({ name: '@flareapp/vue' }));
+        expect(flare.setFramework).not.toHaveBeenCalled();
+    });
+
+    test('tagVueFramework sets framework (Vue + version) only, never sdkInfo', async () => {
+        const { tagVueFramework } = await import('../src/identify');
+        const flare = fakeFlare();
+        tagVueFramework(flare, '3.4.0');
+        expect(flare.setFramework).toHaveBeenCalledWith({ name: 'Vue', version: '3.4.0' });
+        expect(flare.setSdkInfo).not.toHaveBeenCalled();
+    });
+
+    test('each guard is per-instance: same instance tagged once, distinct instances each tagged', async () => {
+        const { tagVueFramework } = await import('../src/identify');
+        const a = fakeFlare();
+        const b = fakeFlare();
+        tagVueFramework(a, '3.4.0');
+        tagVueFramework(a, '3.4.0');
+        tagVueFramework(b, '3.4.0');
+        expect(a.setFramework).toHaveBeenCalledOnce();
+        expect(b.setFramework).toHaveBeenCalledOnce();
+    });
+});

--- a/packages/vue/tests/injectEntry.test.ts
+++ b/packages/vue/tests/injectEntry.test.ts
@@ -1,0 +1,64 @@
+import { mount } from '@vue/test-utils';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { createApp, h } from 'vue';
+
+// NOTE: this file registers NO resolveFlare default (it never imports the web entry). Vitest
+// isolates the module registry per file, so resolveFlare's defaultProvider stays null here —
+// which is exactly what lets the "throws without an instance" assertions hold.
+
+describe('@flareapp/vue/inject entry', () => {
+    beforeEach(() => {
+        vi.resetModules();
+        delete (window as any).flare;
+    });
+
+    test('importing the inject entry does NOT evaluate @flareapp/js root', async () => {
+        const rootFactory = vi.fn(() => ({ flare: {} }));
+        vi.doMock('@flareapp/js', rootFactory);
+
+        await import('../src/inject');
+
+        expect(rootFactory).not.toHaveBeenCalled();
+        expect((window as any).flare).toBeUndefined();
+    });
+
+    test('exports flareVue and FlareErrorBoundary', async () => {
+        const mod = await import('../src/inject');
+        expect(typeof mod.flareVue).toBe('function');
+        expect(mod.FlareErrorBoundary).toBeDefined();
+    });
+
+    test('app.use(flareVue) from inject throws when no flare option and no default', async () => {
+        const { flareVue } = await import('../src/inject');
+        const app = createApp({ render: () => null });
+        expect(() => app.use(flareVue)).toThrow(/No Flare instance available/);
+    });
+
+    test('mounting FlareErrorBoundary from inject throws at setup when no flare prop and no default', async () => {
+        const { FlareErrorBoundary } = await import('../src/inject');
+        expect(() => mount(FlareErrorBoundary, { slots: { default: () => h('div', 'x') } })).toThrow(
+            /No Flare instance available/,
+        );
+    });
+
+    test('a failed install does not poison installedApps: a retry with a valid flare still installs', async () => {
+        const { flareVue } = await import('../src/inject');
+        const app = createApp({ render: () => null });
+
+        // Call the plugin function DIRECTLY (not via app.use) so Vue's own plugin-dedup does not
+        // shadow our installedApps WeakSet. First call has no instance -> resolveFlare throws.
+        expect(() => (flareVue as any)(app, undefined)).toThrow(/No Flare instance available/);
+
+        // Retry with a valid instance MUST install (the failed attempt must not have added the app
+        // to installedApps — that is the resolve-before-add ordering being verified).
+        const injected = {
+            reportSilently: vi.fn(),
+            reportMessage: vi.fn(),
+            setSdkInfo: vi.fn(),
+            setFramework: vi.fn(),
+        } as any;
+        (flareVue as any)(app, { flare: injected });
+        app.config.errorHandler!(new Error('x'), null, 'render');
+        expect(injected.reportSilently).toHaveBeenCalledOnce();
+    });
+});

--- a/packages/vue/tests/injectEntry.test.ts
+++ b/packages/vue/tests/injectEntry.test.ts
@@ -45,12 +45,14 @@ describe('@flareapp/vue/inject entry', () => {
         const { flareVue } = await import('../src/inject');
         const app = createApp({ render: () => null });
 
-        // Call the plugin function DIRECTLY (not via app.use) so Vue's own plugin-dedup does not
-        // shadow our installedApps WeakSet. First call has no instance -> resolveFlare throws.
+        // Call the plugin function DIRECTLY (not via app.use). This verifies OUR installedApps
+        // ordering in isolation. It does NOT reflect the public `app.use` path: Vue adds the plugin
+        // to its own installed-set before invoking install, so a failed `app.use(flareVue)` can't be
+        // retried on the same app regardless of our ordering. First call has no instance -> throws.
         expect(() => (flareVue as any)(app, undefined)).toThrow(/No Flare instance available/);
 
         // Retry with a valid instance MUST install (the failed attempt must not have added the app
-        // to installedApps — that is the resolve-before-add ordering being verified).
+        // to installedApps — the resolve-before-add ordering, verified here via direct invocation).
         const injected = {
             reportSilently: vi.fn(),
             reportMessage: vi.fn(),

--- a/packages/vue/tests/resolveFlare.test.ts
+++ b/packages/vue/tests/resolveFlare.test.ts
@@ -1,10 +1,19 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+// process is ambiently typed without NODE_ENV in this package; cast to a mutable env map.
+const procEnv = (process as unknown as { env: Record<string, string | undefined> }).env;
 
 describe('resolveFlare', () => {
+    const originalNodeEnv = procEnv.NODE_ENV;
+
     beforeEach(() => {
         vi.resetModules();
         delete (window as any).__flare;
         vi.restoreAllMocks();
+    });
+
+    afterEach(() => {
+        procEnv.NODE_ENV = originalNodeEnv;
     });
 
     test('returns the explicit instance when provided', async () => {
@@ -25,18 +34,27 @@ describe('resolveFlare', () => {
         expect(() => resolveFlare()).toThrow(/No Flare instance available/);
     });
 
-    test('registerDefaultFlare warns when the electron bridge is already present', async () => {
+    test('registerDefaultFlare THROWS in dev when the electron bridge is already present', async () => {
+        procEnv.NODE_ENV = 'development';
+        (window as any).__flare = { report: () => {} };
+        const { registerDefaultFlare } = await import('../src/resolveFlare');
+        expect(() => registerDefaultFlare(() => ({}) as any)).toThrow(/\/inject/);
+    });
+
+    test('registerDefaultFlare WARNS (does not throw) in production when the bridge is present', async () => {
+        procEnv.NODE_ENV = 'production';
         const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
         (window as any).__flare = { report: () => {} };
         const { registerDefaultFlare } = await import('../src/resolveFlare');
-        registerDefaultFlare(() => ({}) as any);
+        expect(() => registerDefaultFlare(() => ({}) as any)).not.toThrow();
         expect(warn).toHaveBeenCalledWith(expect.stringContaining('/inject'));
     });
 
-    test('registerDefaultFlare does NOT warn without the bridge', async () => {
+    test('registerDefaultFlare does NOT throw or warn without the bridge', async () => {
+        procEnv.NODE_ENV = 'development';
         const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
         const { registerDefaultFlare } = await import('../src/resolveFlare');
-        registerDefaultFlare(() => ({}) as any);
+        expect(() => registerDefaultFlare(() => ({}) as any)).not.toThrow();
         expect(warn).not.toHaveBeenCalled();
     });
 });

--- a/packages/vue/tests/resolveFlare.test.ts
+++ b/packages/vue/tests/resolveFlare.test.ts
@@ -1,0 +1,42 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+describe('resolveFlare', () => {
+    beforeEach(() => {
+        vi.resetModules();
+        delete (window as any).__flare;
+        vi.restoreAllMocks();
+    });
+
+    test('returns the explicit instance when provided', async () => {
+        const { resolveFlare } = await import('../src/resolveFlare');
+        const explicit = { id: 'explicit' } as any;
+        expect(resolveFlare(explicit)).toBe(explicit);
+    });
+
+    test('returns the registered default when no explicit instance', async () => {
+        const { resolveFlare, registerDefaultFlare } = await import('../src/resolveFlare');
+        const def = { id: 'default' } as any;
+        registerDefaultFlare(() => def);
+        expect(resolveFlare()).toBe(def);
+    });
+
+    test('throws a clear error when no instance and no default', async () => {
+        const { resolveFlare } = await import('../src/resolveFlare');
+        expect(() => resolveFlare()).toThrow(/No Flare instance available/);
+    });
+
+    test('registerDefaultFlare warns when the electron bridge is already present', async () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        (window as any).__flare = { report: () => {} };
+        const { registerDefaultFlare } = await import('../src/resolveFlare');
+        registerDefaultFlare(() => ({}) as any);
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining('/inject'));
+    });
+
+    test('registerDefaultFlare does NOT warn without the bridge', async () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const { registerDefaultFlare } = await import('../src/resolveFlare');
+        registerDefaultFlare(() => ({}) as any);
+        expect(warn).not.toHaveBeenCalled();
+    });
+});

--- a/packages/vue/tests/webEntry.test.ts
+++ b/packages/vue/tests/webEntry.test.ts
@@ -1,0 +1,17 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+describe('@flareapp/vue web entry', () => {
+    beforeEach(() => {
+        vi.resetModules();
+    });
+
+    test('importing the root registers the js singleton as the resolveFlare default', async () => {
+        const singleton = { reportSilently: vi.fn(), setSdkInfo: vi.fn(), setFramework: vi.fn() };
+        vi.doMock('@flareapp/js', () => ({ flare: singleton }));
+
+        await import('../src/index');
+
+        const { resolveFlare } = await import('../src/resolveFlare');
+        expect(resolveFlare()).toBe(singleton);
+    });
+});

--- a/scripts/release-all.mjs
+++ b/scripts/release-all.mjs
@@ -75,6 +75,7 @@ const CORE_REFS = [
     { pkg: 'node', field: 'dependencies', dep: '@flareapp/core' },
     { pkg: 'electron', field: 'dependencies', dep: '@flareapp/core' },
     { pkg: 'react', field: 'dependencies', dep: '@flareapp/core' },
+    { pkg: 'vue', field: 'dependencies', dep: '@flareapp/core' },
 ];
 
 // Lockstep deps that are hard-pinned EXACTLY (not caret). electron pins @flareapp/js exactly,

--- a/scripts/release-all.mjs
+++ b/scripts/release-all.mjs
@@ -76,6 +76,7 @@ const CORE_REFS = [
     { pkg: 'electron', field: 'dependencies', dep: '@flareapp/core' },
     { pkg: 'react', field: 'dependencies', dep: '@flareapp/core' },
     { pkg: 'vue', field: 'dependencies', dep: '@flareapp/core' },
+    { pkg: 'svelte', field: 'dependencies', dep: '@flareapp/core' },
 ];
 
 // Lockstep deps that are hard-pinned EXACTLY (not caret). electron pins @flareapp/js exactly,


### PR DESCRIPTION
**Stacked on #58** (base: `feat/react-electron-injection`). Review the Vue diff in isolation; retarget to `main` once #58 merges.

## Summary

Adds `@flareapp/vue/inject` so both the `flareVue` plugin and the Vue `FlareErrorBoundary` can run in an Electron renderer and route reports through an injected Flare instance (Electron's `RendererFlare`) instead of the `@flareapp/js` root singleton — without breaking web consumers and without pulling the js-root side effects into the renderer.

Web behavior unchanged (zero-prop/zero-option usage still uses the configured `@flareapp/js` singleton). Additive minor: `@flareapp/vue` → `2.5.0`.

### Mirrors the React design (#58), with Vue-specific complexity
- **Two report sites:** the `flareVue` plugin (resolves `options.flare` at install) and the `FlareErrorBoundary` component (resolves the `flare` prop at setup). Both resolve once at wiring time; report paths are infallible.
- **Four root imports handled:** two utility value-imports (`resolveDenylist`, `redactFullPath`) migrated from the root to `@flareapp/core` so the shared module graph is root-free; the two singleton usages replaced with the resolved instance.
- **Identity stays at install/setup, not import** (Vue needs `app.version`, known only then). Split into `registerVueSdkInfo` (web) + `tagVueFramework` (always); injected path tags framework only, never clobbering `@flareapp/electron`'s SDK name. Per-instance `WeakSet` guards.
- **Resolve-before-`installedApps.add` ordering** so a failed `/inject` install doesn't poison the WeakSet — proven by a direct-call retry test.

### Guards
- `verify:inject` follows the inject **chunk graph** transitively (entry shims re-export from a shared chunk) and fails on any `@flareapp/js` root specifier.
- Cross-package electron test drives `@flareapp/vue/inject` → `RendererFlare` → bridge, asserting `sdk = @flareapp/electron`, `framework = Vue`, `context.custom.vue` preserved.

## Test plan
- [x] `packages/vue`: build, 240 tests, `tsc --noEmit` 0 errors, `verify:inject` OK
- [x] `packages/electron`: 41 tests, `tsc --noEmit` 0 errors
- [x] Reviewer: confirm web zero-option path unchanged; `/inject` root-free in built output

## Notes
- Scope: Vue only. Svelte (`@flareapp/svelte/inject`) + the SvelteKit sdk-name regression is the planned next sibling, to stack on this branch.
- `@flareapp/electron` / `@flareapp/sveltekit` need no version bump.
- Follow-ups (non-blocking): an end-to-end electron test for the boundary site (plugin site is covered); restore the lockstep comments in the Vue copy of `verify-inject-no-root.mjs`; the shared-barrel idea to make web/inject export parity structural.