### PR TITLE
chore: fix npm audit vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "flare-client-js",
+    "name": "dhaka",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
@@ -4377,6 +4377,28 @@
                 }
             }
         },
+        "node_modules/@rollup/plugin-replace": {
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-6.0.3.tgz",
+            "integrity": "sha512-J4RZarRvQAm5IF0/LwUUg+obsm+xZhYnbMXmXROyoSE1ATJe3oXSb9L5MMppdxP2ylNSjv6zFBwKYjcKMucVfA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@rollup/pluginutils": "^5.0.1",
+                "magic-string": "^0.30.3"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+            },
+            "peerDependenciesMeta": {
+                "rollup": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/@rollup/pluginutils": {
             "version": "5.4.0",
             "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.4.0.tgz",
@@ -4808,15 +4830,16 @@
             }
         },
         "node_modules/@sveltejs/adapter-node": {
-            "version": "5.5.4",
-            "resolved": "https://registry.npmjs.org/@sveltejs/adapter-node/-/adapter-node-5.5.4.tgz",
-            "integrity": "sha512-45X92CXW+2J8ZUzPv3eLlKWEzINKiiGeFWTjyER4ZN4sGgNoaoeSkCY/QYNxHpPXy71QPsctwccBo9jJs0ySPQ==",
+            "version": "5.5.6",
+            "resolved": "https://registry.npmjs.org/@sveltejs/adapter-node/-/adapter-node-5.5.6.tgz",
+            "integrity": "sha512-OSclz7clrNzpks+CHoPVmc/eZ/+Kz/0VSf4t65TIrw+FXPBXGuqtHOCMITel2ovbyKrx05MQ4HiUj4X0nhueWA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@rollup/plugin-commonjs": "^29.0.0",
                 "@rollup/plugin-json": "^6.1.0",
                 "@rollup/plugin-node-resolve": "^16.0.0",
+                "@rollup/plugin-replace": "^6.0.3",
                 "rollup": "^4.59.0"
             },
             "peerDependencies": {
@@ -4824,9 +4847,9 @@
             }
         },
         "node_modules/@sveltejs/kit": {
-            "version": "2.61.1",
-            "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.61.1.tgz",
-            "integrity": "sha512-Ny8s1SR1TyQS2hD2Rvw0XKzU2Nw1eUF52dTb6T2bdcgz7wSC+Nyb5IwjWYlR4b2dvbbR5NJDiQwHg3rnNseghg==",
+            "version": "2.67.0",
+            "resolved": "https://registry.npmjs.org/@sveltejs/kit/-/kit-2.67.0.tgz",
+            "integrity": "sha512-JXHbsDwRes1Wgyof3q5ApzzpbCWvinKXMQCiV67TFO6xlZPYLoK0fq3xQMqSicDMgCtFGqLkrQXkseOcASdZ8A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -4863,16 +4886,6 @@
                 "typescript": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/@sveltejs/kit/node_modules/cookie": {
-            "version": "0.6.0",
-            "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.6.0.tgz",
-            "integrity": "sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==",
-            "dev": true,
-            "license": "MIT",
-            "engines": {
-                "node": ">= 0.6"
             }
         },
         "node_modules/@sveltejs/kit/node_modules/set-cookie-parser": {
@@ -9524,9 +9537,9 @@
             }
         },
         "node_modules/hono": {
-            "version": "4.12.23",
-            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
-            "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+            "version": "4.12.27",
+            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.27.tgz",
+            "integrity": "sha512-1yrb/+w6HWQJrUCLkJ2IF5jNIPvvFkblV5RNOYl6bV+OA6p9GLcMpHFFGTosSvHvcAUibuUukRqhlYI4z32C7Q==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -12312,34 +12325,6 @@
                 "sass": {
                     "optional": true
                 }
-            }
-        },
-        "node_modules/next/node_modules/postcss": {
-            "version": "8.4.31",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-            "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-            "funding": [
-                {
-                    "type": "opencollective",
-                    "url": "https://opencollective.com/postcss/"
-                },
-                {
-                    "type": "tidelift",
-                    "url": "https://tidelift.com/funding/github/npm/postcss"
-                },
-                {
-                    "type": "github",
-                    "url": "https://github.com/sponsors/ai"
-                }
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "nanoid": "^3.3.6",
-                "picocolors": "^1.0.0",
-                "source-map-js": "^1.0.2"
-            },
-            "engines": {
-                "node": "^10 || ^12 || >=14"
             }
         },
         "node_modules/node-fetch-native": {
@@ -15838,9 +15823,9 @@
             }
         },
         "node_modules/undici": {
-            "version": "7.24.5",
-            "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.5.tgz",
-            "integrity": "sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==",
+            "version": "7.28.0",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
+            "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
             "dev": true,
             "license": "MIT",
             "engines": {

--- a/package.json
+++ b/package.json
@@ -54,5 +54,10 @@
     },
     "optionalDependencies": {
         "@rolldown/binding-linux-x64-gnu": "1.0.3"
+    },
+    "overrides": {
+        "undici": "^7.28.0",
+        "cookie": "^0.7.2",
+        "postcss": "^8.5.10"
     }
 }


### PR DESCRIPTION
## Summary

Clears the resolvable `npm audit` advisories. Stacked on top of #62 (`feat/react-native-client`); the only new content versus that branch is one commit touching `package.json` + `package-lock.json`.

Took **21 -> 12** vulnerabilities, including **all 4 highs**.

### Fixed

| Vuln | Severity | How |
| --- | --- | --- |
| `hono` | high | `npm audit fix` (in-range bump) |
| `undici` (via `release-it`) | high | root override `^7.28.0` |
| `cookie` (via `@sveltejs/kit`, `adapter-node`) | low | root override `^0.7.2` |
| `postcss` (via `next`) | moderate | root override `^8.5.10` |

Used `overrides` rather than `npm audit fix --force`, which proposed bogus **downgrades** (`next@9.3.3`, `@sveltejs/kit@0.0.30`, `release-it@19.2.4`). All affected direct deps are already at their latest, so the fix is to pin the vulnerable transitive leaf forward.

### Deferred (12 remaining, all major bumps)

- **electron 35 -> 42** (1 high) - devDependency of `packages/electron` only.
- **react-native 0.79 -> 0.86** (10 moderate) - pulls the metro / babel-jest / cosmiconfig / js-yaml dev-toolchain cluster; only fixable by the RN major.
- **esbuild 0.27.7** (1 low) - Windows-only dev-server file read; fix is 0.28.1 but `vite@7` pins `^0.27.0`, so forcing it risks breaking vite.

None of the deferred items touch shipped `dist` - all dev / build / playground deps.

## Test plan

- [x] `npm run build` clean
- [x] `npm run typescript` clean (0 errors)
- [x] Full-repo `npm run test` passing