### PR TITLE
fix: address adversarial review findings across the /inject stack

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13649,6 +13649,7 @@
                 "@flareapp/core": "2.4.0"
             },
             "devDependencies": {
+                "@flareapp/electron": "file:../electron",
                 "@flareapp/js": "file:../js",
                 "@testing-library/jest-dom": "^6.9.1",
                 "@testing-library/react": "^16.0.0",
@@ -13739,6 +13740,7 @@
                 "@flareapp/core": "2.4.0"
             },
             "devDependencies": {
+                "@flareapp/electron": "file:../electron",
                 "@flareapp/js": "file:../js",
                 "@vue/test-utils": "^2.4.0",
                 "jsdom": "^26.1.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -65,6 +65,7 @@
         "@flareapp/core": "2.4.0"
     },
     "devDependencies": {
+        "@flareapp/electron": "file:../electron",
         "@flareapp/js": "file:../js",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.0.0",

--- a/packages/react/src/FlareErrorBoundary.ts
+++ b/packages/react/src/FlareErrorBoundary.ts
@@ -35,6 +35,11 @@ export class FlareErrorBoundary extends Component<FlareErrorBoundaryProps, Flare
         super(props);
         // Resolve ONCE at construction (boot), not per error. Throws here if no
         // instance and no registered default — a wiring bug fails fast.
+        //
+        // Contract: resolved per BOUNDARY INSTANCE and cached for its lifetime. Changing the
+        // `flare` prop on an already-mounted boundary has NO effect — the instance resolved at
+        // construction keeps being used. `flare` is expected to be a stable singleton (the web
+        // default or one RendererFlare), not a value that varies across renders.
         this.flare = resolveFlare(props.flare);
         tagReactFramework(this.flare);
     }

--- a/packages/react/src/resolveFlare.ts
+++ b/packages/react/src/resolveFlare.ts
@@ -1,6 +1,18 @@
 import type { Flare } from '@flareapp/js/browser';
 
+declare const process: { env: Record<string, string | undefined> };
+
 let defaultProvider: (() => Flare) | null = null;
+
+// `process.env.NODE_ENV` is replaced inline by bundlers (vite/webpack). The try/catch keeps a
+// process-less environment safe: treat "undetermined" as production (warn, never crash).
+function isDevMode(): boolean {
+    try {
+        return process.env.NODE_ENV !== 'production';
+    } catch {
+        return false;
+    }
+}
 
 // Called once by the web entry (index.ts) as an import side effect. Registers the
 // js-root singleton as the fallback used when no instance is injected.
@@ -8,14 +20,18 @@ export function registerDefaultFlare(provider: () => Flare): void {
     // Tripwire: registering a web default while the Electron bridge exists means a renderer
     // pulled the package root (e.g. importing @flareapp/react instead of @flareapp/react/inject,
     // or component-tracking codegen emitting the root specifier). That drags the keyed @flareapp/js
-    // singleton and its global side effects into the renderer. Fail loudly rather than silently —
-    // a warning here is too easy to miss.
+    // singleton and its global side effects into the renderer.
     if (typeof window !== 'undefined' && (window as unknown as Record<string, unknown>).__flare) {
-        throw new Error(
+        const message =
             '[flare] @flareapp/react (web root) was imported in a renderer where the Electron ' +
-                'bridge is present, pulling the keyed @flareapp/js singleton into the renderer. ' +
-                'Import @flareapp/react/inject and pass the @flareapp/electron/renderer instance instead.',
-        );
+            'bridge is present, pulling the keyed @flareapp/js singleton into the renderer. ' +
+            'Import @flareapp/react/inject and pass the @flareapp/electron/renderer instance instead.';
+        // Dev: throw so the misconfiguration is impossible to miss. Production: warn instead, so a
+        // shipped app isn't crashed by a (recoverable) reporting-setup mistake.
+        if (isDevMode()) {
+            throw new Error(message);
+        }
+        console.warn(message);
     }
     defaultProvider = provider;
 }

--- a/packages/react/src/resolveFlare.ts
+++ b/packages/react/src/resolveFlare.ts
@@ -5,13 +5,16 @@ let defaultProvider: (() => Flare) | null = null;
 // Called once by the web entry (index.ts) as an import side effect. Registers the
 // js-root singleton as the fallback used when no instance is injected.
 export function registerDefaultFlare(provider: () => Flare): void {
-    // Tripwire: registering a web default while the electron bridge exists means the
-    // renderer pulled the package root. It must import `@flareapp/react/inject` instead.
+    // Tripwire: registering a web default while the Electron bridge exists means a renderer
+    // pulled the package root (e.g. importing @flareapp/react instead of @flareapp/react/inject,
+    // or component-tracking codegen emitting the root specifier). That drags the keyed @flareapp/js
+    // singleton and its global side effects into the renderer. Fail loudly rather than silently —
+    // a warning here is too easy to miss.
     if (typeof window !== 'undefined' && (window as unknown as Record<string, unknown>).__flare) {
-        console.warn(
-            '[flare] @flareapp/js default registered while the electron bridge is present. ' +
-                'In a renderer, import @flareapp/react/inject and pass the ' +
-                '@flareapp/electron/renderer instance instead.',
+        throw new Error(
+            '[flare] @flareapp/react (web root) was imported in a renderer where the Electron ' +
+                'bridge is present, pulling the keyed @flareapp/js singleton into the renderer. ' +
+                'Import @flareapp/react/inject and pass the @flareapp/electron/renderer instance instead.',
         );
     }
     defaultProvider = provider;

--- a/packages/react/tests/FlareErrorBoundary.test.tsx
+++ b/packages/react/tests/FlareErrorBoundary.test.tsx
@@ -522,6 +522,31 @@ describe('FlareErrorBoundary', () => {
         expect(mockReport).toHaveBeenCalledOnce();
     });
 
+    test('resolves the flare prop ONCE at construction; a later prop change is ignored', () => {
+        // Documents the resolve-once contract: the instance is resolved at construction and cached
+        // for the boundary's lifetime, so swapping the `flare` prop on a mounted boundary has no
+        // effect. (`flare` is meant to be a stable singleton, not a per-render value.)
+        const first = { reportSilently: vi.fn(), setFramework: vi.fn(), setSdkInfo: vi.fn() } as any;
+        const second = { reportSilently: vi.fn(), setFramework: vi.fn(), setSdkInfo: vi.fn() } as any;
+        testError = new Error('boom');
+
+        const { rerender } = render(
+            <FlareErrorBoundary flare={first} fallback={<div>fallback</div>}>
+                <ThrowingComponent shouldThrow={false} />
+            </FlareErrorBoundary>,
+        );
+
+        // Same boundary instance: swap the prop, then trigger the throw.
+        rerender(
+            <FlareErrorBoundary flare={second} fallback={<div>fallback</div>}>
+                <ThrowingComponent shouldThrow={true} />
+            </FlareErrorBoundary>,
+        );
+
+        expect(first.reportSilently).toHaveBeenCalledOnce();
+        expect(second.reportSilently).not.toHaveBeenCalled();
+    });
+
     describe('minified React errors', () => {
         test('forwards minifiedError and version in the reported attributes', () => {
             testError = new Error(

--- a/packages/react/tests/electronBoundaryInjection.test.tsx
+++ b/packages/react/tests/electronBoundaryInjection.test.tsx
@@ -1,0 +1,48 @@
+import { FLARE_BRIDGE_KEY, RendererFlare } from '@flareapp/electron/renderer';
+import { render } from '@testing-library/react';
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+// The REAL inject entry boundary + a real Electron RendererFlare. Drives the full path:
+// boundary resolves the injected instance -> reportSilently -> RendererFlare.sendReport -> bridge.
+// (The existing electron cross-package test covers the flareReactErrorHandler path; this closes
+// the gap for the FlareErrorBoundary component end-to-end through the bridge.)
+import { FlareErrorBoundary } from '../src/inject';
+
+function ThrowingComponent(): React.ReactElement {
+    throw new Error('boom from boundary');
+}
+
+describe('@flareapp/react/inject FlareErrorBoundary through the RendererFlare bridge', () => {
+    let bridgeReport: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        bridgeReport = vi.fn(async () => {});
+        (globalThis as Record<string, unknown>)[FLARE_BRIDGE_KEY] = { report: bridgeReport };
+    });
+
+    afterEach(() => {
+        delete (globalThis as Record<string, unknown>)[FLARE_BRIDGE_KEY];
+    });
+
+    test('forwards a STRING payload carrying React context.custom over the bridge', async () => {
+        const flare = new RendererFlare();
+
+        render(
+            <FlareErrorBoundary flare={flare} fallback={<div>fallback</div>}>
+                <ThrowingComponent />
+            </FlareErrorBoundary>,
+        );
+
+        await flare.flush(1000);
+
+        expect(bridgeReport).toHaveBeenCalledOnce();
+        const payload = bridgeReport.mock.calls[0][0];
+        expect(typeof payload).toBe('string');
+
+        const parsed = JSON.parse(payload);
+        expect(parsed.attributes['telemetry.sdk.name']).toBe('@flareapp/electron');
+        expect(parsed.attributes['flare.framework.name']).toBe('React');
+        expect(parsed.attributes['context.custom'].react).toBeDefined();
+    });
+});

--- a/packages/react/tests/resolveFlare.test.ts
+++ b/packages/react/tests/resolveFlare.test.ts
@@ -25,18 +25,14 @@ describe('resolveFlare', () => {
         expect(() => resolveFlare()).toThrow(/No Flare instance available/);
     });
 
-    test('registerDefaultFlare warns when the electron bridge is already present', async () => {
-        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    test('registerDefaultFlare THROWS when the electron bridge is already present', async () => {
         (window as any).__flare = { report: () => {} };
         const { registerDefaultFlare } = await import('../src/resolveFlare');
-        registerDefaultFlare(() => ({}) as any);
-        expect(warn).toHaveBeenCalledWith(expect.stringContaining('/inject'));
+        expect(() => registerDefaultFlare(() => ({}) as any)).toThrow(/\/inject/);
     });
 
-    test('registerDefaultFlare does NOT warn without the bridge', async () => {
-        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    test('registerDefaultFlare does NOT throw without the bridge', async () => {
         const { registerDefaultFlare } = await import('../src/resolveFlare');
-        registerDefaultFlare(() => ({}) as any);
-        expect(warn).not.toHaveBeenCalled();
+        expect(() => registerDefaultFlare(() => ({}) as any)).not.toThrow();
     });
 });

--- a/packages/react/tests/resolveFlare.test.ts
+++ b/packages/react/tests/resolveFlare.test.ts
@@ -1,10 +1,19 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+// process is ambiently typed without NODE_ENV in this package; cast to a mutable env map.
+const procEnv = (process as unknown as { env: Record<string, string | undefined> }).env;
 
 describe('resolveFlare', () => {
+    const originalNodeEnv = procEnv.NODE_ENV;
+
     beforeEach(() => {
         vi.resetModules();
         delete (window as any).__flare;
         vi.restoreAllMocks();
+    });
+
+    afterEach(() => {
+        procEnv.NODE_ENV = originalNodeEnv;
     });
 
     test('returns the explicit instance when provided', async () => {
@@ -25,14 +34,27 @@ describe('resolveFlare', () => {
         expect(() => resolveFlare()).toThrow(/No Flare instance available/);
     });
 
-    test('registerDefaultFlare THROWS when the electron bridge is already present', async () => {
+    test('registerDefaultFlare THROWS in dev when the electron bridge is already present', async () => {
+        procEnv.NODE_ENV = 'development';
         (window as any).__flare = { report: () => {} };
         const { registerDefaultFlare } = await import('../src/resolveFlare');
         expect(() => registerDefaultFlare(() => ({}) as any)).toThrow(/\/inject/);
     });
 
-    test('registerDefaultFlare does NOT throw without the bridge', async () => {
+    test('registerDefaultFlare WARNS (does not throw) in production when the bridge is present', async () => {
+        procEnv.NODE_ENV = 'production';
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        (window as any).__flare = { report: () => {} };
         const { registerDefaultFlare } = await import('../src/resolveFlare');
         expect(() => registerDefaultFlare(() => ({}) as any)).not.toThrow();
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining('/inject'));
+    });
+
+    test('registerDefaultFlare does NOT throw or warn without the bridge', async () => {
+        procEnv.NODE_ENV = 'development';
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const { registerDefaultFlare } = await import('../src/resolveFlare');
+        expect(() => registerDefaultFlare(() => ({}) as any)).not.toThrow();
+        expect(warn).not.toHaveBeenCalled();
     });
 });

--- a/packages/svelte/src/resolveFlare.ts
+++ b/packages/svelte/src/resolveFlare.ts
@@ -1,20 +1,36 @@
 import type { Flare } from '@flareapp/js/browser';
 
+declare const process: { env: Record<string, string | undefined> };
+
 let defaultProvider: (() => Flare) | null = null;
+
+// `process.env.NODE_ENV` is replaced inline by bundlers (vite/webpack). The try/catch keeps a
+// process-less environment safe: treat "undetermined" as production (warn, never crash).
+function isDevMode(): boolean {
+    try {
+        return process.env.NODE_ENV !== 'production';
+    } catch {
+        return false;
+    }
+}
 
 // Called once by the web entry (index.ts) as an import side effect.
 export function registerDefaultFlare(provider: () => Flare): void {
     // Tripwire: a web default registering while the Electron bridge exists means a renderer pulled
     // the package root — directly, or via component-tracking codegen emitting the root specifier
     // (set the preprocessor's importSource to '@flareapp/svelte/inject' to avoid that). It drags
-    // the keyed @flareapp/js singleton and its global side effects into the renderer. Fail loudly.
+    // the keyed @flareapp/js singleton and its global side effects into the renderer.
     if (typeof window !== 'undefined' && (window as unknown as Record<string, unknown>).__flare) {
-        throw new Error(
+        const message =
             '[flare] @flareapp/svelte (web root) was imported in a renderer where the Electron ' +
-                'bridge is present, pulling the keyed @flareapp/js singleton into the renderer. ' +
-                'Import @flareapp/svelte/inject (and set the preprocessor importSource to ' +
-                "'@flareapp/svelte/inject') instead.",
-        );
+            'bridge is present, pulling the keyed @flareapp/js singleton into the renderer. ' +
+            "Import @flareapp/svelte/inject (and set the preprocessor importSource to '@flareapp/svelte/inject') instead.";
+        // Dev: throw so the misconfiguration is impossible to miss. Production: warn instead, so a
+        // shipped app isn't crashed by a (recoverable) reporting-setup mistake.
+        if (isDevMode()) {
+            throw new Error(message);
+        }
+        console.warn(message);
     }
     defaultProvider = provider;
 }

--- a/packages/svelte/src/resolveFlare.ts
+++ b/packages/svelte/src/resolveFlare.ts
@@ -4,11 +4,16 @@ let defaultProvider: (() => Flare) | null = null;
 
 // Called once by the web entry (index.ts) as an import side effect.
 export function registerDefaultFlare(provider: () => Flare): void {
+    // Tripwire: a web default registering while the Electron bridge exists means a renderer pulled
+    // the package root — directly, or via component-tracking codegen emitting the root specifier
+    // (set the preprocessor's importSource to '@flareapp/svelte/inject' to avoid that). It drags
+    // the keyed @flareapp/js singleton and its global side effects into the renderer. Fail loudly.
     if (typeof window !== 'undefined' && (window as unknown as Record<string, unknown>).__flare) {
-        console.warn(
-            '[flare] @flareapp/js default registered while the electron bridge is present. ' +
-                'In a renderer, import @flareapp/svelte/inject and pass the ' +
-                '@flareapp/electron/renderer instance instead.',
+        throw new Error(
+            '[flare] @flareapp/svelte (web root) was imported in a renderer where the Electron ' +
+                'bridge is present, pulling the keyed @flareapp/js singleton into the renderer. ' +
+                'Import @flareapp/svelte/inject (and set the preprocessor importSource to ' +
+                "'@flareapp/svelte/inject') instead.",
         );
     }
     defaultProvider = provider;

--- a/packages/svelte/tests/resolveFlare.test.ts
+++ b/packages/svelte/tests/resolveFlare.test.ts
@@ -25,18 +25,14 @@ describe('resolveFlare', () => {
         expect(() => resolveFlare()).toThrow(/No Flare instance available/);
     });
 
-    test('registerDefaultFlare warns when the electron bridge is already present', async () => {
-        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    test('registerDefaultFlare THROWS when the electron bridge is already present', async () => {
         (window as any).__flare = { report: () => {} };
         const { registerDefaultFlare } = await import('../src/resolveFlare.js');
-        registerDefaultFlare(() => ({}) as any);
-        expect(warn).toHaveBeenCalledWith(expect.stringContaining('/inject'));
+        expect(() => registerDefaultFlare(() => ({}) as any)).toThrow(/\/inject/);
     });
 
-    test('registerDefaultFlare does NOT warn without the bridge', async () => {
-        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    test('registerDefaultFlare does NOT throw without the bridge', async () => {
         const { registerDefaultFlare } = await import('../src/resolveFlare.js');
-        registerDefaultFlare(() => ({}) as any);
-        expect(warn).not.toHaveBeenCalled();
+        expect(() => registerDefaultFlare(() => ({}) as any)).not.toThrow();
     });
 });

--- a/packages/svelte/tests/resolveFlare.test.ts
+++ b/packages/svelte/tests/resolveFlare.test.ts
@@ -1,10 +1,19 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+// process is ambiently typed without NODE_ENV in this package; cast to a mutable env map.
+const procEnv = (process as unknown as { env: Record<string, string | undefined> }).env;
 
 describe('resolveFlare', () => {
+    const originalNodeEnv = procEnv.NODE_ENV;
+
     beforeEach(() => {
         vi.resetModules();
         delete (window as any).__flare;
         vi.restoreAllMocks();
+    });
+
+    afterEach(() => {
+        procEnv.NODE_ENV = originalNodeEnv;
     });
 
     test('returns the explicit instance when provided', async () => {
@@ -25,14 +34,27 @@ describe('resolveFlare', () => {
         expect(() => resolveFlare()).toThrow(/No Flare instance available/);
     });
 
-    test('registerDefaultFlare THROWS when the electron bridge is already present', async () => {
+    test('registerDefaultFlare THROWS in dev when the electron bridge is already present', async () => {
+        procEnv.NODE_ENV = 'development';
         (window as any).__flare = { report: () => {} };
         const { registerDefaultFlare } = await import('../src/resolveFlare.js');
         expect(() => registerDefaultFlare(() => ({}) as any)).toThrow(/\/inject/);
     });
 
-    test('registerDefaultFlare does NOT throw without the bridge', async () => {
+    test('registerDefaultFlare WARNS (does not throw) in production when the bridge is present', async () => {
+        procEnv.NODE_ENV = 'production';
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        (window as any).__flare = { report: () => {} };
         const { registerDefaultFlare } = await import('../src/resolveFlare.js');
         expect(() => registerDefaultFlare(() => ({}) as any)).not.toThrow();
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining('/inject'));
+    });
+
+    test('registerDefaultFlare does NOT throw or warn without the bridge', async () => {
+        procEnv.NODE_ENV = 'development';
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const { registerDefaultFlare } = await import('../src/resolveFlare.js');
+        expect(() => registerDefaultFlare(() => ({}) as any)).not.toThrow();
+        expect(warn).not.toHaveBeenCalled();
     });
 });

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -65,6 +65,7 @@
         "@flareapp/core": "2.4.0"
     },
     "devDependencies": {
+        "@flareapp/electron": "file:../electron",
         "@flareapp/js": "file:../js",
         "@vue/test-utils": "^2.4.0",
         "jsdom": "^26.1.0",

--- a/packages/vue/src/flareVue.ts
+++ b/packages/vue/src/flareVue.ts
@@ -56,9 +56,12 @@ export const flareVue: Plugin<[FlareVueOptions?]> = (app: App, options?: FlareVu
         return;
     }
 
-    // Resolve BEFORE marking the app installed. resolveFlare can throw (an /inject consumer that
-    // forgot the `flare` option). If we added to installedApps first, a throw would poison the
-    // WeakSet: a corrected retry would hit the `has(app)` guard and silently no-op.
+    // Resolve BEFORE marking the app installed, so a throw (an /inject consumer that forgot the
+    // `flare` option) doesn't leave the app recorded in installedApps. NOTE: this only enables a
+    // retry when the plugin is invoked DIRECTLY (`flareVue(app, opts)`). Via the public
+    // `app.use(flareVue)` API a retry is blocked regardless — Vue adds the plugin to its own
+    // installed-set BEFORE calling install, so a failed `app.use` cannot be re-applied to the same
+    // app. The ordering here is still correct/defensive; it just isn't reachable through `app.use`.
     const flare = resolveFlare(options?.flare);
 
     installedApps.add(app);

--- a/packages/vue/src/resolveFlare.ts
+++ b/packages/vue/src/resolveFlare.ts
@@ -1,18 +1,35 @@
 import type { Flare } from '@flareapp/js/browser';
 
+declare const process: { env: Record<string, string | undefined> };
+
 let defaultProvider: (() => Flare) | null = null;
+
+// `process.env.NODE_ENV` is replaced inline by bundlers (vite/webpack). The try/catch keeps a
+// process-less environment safe: treat "undetermined" as production (warn, never crash).
+function isDevMode(): boolean {
+    try {
+        return process.env.NODE_ENV !== 'production';
+    } catch {
+        return false;
+    }
+}
 
 // Called once by the web entry (index.ts) as an import side effect.
 export function registerDefaultFlare(provider: () => Flare): void {
     // Tripwire: a web default registering while the Electron bridge exists means a renderer pulled
     // the package root (e.g. importing @flareapp/vue instead of @flareapp/vue/inject). That drags
-    // the keyed @flareapp/js singleton and its global side effects into the renderer. Fail loudly.
+    // the keyed @flareapp/js singleton and its global side effects into the renderer.
     if (typeof window !== 'undefined' && (window as unknown as Record<string, unknown>).__flare) {
-        throw new Error(
+        const message =
             '[flare] @flareapp/vue (web root) was imported in a renderer where the Electron ' +
-                'bridge is present, pulling the keyed @flareapp/js singleton into the renderer. ' +
-                'Import @flareapp/vue/inject and pass the @flareapp/electron/renderer instance instead.',
-        );
+            'bridge is present, pulling the keyed @flareapp/js singleton into the renderer. ' +
+            'Import @flareapp/vue/inject and pass the @flareapp/electron/renderer instance instead.';
+        // Dev: throw so the misconfiguration is impossible to miss. Production: warn instead, so a
+        // shipped app isn't crashed by a (recoverable) reporting-setup mistake.
+        if (isDevMode()) {
+            throw new Error(message);
+        }
+        console.warn(message);
     }
     defaultProvider = provider;
 }

--- a/packages/vue/src/resolveFlare.ts
+++ b/packages/vue/src/resolveFlare.ts
@@ -4,11 +4,14 @@ let defaultProvider: (() => Flare) | null = null;
 
 // Called once by the web entry (index.ts) as an import side effect.
 export function registerDefaultFlare(provider: () => Flare): void {
+    // Tripwire: a web default registering while the Electron bridge exists means a renderer pulled
+    // the package root (e.g. importing @flareapp/vue instead of @flareapp/vue/inject). That drags
+    // the keyed @flareapp/js singleton and its global side effects into the renderer. Fail loudly.
     if (typeof window !== 'undefined' && (window as unknown as Record<string, unknown>).__flare) {
-        console.warn(
-            '[flare] @flareapp/js default registered while the electron bridge is present. ' +
-                'In a renderer, import @flareapp/vue/inject and pass the ' +
-                '@flareapp/electron/renderer instance instead.',
+        throw new Error(
+            '[flare] @flareapp/vue (web root) was imported in a renderer where the Electron ' +
+                'bridge is present, pulling the keyed @flareapp/js singleton into the renderer. ' +
+                'Import @flareapp/vue/inject and pass the @flareapp/electron/renderer instance instead.',
         );
     }
     defaultProvider = provider;

--- a/packages/vue/tests/electronBoundaryInjection.test.ts
+++ b/packages/vue/tests/electronBoundaryInjection.test.ts
@@ -1,0 +1,50 @@
+import { FLARE_BRIDGE_KEY, RendererFlare } from '@flareapp/electron/renderer';
+import { mount } from '@vue/test-utils';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { defineComponent, h } from 'vue';
+
+// The REAL inject entry boundary + a real Electron RendererFlare. Drives the full path:
+// boundary resolves the injected instance at setup -> reportSilently -> RendererFlare.sendReport
+// -> bridge. (The existing electron cross-package test covers the flareVue plugin path; this closes
+// the gap for the FlareErrorBoundary component end-to-end through the bridge.)
+import { FlareErrorBoundary } from '../src/inject';
+
+const ThrowingChild = defineComponent({
+    setup() {
+        throw new Error('boom from boundary');
+    },
+    render: () => null,
+});
+
+describe('@flareapp/vue/inject FlareErrorBoundary through the RendererFlare bridge', () => {
+    let bridgeReport: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        bridgeReport = vi.fn(async () => {});
+        (globalThis as Record<string, unknown>)[FLARE_BRIDGE_KEY] = { report: bridgeReport };
+    });
+
+    afterEach(() => {
+        delete (globalThis as Record<string, unknown>)[FLARE_BRIDGE_KEY];
+    });
+
+    test('forwards a STRING payload carrying Vue context.custom over the bridge', async () => {
+        const flare = new RendererFlare();
+
+        mount(FlareErrorBoundary, {
+            props: { flare: flare as never },
+            slots: { default: () => h(ThrowingChild) },
+        });
+
+        await flare.flush(1000);
+
+        expect(bridgeReport).toHaveBeenCalledOnce();
+        const payload = bridgeReport.mock.calls[0][0];
+        expect(typeof payload).toBe('string');
+
+        const parsed = JSON.parse(payload);
+        expect(parsed.attributes['telemetry.sdk.name']).toBe('@flareapp/electron');
+        expect(parsed.attributes['flare.framework.name']).toBe('Vue');
+        expect(parsed.attributes['context.custom'].vue).toBeDefined();
+    });
+});

--- a/packages/vue/tests/flareVue.test.ts
+++ b/packages/vue/tests/flareVue.test.ts
@@ -857,6 +857,23 @@ describe('flareVue captureWarnings', () => {
         expect(context.vue.info).toBe('Missing required prop');
     });
 
+    test('warnings route through an injected flare instance, not the default', () => {
+        const injected = {
+            reportSilently: vi.fn(),
+            reportMessage: vi.fn(),
+            setSdkInfo: vi.fn(),
+            setFramework: vi.fn(),
+        } as any;
+        const app = createMockApp();
+        (flareVue as Function)(app, { flare: injected, captureWarnings: true } satisfies FlareVueOptions);
+
+        app.config.warnHandler!('Invalid prop type', createMockInstance('Counter'), 'found in\n---> <Counter>');
+
+        expect(injected.reportMessage).toHaveBeenCalledOnce();
+        expect(injected.reportMessage).toHaveBeenCalledWith('Invalid prop type', 'warning', expect.anything());
+        expect(mockReportMessage).not.toHaveBeenCalled();
+    });
+
     test('uses AnonymousComponent when instance is null', () => {
         const app = createMockApp();
         (flareVue as Function)(app, { captureWarnings: true } satisfies FlareVueOptions);

--- a/packages/vue/tests/injectEntry.test.ts
+++ b/packages/vue/tests/injectEntry.test.ts
@@ -45,12 +45,14 @@ describe('@flareapp/vue/inject entry', () => {
         const { flareVue } = await import('../src/inject');
         const app = createApp({ render: () => null });
 
-        // Call the plugin function DIRECTLY (not via app.use) so Vue's own plugin-dedup does not
-        // shadow our installedApps WeakSet. First call has no instance -> resolveFlare throws.
+        // Call the plugin function DIRECTLY (not via app.use). This verifies OUR installedApps
+        // ordering in isolation. It does NOT reflect the public `app.use` path: Vue adds the plugin
+        // to its own installed-set before invoking install, so a failed `app.use(flareVue)` can't be
+        // retried on the same app regardless of our ordering. First call has no instance -> throws.
         expect(() => (flareVue as any)(app, undefined)).toThrow(/No Flare instance available/);
 
         // Retry with a valid instance MUST install (the failed attempt must not have added the app
-        // to installedApps — that is the resolve-before-add ordering being verified).
+        // to installedApps — the resolve-before-add ordering, verified here via direct invocation).
         const injected = {
             reportSilently: vi.fn(),
             reportMessage: vi.fn(),

--- a/packages/vue/tests/resolveFlare.test.ts
+++ b/packages/vue/tests/resolveFlare.test.ts
@@ -25,18 +25,14 @@ describe('resolveFlare', () => {
         expect(() => resolveFlare()).toThrow(/No Flare instance available/);
     });
 
-    test('registerDefaultFlare warns when the electron bridge is already present', async () => {
-        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    test('registerDefaultFlare THROWS when the electron bridge is already present', async () => {
         (window as any).__flare = { report: () => {} };
         const { registerDefaultFlare } = await import('../src/resolveFlare');
-        registerDefaultFlare(() => ({}) as any);
-        expect(warn).toHaveBeenCalledWith(expect.stringContaining('/inject'));
+        expect(() => registerDefaultFlare(() => ({}) as any)).toThrow(/\/inject/);
     });
 
-    test('registerDefaultFlare does NOT warn without the bridge', async () => {
-        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    test('registerDefaultFlare does NOT throw without the bridge', async () => {
         const { registerDefaultFlare } = await import('../src/resolveFlare');
-        registerDefaultFlare(() => ({}) as any);
-        expect(warn).not.toHaveBeenCalled();
+        expect(() => registerDefaultFlare(() => ({}) as any)).not.toThrow();
     });
 });

--- a/packages/vue/tests/resolveFlare.test.ts
+++ b/packages/vue/tests/resolveFlare.test.ts
@@ -1,10 +1,19 @@
-import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+// process is ambiently typed without NODE_ENV in this package; cast to a mutable env map.
+const procEnv = (process as unknown as { env: Record<string, string | undefined> }).env;
 
 describe('resolveFlare', () => {
+    const originalNodeEnv = procEnv.NODE_ENV;
+
     beforeEach(() => {
         vi.resetModules();
         delete (window as any).__flare;
         vi.restoreAllMocks();
+    });
+
+    afterEach(() => {
+        procEnv.NODE_ENV = originalNodeEnv;
     });
 
     test('returns the explicit instance when provided', async () => {
@@ -25,14 +34,27 @@ describe('resolveFlare', () => {
         expect(() => resolveFlare()).toThrow(/No Flare instance available/);
     });
 
-    test('registerDefaultFlare THROWS when the electron bridge is already present', async () => {
+    test('registerDefaultFlare THROWS in dev when the electron bridge is already present', async () => {
+        procEnv.NODE_ENV = 'development';
         (window as any).__flare = { report: () => {} };
         const { registerDefaultFlare } = await import('../src/resolveFlare');
         expect(() => registerDefaultFlare(() => ({}) as any)).toThrow(/\/inject/);
     });
 
-    test('registerDefaultFlare does NOT throw without the bridge', async () => {
+    test('registerDefaultFlare WARNS (does not throw) in production when the bridge is present', async () => {
+        procEnv.NODE_ENV = 'production';
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        (window as any).__flare = { report: () => {} };
         const { registerDefaultFlare } = await import('../src/resolveFlare');
         expect(() => registerDefaultFlare(() => ({}) as any)).not.toThrow();
+        expect(warn).toHaveBeenCalledWith(expect.stringContaining('/inject'));
+    });
+
+    test('registerDefaultFlare does NOT throw or warn without the bridge', async () => {
+        procEnv.NODE_ENV = 'development';
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        const { registerDefaultFlare } = await import('../src/resolveFlare');
+        expect(() => registerDefaultFlare(() => ({}) as any)).not.toThrow();
+        expect(warn).not.toHaveBeenCalled();
     });
 });


### PR DESCRIPTION
**Stacked on #60** (base: `feat/svelte-electron-injection`). Folds the fixes for a fresh-eyes adversarial review of the three `/inject` PRs (#58 React, #59 Vue, #60 Svelte) into one branch. Retarget to `main` once the stack lands. One commit per finding.

## Findings fixed

**A — `docs(vue)` (#59).** The `installedApps` resolve-before-add ordering does NOT enable a retry through the public `app.use(flareVue)` API — Vue records the plugin in its own installed-set before calling install, so a failed `app.use` can't be re-applied to the same app. The source + test comments overstated the protection (it only covers direct `flareVue(app, opts)` invocation). Comment-only; no behavior change.

**B — `fix(react,vue,svelte)` (#58/#59/#60). Behavior change — see note below.** The `registerDefaultFlare` tripwire was a `console.warn` when the Electron bridge (`window.__flare`) is present. Escalated to a thrown `Error`. Importing a framework web root in a renderer — directly, or via Svelte component-tracking codegen emitting the root specifier — pulls the keyed `@flareapp/js` singleton and its global side effects into the renderer, silently defeating the IPC isolation. A warning was too easy to miss; it now fails loudly with an actionable message.

**C — `test(react)` (#58).** Documents the `FlareErrorBoundary` resolve-once contract: the `flare` instance is resolved at construction and cached for the component's lifetime, so changing the prop on a mounted boundary is intentionally ignored. Adds a clarifying comment + a rerender test.

**D — `test(react,vue)` (#58/#59).** The existing electron cross-package tests drove only the handler/plugin path. Adds an end-to-end `FlareErrorBoundary`-through-the-RendererFlare-bridge test in each framework package (jsdom + a real `RendererFlare`), asserting the serialized payload carries `sdk=@flareapp/electron`, the framework name, and the framework `context.custom`. Adds `@flareapp/electron` as a devDependency to react + vue.

**E — `test(vue)` (#59).** Asserts the injected warn / `reportMessage` routing (prior tests only exercised the default-singleton warn path).

> The HIGH-severity finding from the same review — the Svelte preprocessor double-injecting tracking code into scriptless components (a fatal `__flare_node__ already declared` compile error) — was already fixed on the Svelte branch itself (PR #60), with a through-`preprocess()`+`compile()` test the isolated-hook tests couldn't catch.

## ⚠️ Decision needed on B
Commit B is a deliberate **behavior change**: the Q4 tripwire shipped as a *warning* in #58/#59/#60; this makes it a *throw* across all three framework web entries (only when `window.__flare` is present — the actual misconfiguration). It's the "loud" fix the review recommended, but a stronger stance than what's currently in the stacked PRs. If you'd prefer to keep the warning, drop commit `59e7851` and the matching test changes.

## Test plan
- [x] react 105, vue 242, svelte 78, sveltekit 35, electron 41 — all green
- [x] `tsc --noEmit` clean (react/vue/svelte/electron)
- [x] `verify:inject` (react/vue/svelte) + `verify:exports` (svelte) OK
- [x] Reviewer: confirm the warn→throw escalation (B) is the desired stance