### PR TITLE
feat(react-native-sourcemaps): sourcemap upload — CLI, bare native hooks, and Expo config plugin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,27 +25,28 @@ integrations for React, Vue, and Svelte, and a Vite plugin for sourcemap uploads
 npm workspaces monorepo with 9 published packages, 1 internal package, 4 framework playground apps, a shared fixture
 package, and a Playwright-based e2e suite:
 
-| Package                 | npm name                       | Purpose                                                                                        |
-| ----------------------- | ------------------------------ | ---------------------------------------------------------------------------------------------- |
-| `packages/core`         | `@flareapp/core`               | Environment-agnostic Flare core (shared between js + node)                                     |
-| `packages/js`           | `@flareapp/js`                 | Core client — error capture, stack traces, context, API reporting                              |
-| `packages/react`        | `@flareapp/react`              | React `FlareErrorBoundary` error boundary component; `/inject` entry for Electron renderers    |
-| `packages/vue`          | `@flareapp/vue`                | Vue error handler plugin (`flareVue()`); `/inject` entry for Electron renderers                |
-| `packages/svelte`       | `@flareapp/svelte`             | Svelte 5 `FlareErrorBoundary` with props serialization; `/inject` entry for Electron renderers |
-| `packages/sveltekit`    | `@flareapp/sveltekit`          | SvelteKit error hooks (`handleErrorWithFlare`) + route context                                 |
-| `packages/vite`         | `@flareapp/vite`               | Vite build plugin for sourcemap upload with retry logic                                        |
-| `packages/webpack`      | `@flareapp/webpack`            | Webpack 5 plugin for sourcemap upload                                                          |
-| `packages/nextjs`       | `@flareapp/nextjs`             | Next.js wrapper (`withFlareSourcemaps`) for sourcemap upload                                   |
-| `packages/node`         | `@flareapp/node`               | Node.js SDK (process handlers, AsyncLocalStorage scope)                                        |
-| `packages/react-native` | `@flareapp/react-native`       | React Native SDK (pure-JS, Expo + bare; ErrorUtils + boundary capture)                         |
-| `packages/electron`     | `@flareapp/electron`           | Electron SDK (main + preload + renderer, IPC-unified)                                          |
-| `packages/flare-api`    | `@flareapp/flare-api`          | Shared API client for sourcemap uploads (private, not published)                               |
-| `playgrounds/shared`    | `@flareapp/playgrounds-shared` | Shared TS fixtures: products, scenarios, testIds, Tailwind tokens                              |
-| `playgrounds/js`        | `@flareapp/playgrounds-js`     | Vanilla TS + Vite webshop (port 5180)                                                          |
-| `playgrounds/react`     | `@flareapp/playgrounds-react`  | React 19 + TanStack Router webshop (port 5181)                                                 |
-| `playgrounds/vue`       | `@flareapp/playgrounds-vue`    | Vue 3 + vue-router webshop (port 5182)                                                         |
-| `playgrounds/svelte`    | `@flareapp/playgrounds-svelte` | SvelteKit (adapter-node) webshop (port 5183)                                                   |
-| `e2e/`                  | (not a workspace)              | Playwright specs + fake-flare-server fixture                                                   |
+| Package                            | npm name                            | Purpose                                                                                        |
+| ---------------------------------- | ----------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `packages/core`                    | `@flareapp/core`                    | Environment-agnostic Flare core (shared between js + node)                                     |
+| `packages/js`                      | `@flareapp/js`                      | Core client — error capture, stack traces, context, API reporting                              |
+| `packages/react`                   | `@flareapp/react`                   | React `FlareErrorBoundary` error boundary component; `/inject` entry for Electron renderers    |
+| `packages/vue`                     | `@flareapp/vue`                     | Vue error handler plugin (`flareVue()`); `/inject` entry for Electron renderers                |
+| `packages/svelte`                  | `@flareapp/svelte`                  | Svelte 5 `FlareErrorBoundary` with props serialization; `/inject` entry for Electron renderers |
+| `packages/sveltekit`               | `@flareapp/sveltekit`               | SvelteKit error hooks (`handleErrorWithFlare`) + route context                                 |
+| `packages/vite`                    | `@flareapp/vite`                    | Vite build plugin for sourcemap upload with retry logic                                        |
+| `packages/webpack`                 | `@flareapp/webpack`                 | Webpack 5 plugin for sourcemap upload                                                          |
+| `packages/nextjs`                  | `@flareapp/nextjs`                  | Next.js wrapper (`withFlareSourcemaps`) for sourcemap upload                                   |
+| `packages/node`                    | `@flareapp/node`                    | Node.js SDK (process handlers, AsyncLocalStorage scope)                                        |
+| `packages/react-native`            | `@flareapp/react-native`            | React Native SDK (pure-JS, Expo + bare; ErrorUtils + boundary capture)                         |
+| `packages/react-native-sourcemaps` | `@flareapp/react-native-sourcemaps` | RN/Metro sourcemap upload: Babel version inlining + `flare-rn-sourcemaps` upload CLI           |
+| `packages/electron`                | `@flareapp/electron`                | Electron SDK (main + preload + renderer, IPC-unified)                                          |
+| `packages/flare-api`               | `@flareapp/flare-api`               | Shared API client for sourcemap uploads (private, not published)                               |
+| `playgrounds/shared`               | `@flareapp/playgrounds-shared`      | Shared TS fixtures: products, scenarios, testIds, Tailwind tokens                              |
+| `playgrounds/js`                   | `@flareapp/playgrounds-js`          | Vanilla TS + Vite webshop (port 5180)                                                          |
+| `playgrounds/react`                | `@flareapp/playgrounds-react`       | React 19 + TanStack Router webshop (port 5181)                                                 |
+| `playgrounds/vue`                  | `@flareapp/playgrounds-vue`         | Vue 3 + vue-router webshop (port 5182)                                                         |
+| `playgrounds/svelte`               | `@flareapp/playgrounds-svelte`      | SvelteKit (adapter-node) webshop (port 5183)                                                   |
+| `e2e/`                             | (not a workspace)                   | Playwright specs + fake-flare-server fixture                                                   |
 
 ## Tech stack
 

--- a/docs/superpowers/specs/2026-06-24-react-native-sourcemaps-design.md
+++ b/docs/superpowers/specs/2026-06-24-react-native-sourcemaps-design.md
@@ -34,22 +34,28 @@ client handoff. Three facts drive the whole design:
   backend work, so it is **out of scope**. We use the version model.
 
 - **The version must be fixed before the bundle is built.** It has to be baked into
-  the bundle's runtime config *and* used at upload. The CLI therefore cannot
+  the bundle's runtime config _and_ used at upload. The CLI therefore cannot
   generate a fresh version at upload time (the shipped bundle would not carry it).
   The version is an input to both halves, never an output of either.
 
-- **Metro does not inline arbitrary `process.env.X`.** Bare RN only exposes
-  `__DEV__`/`NODE_ENV`; Expo additionally inlines `EXPO_PUBLIC_*`. So a plain
-  `process.env.FLARE_SOURCEMAP_VERSION` is `undefined` at runtime in a bare app
-  unless a transform replaces it. This is why the Babel plugin exists (the same
-  reason Sentry ships one).
+- **The version must be inlined at bundle time, and `process.env` is the wrong
+  channel.** Metro does not inline arbitrary `process.env.X` (bare RN only exposes
+  `__DEV__`/`NODE_ENV`; Expo adds `EXPO_PUBLIC_*`), so a build-time transform is
+  needed either way — this is why the Babel plugin exists (the same reason Sentry
+  ships one). The original plan used `process.env.FLARE_SOURCEMAP_VERSION` as the
+  inlined token, but verification on a bare RN app showed that is a real DX wart:
+  bare RN does not type `process` (it requires `@types/node`, which wrongly drags
+  Node globals into an RN app), and `process.env.X` _looks_ like a runtime env read
+  when it is actually build-time-substituted. So the plugin instead inlines a
+  **typed import** the app reads as a normal `string` (see Babel plugin below).
 
 The runtime config surface already exists: core's public
 `configure(config: Partial<Config>)` (`packages/core/src/Flare.ts:259`) accepts
 `sourcemapVersionId`, so app code does:
 
-```js
-flare.light(KEY).configure({ sourcemapVersionId: process.env.FLARE_SOURCEMAP_VERSION });
+```ts
+import { flareSourcemapVersion } from '@flareapp/react-native-sourcemaps/runtime';
+flare.light(KEY).configure({ sourcemapVersionId: flareSourcemapVersion });
 ```
 
 ## Why a separate package (not folded into `@flareapp/react-native`)
@@ -72,6 +78,7 @@ packages/react-native-sourcemaps/
   src/
     version.ts            # resolveVersion() — shared by babel + cli
     babel.ts              # the version-inlining Babel plugin
+    runtime.ts            # RN-safe: `export const flareSourcemapVersion = ''` (./runtime)
     uploadSourcemaps.ts   # core upload logic (no process.argv; testable)
     cli.ts                # bin entry: arg parse -> uploadSourcemaps()
     types.ts
@@ -89,8 +96,9 @@ packages/react-native-sourcemaps/
 
 - `"bin": { "flare-rn-sourcemaps": "./dist/cli.cjs" }`
 - `"exports"`: `"."` (programmatic API), `"./babel"` (Babel plugin),
-  `"./expo"` (config plugin), `"./package.json"`, and the raw `flare.gradle` /
-  `scripts/flare-xcode.sh` shipped via `"files"`.
+  `"./runtime"` (the RN-safe `flareSourcemapVersion` const, the only entry app code
+  imports), `"./expo"` (config plugin), `"./package.json"`, and the raw
+  `flare.gradle` / `scripts/flare-xcode.sh` shipped via `"files"`.
 - `"files"` must include `dist`, `flare.gradle`, `scripts/`, `app.plugin.js`.
 - depends on `@flareapp/flare-api`; dev/peer dep on `@babel/core` for the plugin.
 - Built with tsdown (CJS + ESM + d.ts), matching the other build-time packages.
@@ -125,16 +133,26 @@ Added to `babel.config.js`:
 module.exports = { plugins: ['@flareapp/react-native-sourcemaps/babel'] };
 ```
 
-At bundle time it replaces the member expression `process.env.FLARE_SOURCEMAP_VERSION`
-with the resolved version as a string literal. Chosen over a magic global because it
-needs no ambient TypeScript declaration and Expo's own inliner ignores
-non-`EXPO_PUBLIC_` names, so there is no collision. The plugin owns that token.
+At bundle time the plugin finds `import { flareSourcemapVersion } from
+'@flareapp/react-native-sourcemaps/runtime'`, replaces every reference to that binding
+with the resolved version string literal, and removes the now-dead import (so nothing
+of this package ships in the app bundle). It resolves the version once per file
+(lazily, only when the import is present) via the shared `resolveVersion()`, and a
+`pre()` hook resets that per-file cache since Babel reuses plugin instances across
+files.
 
-Plugin ordering: the default bare-RN preset and Expo preset do not inline arbitrary
-`process.env` reads, so in a stock setup ordering is moot. If a project adds a generic
-`process.env` transform (e.g. `babel-plugin-transform-inline-environment-variables`),
-this plugin must run before it, otherwise the token is rewritten or stripped before we
-see it. The README states this caveat.
+Why a typed import rather than `process.env.FLARE_SOURCEMAP_VERSION` (the original
+plan): the import is a normal typed `string`, so app authors need no `process` global,
+no `@types/node`, and no ambient declaration, and there is no "looks like a runtime env
+var but isn't" confusion. The `/runtime` entry is RN-safe (no Node imports) so it is
+safe in Metro's graph; without the plugin it is the empty-string default, which is
+harmless because maps are only uploaded for release builds. This mirrors the
+ecosystem norm for build constants (e.g. expo-updates' `Updates.runtimeVersion`)
+rather than `process.env`.
+
+Plugin ordering: matching a named import is robust against other `process.env`
+transforms, so ordering is not a concern in a stock setup. The aliased form
+(`import { flareSourcemapVersion as v }`) is handled.
 
 ### 3. CLI (`cli.ts` + `uploadSourcemaps.ts`)
 
@@ -184,7 +202,7 @@ unset, so the inlined value and the uploaded `version_id` cannot silently diverg
 
 ### 5. iOS — `scripts/flare-xcode.sh`
 
-The user repoints the *"Bundle React Native code and images"* build phase from
+The user repoints the _"Bundle React Native code and images"_ build phase from
 `react-native-xcode.sh` to `flare-xcode.sh` (documented, manual; committed once):
 
 ```sh
@@ -232,7 +250,7 @@ are folded into the single required implementation checkpoint below.
 
 **1. Hermes-composed map.** RN release builds default to Hermes, which compiles the JS
 bundle to bytecode. Production stack frames are positions in that bytecode, so the map
-that actually symbolicates is the *composed* map (the Metro JS->source map composed
+that actually symbolicates is the _composed_ map (the Metro JS->source map composed
 with the Hermes bytecode->JS map, via `compose-source-maps`). Uploading the plain
 Metro JS map instead yields wrong lines or no match at all. We do not run the
 composition ourselves (out of scope below); we consume the build's composed output.
@@ -278,8 +296,10 @@ assumption.
 - Matching model: **version-based** (not Debug ID). [backend constraint]
 - Package: **separate `@flareapp/react-native-sourcemaps`**, not folded into the
   runtime SDK. [packaging hygiene]
-- Version injection: **Babel plugin** inlining `process.env.FLARE_SOURCEMAP_VERSION`,
-  shared `resolveVersion()` with env-var single channel. [Approach 2]
+- Version injection: **Babel plugin** inlining a typed `flareSourcemapVersion` import
+  from `./runtime` (revised from `process.env.FLARE_SOURCEMAP_VERSION` after the bare-RN
+  verification showed `process` is untyped and the channel is misleading), shared
+  `resolveVersion()` with `FLARE_SOURCEMAP_VERSION` env-var single channel. [Approach 2]
 - Native wiring: **Sentry-parity** — Android Gradle one-liner + iOS build-phase
   script + Expo config plugin. [option 2]
 - Name: **`...-sourcemaps`**, not `...-metro` (carries Gradle/Xcode, not just Metro).

--- a/docs/superpowers/specs/2026-06-24-react-native-sourcemaps-design.md
+++ b/docs/superpowers/specs/2026-06-24-react-native-sourcemaps-design.md
@@ -107,6 +107,16 @@ Babel plugin and the CLI, so they cannot disagree. Precedence:
 Never a random UUID as a fallback — a random default would silently desync the two
 halves. The env var is the recommended single channel for CI/native builds.
 
+The `package.json` fallback is a convenience for the manual flow, but it carries the
+same desync hazard in a quieter form: if `FLARE_SOURCEMAP_VERSION` is set when the
+bundle is built but absent when the CLI later uploads (or vice versa), one half
+resolves to the real version and the other silently falls back to the `package.json`
+version. They mismatch, symbolication fails, and the only signal is a `console.warn`.
+The fallback is therefore safe only when both halves resolve it identically. The
+automatic native wiring (Android/iOS/Expo) must NOT rely on the fallback: it requires
+`FLARE_SOURCEMAP_VERSION` to be set and fails the build when it is absent, so a desync
+surfaces as a hard error rather than a broken-but-green release.
+
 ### 2. Babel plugin (`babel.ts`, exposed as `@flareapp/react-native-sourcemaps/babel`)
 
 Added to `babel.config.js`:
@@ -119,6 +129,12 @@ At bundle time it replaces the member expression `process.env.FLARE_SOURCEMAP_VE
 with the resolved version as a string literal. Chosen over a magic global because it
 needs no ambient TypeScript declaration and Expo's own inliner ignores
 non-`EXPO_PUBLIC_` names, so there is no collision. The plugin owns that token.
+
+Plugin ordering: the default bare-RN preset and Expo preset do not inline arbitrary
+`process.env` reads, so in a stock setup ordering is moot. If a project adds a generic
+`process.env` transform (e.g. `babel-plugin-transform-inline-environment-variables`),
+this plugin must run before it, otherwise the token is rewritten or stripped before we
+see it. The README states this caveat.
 
 ### 3. CLI (`cli.ts` + `uploadSourcemaps.ts`)
 
@@ -162,8 +178,9 @@ In `project.afterEvaluate`, for each build variant the script:
 
 This mirrors Sentry's `sentry.gradle.kts` flow minus the Debug ID copy step.
 `FLARE_SOURCEMAP_VERSION` must be present in the build environment so the Babel plugin
-inlines the same value the upload uses; the Gradle script propagates/forwards it to
-the CLI invocation.
+inlines the same value the upload uses; the Gradle script forwards it to the CLI
+invocation and fails the build (rather than falling back to `package.json`) when it is
+unset, so the inlined value and the uploaded `version_id` cannot silently diverge.
 
 ### 5. iOS — `scripts/flare-xcode.sh`
 
@@ -180,7 +197,9 @@ FLARE_XCODE="../node_modules/@flareapp/react-native-sourcemaps/scripts/flare-xco
 `flare-xcode.sh` runs the normal `react-native-xcode.sh` (producing bundle + map),
 then runs the CLI upload against the produced map. Env (`FLARE_API_KEY`,
 `FLARE_SOURCEMAP_VERSION`, `FLARE_DISABLE_AUTO_UPLOAD`) comes from `.xcode.env` or the
-build phase. No pbxproj codemod ships in v1 — this is the one genuinely manual step.
+build phase. Like the Gradle path, it requires `FLARE_SOURCEMAP_VERSION` and errors
+when it is unset rather than falling back, so the inlined and uploaded versions stay
+in lockstep. No pbxproj codemod ships in v1 — this is the one genuinely manual step.
 
 ### 6. Expo — config plugin (`expo/index.ts`, `withFlareSourcemaps`)
 
@@ -202,19 +221,36 @@ maps emitted into `dist/`.
 - `FLARE_DISABLE_AUTO_UPLOAD=true` opts out of the native auto-upload.
 - Upload runs only for release / non-dev builds.
 - Missing API key warns and no-ops (consistent with vite/webpack/nextjs).
+- The native auto-wiring requires `FLARE_SOURCEMAP_VERSION` and fails the build when it
+  is unset (no `package.json` fallback in the automatic path), so the inlined runtime
+  version and the uploaded `version_id` cannot silently diverge.
 
-## Open risk: `relative_filename` matching
+## Open risks: map composition and `relative_filename` matching
 
-The backend matches a map to a stack frame by `relative_filename` (suffix) +
-`version_id`. What an RN **production** stack frame's `fileName` actually is
-(`index.android.bundle`? a full APK path? `main.jsbundle` / `index.bundle` on iOS?)
-is **not yet verified** against a live Flare report or the backend matcher. Therefore:
+Two things are unverified until a real release build is symbolicated end to end. Both
+are folded into the single required implementation checkpoint below.
 
-- `--bundle-filename` is a required, configurable flag (native wiring defaults it to
-  the bundle asset name the build emits).
-- **End-to-end symbolication of a real release build is a required implementation
-  checkpoint**, not an assumption. If matching needs a different value, this flag is
-  the adaptation point.
+**1. Hermes-composed map.** RN release builds default to Hermes, which compiles the JS
+bundle to bytecode. Production stack frames are positions in that bytecode, so the map
+that actually symbolicates is the *composed* map (the Metro JS->source map composed
+with the Hermes bytecode->JS map, via `compose-source-maps`). Uploading the plain
+Metro JS map instead yields wrong lines or no match at all. We do not run the
+composition ourselves (out of scope below); we consume the build's composed output.
+The checkpoint must confirm the map handed to `--sourcemap` is the Hermes-composed
+one, not the intermediate Metro map. This is the more common RN symbolication pitfall
+and matters more than the filename.
+
+**2. `relative_filename` matching.** The backend matches a map to a stack frame by
+`relative_filename` (suffix) + `version_id`. What an RN **production** stack frame's
+`fileName` actually is (`index.android.bundle`? a full APK path? `main.jsbundle` /
+`index.bundle` on iOS?) is **not yet verified** against a live Flare report or the
+backend matcher. So `--bundle-filename` is a required, configurable flag (native wiring
+defaults it to the bundle asset name the build emits); if matching needs a different
+value, this flag is the adaptation point.
+
+**End-to-end symbolication of a real release build is a required implementation
+checkpoint** covering both the composed-map and the filename questions, not an
+assumption.
 
 ## Testing
 
@@ -253,5 +289,6 @@ is **not yet verified** against a live Flare report or the backend matcher. Ther
 
 - Bare-RN codemod wizard (`flare-rn-sourcemaps init`) if manual setup proves painful.
 - Debug ID support (gated on Flare backend).
-- Verify and, if needed, document per-platform `relative_filename` once real-build
+- Verify the Hermes-composed map (not the intermediate Metro map) is what gets
+  uploaded, and verify/document per-platform `relative_filename`, once real-build
   symbolication is exercised.

--- a/docs/superpowers/specs/2026-06-24-react-native-sourcemaps-design.md
+++ b/docs/superpowers/specs/2026-06-24-react-native-sourcemaps-design.md
@@ -1,0 +1,257 @@
+# `@flareapp/react-native-sourcemaps` — design
+
+Date: 2026-06-24
+Status: approved for planning
+Author: brainstorm session (Dries + Claude)
+
+## Summary
+
+A new build-time package, `@flareapp/react-native-sourcemaps`, that uploads React
+Native JavaScript sourcemaps to Flare and gets a matching version into the running
+app so reports symbolicate. It pairs three pieces:
+
+1. a **Babel plugin** that inlines a build-time `version` into the app bundle,
+2. a **CLI** (`flare-rn-sourcemaps upload`) that uploads a `.map` under that same
+   version, and
+3. **native build wiring** (an Android Gradle script + an iOS build-phase shell
+   script + an Expo config plugin) so the upload runs automatically as part of a
+   release build.
+
+It reuses the shared `@flareapp/flare-api` client (same uploader, retry logic, and
+payload as the vite/webpack/nextjs plugins). It is never imported into the running
+app; only `@flareapp/react-native` runs there.
+
+## Background and constraints
+
+This is the "Metro sourcemap-upload package" follow-up named in the React Native
+client handoff. Three facts drive the whole design:
+
+- **Flare matches sourcemaps by version, not Debug ID.** The client reports
+  `sourcemapVersionId` (`packages/core/src/Flare.ts:564`) and the uploader sends a
+  matching `version_id` + `relative_filename` (`packages/flare-api/src/FlareApi.ts:26`).
+  The backend has no Debug ID concept. Sentry's Debug ID model (a GUID baked into
+  both bundle and map, matched without a release string) is more robust but needs
+  backend work, so it is **out of scope**. We use the version model.
+
+- **The version must be fixed before the bundle is built.** It has to be baked into
+  the bundle's runtime config *and* used at upload. The CLI therefore cannot
+  generate a fresh version at upload time (the shipped bundle would not carry it).
+  The version is an input to both halves, never an output of either.
+
+- **Metro does not inline arbitrary `process.env.X`.** Bare RN only exposes
+  `__DEV__`/`NODE_ENV`; Expo additionally inlines `EXPO_PUBLIC_*`. So a plain
+  `process.env.FLARE_SOURCEMAP_VERSION` is `undefined` at runtime in a bare app
+  unless a transform replaces it. This is why the Babel plugin exists (the same
+  reason Sentry ships one).
+
+The runtime config surface already exists: core's public
+`configure(config: Partial<Config>)` (`packages/core/src/Flare.ts:259`) accepts
+`sourcemapVersionId`, so app code does:
+
+```js
+flare.light(KEY).configure({ sourcemapVersionId: process.env.FLARE_SOURCEMAP_VERSION });
+```
+
+## Why a separate package (not folded into `@flareapp/react-native`)
+
+`@flareapp/react-native` is the runtime SDK; it loads inside Hermes/JSC and has a
+fragile packaging contract (the `react-native` export condition that dodges
+`node:module`). A sourcemap uploader is the opposite: a build-time Node tool needing
+`node:fs`/`node:zlib` (via `@flareapp/flare-api`) and arg parsing. Folding Node build
+tooling into the runtime package invites Metro to resolve `node:*`, bloats the app
+install, and blurs the package's purpose. Every other sourcemap tool in this repo is
+its own package (`@flareapp/vite`, `@flareapp/webpack`, `@flareapp/nextjs`), all
+depending on `@flareapp/flare-api`. This follows that precedent.
+
+## Components
+
+### Package layout
+
+```
+packages/react-native-sourcemaps/
+  src/
+    version.ts            # resolveVersion() — shared by babel + cli
+    babel.ts              # the version-inlining Babel plugin
+    uploadSourcemaps.ts   # core upload logic (no process.argv; testable)
+    cli.ts                # bin entry: arg parse -> uploadSourcemaps()
+    types.ts
+    index.ts              # programmatic API + types
+  expo/
+    index.ts              # Expo config plugin (withFlareSourcemaps)
+  flare.gradle            # Android: applied from android/app/build.gradle
+  scripts/
+    flare-xcode.sh        # iOS: wraps react-native-xcode.sh then uploads
+  app.plugin.js           # Expo entry pointer -> ./expo
+  package.json
+```
+
+`package.json` highlights:
+
+- `"bin": { "flare-rn-sourcemaps": "./dist/cli.cjs" }`
+- `"exports"`: `"."` (programmatic API), `"./babel"` (Babel plugin),
+  `"./expo"` (config plugin), `"./package.json"`, and the raw `flare.gradle` /
+  `scripts/flare-xcode.sh` shipped via `"files"`.
+- `"files"` must include `dist`, `flare.gradle`, `scripts/`, `app.plugin.js`.
+- depends on `@flareapp/flare-api`; dev/peer dep on `@babel/core` for the plugin.
+- Built with tsdown (CJS + ESM + d.ts), matching the other build-time packages.
+
+### 1. Version resolution (`version.ts`)
+
+A single `resolveVersion(opts?: { version?: string }): string` used by **both** the
+Babel plugin and the CLI, so they cannot disagree. Precedence:
+
+1. explicit `--version` flag / plugin option,
+2. `FLARE_SOURCEMAP_VERSION` env var,
+3. fallback: the app's `package.json` `version`, with a warning logged.
+
+Never a random UUID as a fallback — a random default would silently desync the two
+halves. The env var is the recommended single channel for CI/native builds.
+
+### 2. Babel plugin (`babel.ts`, exposed as `@flareapp/react-native-sourcemaps/babel`)
+
+Added to `babel.config.js`:
+
+```js
+module.exports = { plugins: ['@flareapp/react-native-sourcemaps/babel'] };
+```
+
+At bundle time it replaces the member expression `process.env.FLARE_SOURCEMAP_VERSION`
+with the resolved version as a string literal. Chosen over a magic global because it
+needs no ambient TypeScript declaration and Expo's own inliner ignores
+non-`EXPO_PUBLIC_` names, so there is no collision. The plugin owns that token.
+
+### 3. CLI (`cli.ts` + `uploadSourcemaps.ts`)
+
+```
+npx flare-rn-sourcemaps upload \
+  --api-key <key> \
+  --sourcemap <path/to.bundle.map> \
+  --bundle-filename <index.android.bundle> \
+  [--version <v>] \
+  [--api-endpoint <url>] \
+  [--strip-prefix <path>]
+```
+
+`uploadSourcemaps(opts)` reads the `.map`, builds a
+`Sourcemap { originalFile, content }`, and calls `FlareApi.uploadSourcemap` under the
+resolved `version_id`. Flare's upload payload needs only `relative_filename` +
+sourcemap content (`FlareApi.ts:26-27`), **not** the bundle bytes — so, unlike
+`sentry-cli`, the CLI does not ingest the bundle file. `cli.ts` only parses
+`process.argv` and delegates; all logic lives in the testable `uploadSourcemaps`.
+
+API-key handling mirrors the other plugins: missing key warns and no-ops rather than
+throwing.
+
+### 4. Android — `flare.gradle`
+
+User adds one line to `android/app/build.gradle` (and commits it):
+
+```groovy
+apply from: "../../node_modules/@flareapp/react-native-sourcemaps/flare.gradle"
+```
+
+In `project.afterEvaluate`, for each build variant the script:
+
+1. finds the RN bundle task `bundle{Variant}JsAndAssets`,
+2. reads that task's `bundleOutput` / `sourcemapOutput`; if the app did not set a
+   sourcemap output, forces one (`bundleOutput + ".map"`) so there is a map to
+   upload,
+3. registers an upload task wired via `bundleTask.finalizedBy(uploadTask)` that calls
+   the CLI with the bundle's own paths, `--bundle-filename` = the bundle asset name,
+   and the resolved version.
+
+This mirrors Sentry's `sentry.gradle.kts` flow minus the Debug ID copy step.
+`FLARE_SOURCEMAP_VERSION` must be present in the build environment so the Babel plugin
+inlines the same value the upload uses; the Gradle script propagates/forwards it to
+the CLI invocation.
+
+### 5. iOS — `scripts/flare-xcode.sh`
+
+The user repoints the *"Bundle React Native code and images"* build phase from
+`react-native-xcode.sh` to `flare-xcode.sh` (documented, manual; committed once):
+
+```sh
+set -e
+WITH_ENVIRONMENT="../node_modules/react-native/scripts/xcode/with-environment.sh"
+FLARE_XCODE="../node_modules/@flareapp/react-native-sourcemaps/scripts/flare-xcode.sh"
+/bin/sh -c "$WITH_ENVIRONMENT $FLARE_XCODE"
+```
+
+`flare-xcode.sh` runs the normal `react-native-xcode.sh` (producing bundle + map),
+then runs the CLI upload against the produced map. Env (`FLARE_API_KEY`,
+`FLARE_SOURCEMAP_VERSION`, `FLARE_DISABLE_AUTO_UPLOAD`) comes from `.xcode.env` or the
+build phase. No pbxproj codemod ships in v1 — this is the one genuinely manual step.
+
+### 6. Expo — config plugin (`expo/index.ts`, `withFlareSourcemaps`)
+
+For Expo (and EAS) users, a config plugin in `app.json` / `app.config.js`:
+
+```js
+{ "plugins": [["@flareapp/react-native-sourcemaps/expo", { /* options */ }]] }
+```
+
+At `expo prebuild` it code-mods the generated native projects: applies the Gradle
+script in `app/build.gradle` and repoints the iOS bundle build phase at
+`flare-xcode.sh`. Idempotent because prebuild regenerates the native dirs. These
+mods are unit-testable (as Sentry's `modify*` plugin tests are). For the
+managed/`expo export` flow that does not run a native build, the same CLI uploads the
+maps emitted into `dist/`.
+
+## Controls and safety
+
+- `FLARE_DISABLE_AUTO_UPLOAD=true` opts out of the native auto-upload.
+- Upload runs only for release / non-dev builds.
+- Missing API key warns and no-ops (consistent with vite/webpack/nextjs).
+
+## Open risk: `relative_filename` matching
+
+The backend matches a map to a stack frame by `relative_filename` (suffix) +
+`version_id`. What an RN **production** stack frame's `fileName` actually is
+(`index.android.bundle`? a full APK path? `main.jsbundle` / `index.bundle` on iOS?)
+is **not yet verified** against a live Flare report or the backend matcher. Therefore:
+
+- `--bundle-filename` is a required, configurable flag (native wiring defaults it to
+  the bundle asset name the build emits).
+- **End-to-end symbolication of a real release build is a required implementation
+  checkpoint**, not an assumption. If matching needs a different value, this flag is
+  the adaptation point.
+
+## Testing
+
+- **Fully unit-tested (Vitest, package-local):** `resolveVersion()` precedence; the
+  Babel transform (input source -> inlined literal) via `@babel/core` `transform`;
+  `uploadSourcemaps` against the shared `FakeApi`; the Expo config-plugin mods
+  (Gradle-apply insertion + Xcode-phase repoint) against fixture project files.
+- **Not unit-testable in this JS monorepo:** `flare.gradle` and `flare-xcode.sh`.
+  These are validated by a **manual smoke build** on a sample bare-RN app (iOS +
+  Android release), the same way the RN client itself was smoke-tested. The plan and
+  docs state this plainly rather than imply coverage we do not have.
+
+## Out of scope
+
+- **Debug IDs** (needs Flare backend work; a separate initiative).
+- **Owning bundle / Hermes compilation.** We consume the native build's outputs
+  (composed `.map`); we do not run `react-native bundle`, `hermesc`, or
+  `compose-source-maps`.
+- **A bare-RN codemod wizard** (pbxproj patching). Manual docs cover bare-RN iOS;
+  a wizard is a clean follow-up if demand appears.
+- **Auto-injecting the `configure({ sourcemapVersionId })` call** into app code.
+
+## Decisions captured
+
+- Matching model: **version-based** (not Debug ID). [backend constraint]
+- Package: **separate `@flareapp/react-native-sourcemaps`**, not folded into the
+  runtime SDK. [packaging hygiene]
+- Version injection: **Babel plugin** inlining `process.env.FLARE_SOURCEMAP_VERSION`,
+  shared `resolveVersion()` with env-var single channel. [Approach 2]
+- Native wiring: **Sentry-parity** — Android Gradle one-liner + iOS build-phase
+  script + Expo config plugin. [option 2]
+- Name: **`...-sourcemaps`**, not `...-metro` (carries Gradle/Xcode, not just Metro).
+- iOS bare-RN injection: **manual docs**, no postinstall, no v1 codemod wizard.
+
+## Follow-ups (own specs/PRs)
+
+- Bare-RN codemod wizard (`flare-rn-sourcemaps init`) if manual setup proves painful.
+- Debug ID support (gated on Flare backend).
+- Verify and, if needed, document per-platform `relative_filename` once real-build
+  symbolication is exercised.

--- a/docs/superpowers/specs/2026-06-25-rn-bare-sourcemap-auto-upload-design.md
+++ b/docs/superpowers/specs/2026-06-25-rn-bare-sourcemap-auto-upload-design.md
@@ -33,7 +33,11 @@ package**. No new npm package.
   `2026-06-24` design listed; it is redundant given how small the wiring is.
 - No JSC-specific handling. Hermes is the RN default; a JSC build still produces a
   plain `.map` the same hooks upload, just without special treatment.
-- No Debug-build uploads. Release variants/configurations only.
+- No Debug-build uploads. The hooks skip **debug** builds (matched case-insensitively
+  as a substring) and otherwise upload whenever a composed sourcemap was produced —
+  configuration-name-agnostic, so renamed/custom release configs (Staging, Production,
+  AppStore, custom Android build types) are covered. Gating on the artifact, not a
+  literal `Release` name, is what makes bare/brownfield projects work.
 
 ## Configuration — `flare.json`
 
@@ -156,7 +160,10 @@ apply from: "../../node_modules/@flareapp/react-native-sourcemaps/flare.gradle"
   bare `flare-rn-sourcemaps` is not on `PATH` inside a Gradle `exec`:
   `npx flare-rn-sourcemaps upload --sourcemap <map> --config "$rootDir/flare.json"
 --auto`.
-- Is guarded to release variants only; debug builds do nothing.
+- Skips only `*debug*` (case-insensitive) variants; for every other variant it relies
+  on the "no sourcemap -> skip" guard, so renamed/custom release build types still
+  upload. The fallback map path derives the variant subdir from the task name (not a
+  hardcoded `release/`).
 
 The exact task-graph wiring (variant iteration, task-name resolution across RN
 Gradle Plugin versions) is to be confirmed during implementation research against
@@ -195,7 +202,9 @@ We get that without touching RN's stock build phase. Two documented manual edits
 
 `flare-xcode.sh`:
 
-- Guards on `CONFIGURATION == Release` (no-op otherwise).
+- Skips only when `$CONFIGURATION` contains `debug` (case-insensitive, via `tr` +
+  `case` — POSIX, no bashisms). For every other configuration name it falls through to
+  the sourcemap-existence check below, so renamed/custom release configs upload.
 - Resolves the map path. Prefer `$SOURCEMAP_FILE` (present now that the phase is
   wrapped in `with-environment.sh`); if it is unset, reconstruct
   `$CONFIGURATION_BUILD_DIR/main.jsbundle.map` (Xcode build settings like

--- a/docs/superpowers/specs/2026-06-25-rn-bare-sourcemap-auto-upload-design.md
+++ b/docs/superpowers/specs/2026-06-25-rn-bare-sourcemap-auto-upload-design.md
@@ -1,0 +1,190 @@
+# Bare React Native automatic sourcemap upload — design
+
+Date: 2026-06-25
+Package: `@flareapp/react-native-sourcemaps`
+Status: approved, ready for implementation planning
+
+## Goal
+
+Make a **bare** React Native release build upload its composed Hermes sourcemap to
+Flare automatically, as part of the native build, with no manual CLI step. This is
+"Plan 2 — native auto-wiring" deferred from the original RN sourcemaps work
+(`2026-06-24-react-native-sourcemaps-design.md`). The JS core it builds on — the
+`flare-rn-sourcemaps upload` CLI, `uploadSourcemaps()`, `resolveVersion()`, and the
+babel version-inlining plugin — already shipped (PR #66) and is verified end-to-end
+on Android/iOS/Expo.
+
+This spec covers **bare RN only** (Android + iOS). The Expo config plugin for CNG
+mode is a **separate, later spec** that injects these same hooks at prebuild; it is
+explicitly out of scope here. Building bare first gives that plugin concrete hooks
+to inject.
+
+All new artifacts ship **inside the existing `@flareapp/react-native-sourcemaps`
+package**. No new npm package.
+
+## Non-goals (YAGNI)
+
+- No automated installer that patches `build.gradle` / `.pbxproj`. Wiring is manual
+  and documented. (The Expo plugin is the automated-wiring story for CNG users.)
+- No `failBuild` strict mode. Uploads never fail the build (see Failure behaviour).
+- No JSC-specific handling. Hermes is the RN default; a JSC build still produces a
+  plain `.map` the same hooks upload, just without special treatment.
+- No Debug-build uploads. Release variants/configurations only.
+
+## Configuration — `flare.json`
+
+A committed JSON file at the project root, read by both platform hooks:
+
+```json
+{
+    "apiKey": "...",
+    "apiEndpoint": "https://flareapp.io/api/sourcemaps",
+    "version": "optional-explicit-version"
+}
+```
+
+The Flare project API key is already embedded in the shipped app for error
+reporting, so committing it here is not a meaningful secret leak.
+
+Per-field resolution, **env var wins**, then file, then default:
+
+| Field        | Env override              | `flare.json` key | Default                                 |
+| ------------ | ------------------------- | ---------------- | --------------------------------------- |
+| API key      | `FLARE_API_KEY`           | `apiKey`         | (none — skip upload with banner)        |
+| API endpoint | `FLARE_API_ENDPOINT`      | `apiEndpoint`    | `https://flareapp.io/api/sourcemaps`    |
+| Version      | `FLARE_SOURCEMAP_VERSION` | `version`        | `resolveVersion()` chain (package.json) |
+
+The env-first rule lets CI inject the key without editing files, while `flare.json`
+is the single committed source of truth the later Expo plugin will reuse.
+
+The `version` must match what the babel plugin inlined into the bundle
+(`flareSourcemapVersion`). Both sides flow through the same `resolveVersion()` chain
+(flag/`version` > `FLARE_SOURCEMAP_VERSION` > package.json `version`), and the babel
+transform and the native upload run inside the same build invocation, so they see
+the same env and the same package.json. This coupling is a correctness invariant:
+if they diverge, the backend version match fails and frames stay unresolved.
+
+## Android — `flare.gradle`
+
+Ship `flare.gradle` in the package. The user adds one line to
+`android/app/build.gradle`:
+
+```gradle
+apply from: "../../node_modules/@flareapp/react-native-sourcemaps/flare.gradle"
+```
+
+`flare.gradle`:
+
+- Hooks each **release** `bundle{Variant}JsAndAssets` task with a `doLast` action.
+- Resolves the composed map RN already generated at
+  `android/app/build/generated/sourcemaps/react/release/index.android.bundle.map`.
+- Reads `flare.json` / env (via the CLI's self-config — see Shared internals).
+- Shells out to `flare-rn-sourcemaps upload --sourcemap <map>
+--bundle-filename index.android.bundle`.
+- Is guarded to release variants only; debug builds do nothing.
+
+The exact task-graph wiring (variant iteration, task-name resolution across RN
+Gradle Plugin versions) is to be confirmed during implementation research against
+the bare playground.
+
+## iOS — `flare-xcode.sh` + `.xcode.env` (approach iOS-1)
+
+`react-native-xcode.sh` only emits a composed `.map` when `SOURCEMAP_FILE` is set.
+We get that without touching RN's stock build phase. Two documented manual edits:
+
+1. Add to `ios/.xcode.env` (committed — safe in bare RN; unlike CNG, native dirs are
+   not regenerated):
+
+    ```sh
+    export SOURCEMAP_FILE="$CONFIGURATION_BUILD_DIR/main.jsbundle.map"
+    ```
+
+    The stock "Bundle React Native code and images" phase now emits the map.
+
+2. Add a new "Upload Flare sourcemaps" build phase **after** the bundle phase,
+   running:
+
+    ```sh
+    ../node_modules/@flareapp/react-native-sourcemaps/scripts/flare-xcode.sh
+    ```
+
+`flare-xcode.sh`:
+
+- Guards on `CONFIGURATION == Release` (no-op otherwise).
+- Locates the map at the `SOURCEMAP_FILE` path the bundle phase just wrote.
+- Reads `flare.json` / env.
+- Calls `flare-rn-sourcemaps upload --sourcemap <map>
+--bundle-filename main.jsbundle`.
+
+The stock RN bundle phase is never modified, so RN upgrades that touch it don't
+break Flare (upgrade-safe).
+
+## Shared internals
+
+Both hooks ultimately invoke the same CLI / `uploadSourcemaps()` path already
+verified end-to-end. The one new shared piece is a small **`flare.json` reader**
+that merges env overrides over file values (precedence table above).
+
+The CLI (`flare-rn-sourcemaps upload`) gains an implicit "read `flare.json` if a flag
+is absent" behaviour so the hooks can call it with minimal flags and let it
+self-configure. Existing explicit flags keep working unchanged and still take
+precedence over `flare.json` (explicit flag > env > file > default). This keeps the
+manual/verification CLI flow from PR #66 fully backward compatible.
+
+## Failure behaviour & the banner
+
+Uploads **never fail the build**. On no-key or upload error (timeout, 5xx, missing
+map, etc.), print a multi-line boxed banner to stderr — deliberately large so it is
+not overlooked in a long CI log:
+
+```
+
+============================================================
+  FLARE SOURCEMAP UPLOAD FAILED
+  Reason: <message>
+  Your release will report minified stack traces until the
+  sourcemap is uploaded. Re-run manually:
+    npx flare-rn-sourcemaps upload --sourcemap <path> \
+      --bundle-filename <name> --api-key <key>
+============================================================
+
+```
+
+(blank line above and below the box.) Rationale: a transient upload failure should
+not block shipping a working app — only symbolication is delayed and is recoverable
+with a manual re-run. The no-key case especially must never break a build (e.g. a
+contributor building without Flare credentials). A one-line "failed to upload"
+message is too easy to miss, hence the banner.
+
+Successful uploads keep the existing concise success log
+(`@flareapp/react-native-sourcemaps: Successfully uploaded sourcemap to Flare.`).
+
+## Testing
+
+- **Unit (Vitest, same as the rest of the package):**
+    - `flare.json` reader: env-override precedence, missing file, malformed JSON,
+      partial file (some keys present), and the explicit-flag > env > file > default
+      chain.
+    - Banner formatter: shape, reason interpolation, surrounding blank lines.
+    - CLI self-config path: flags still win; falls back to `flare.json`; falls back to
+      env; skip-with-banner when no key resolvable.
+- **Not unit-tested:** the Gradle and shell glue (no RN/Android/Xcode toolchain in
+  CI). Correctness is verified via a manual runbook against the bare playground
+  (`playgrounds/react-native-bare`) on an Android emulator and an iOS simulator,
+  the same approach that validated the JS core in PR #66. The runbook is recorded in
+  `.context/` (gitignored).
+
+## Docs
+
+- Update the package `README.md`: the Android one-liner, the two iOS edits, the
+  `flare.json` format and resolution rules, and the failure/banner behaviour.
+- Cross-link / extend the flareapp.io RN sourcemaps doc in a separate docs PR,
+  coordinated with the package release (the docs reference an installed package
+  version), as was done for PR #66 / docs PR #2436.
+
+## Build / packaging notes
+
+- New shipped files (`flare.gradle`, `scripts/flare-xcode.sh`) must be added to the
+  package `files` allowlist so they are published. They are not TypeScript build
+  outputs — confirm tsdown / `files` includes them (currently `files: ["dist"]`).
+- `flare-xcode.sh` must be executable (mode `0755`) in the published tarball.

--- a/docs/superpowers/specs/2026-06-25-rn-bare-sourcemap-auto-upload-design.md
+++ b/docs/superpowers/specs/2026-06-25-rn-bare-sourcemap-auto-upload-design.md
@@ -178,7 +178,7 @@ We get that without touching RN's stock build phase. Two documented manual edits
    not regenerated):
 
     ```sh
-    export SOURCEMAP_FILE="$CONFIGURATION_BUILD_DIR/main.jsbundle.map"
+    export SOURCEMAP_FILE="$TARGET_TEMP_DIR/main.jsbundle.map"
     ```
 
     The stock "Bundle React Native code and images" phase sources `.xcode.env`
@@ -207,7 +207,7 @@ We get that without touching RN's stock build phase. Two documented manual edits
   the sourcemap-existence check below, so renamed/custom release configs upload.
 - Resolves the map path. Prefer `$SOURCEMAP_FILE` (present now that the phase is
   wrapped in `with-environment.sh`); if it is unset, reconstruct
-  `$CONFIGURATION_BUILD_DIR/main.jsbundle.map` (Xcode build settings like
+  `$TARGET_TEMP_DIR/main.jsbundle.map` (Xcode build settings like
   `CONFIGURATION_BUILD_DIR` are auto-exported to run-script phases even without
   `.xcode.env`). Banner-and-skip if neither yields an existing file.
 - Reads `flare.json` via `--config "$SRCROOT/../flare.json"`, with env overrides.

--- a/docs/superpowers/specs/2026-06-25-rn-bare-sourcemap-auto-upload-design.md
+++ b/docs/superpowers/specs/2026-06-25-rn-bare-sourcemap-auto-upload-design.md
@@ -27,42 +27,111 @@ package**. No new npm package.
 - No automated installer that patches `build.gradle` / `.pbxproj`. Wiring is manual
   and documented. (The Expo plugin is the automated-wiring story for CNG users.)
 - No `failBuild` strict mode. Uploads never fail the build (see Failure behaviour).
+- No `FLARE_DISABLE_AUTO_UPLOAD` opt-out env var. The wiring is manual and tiny (one
+  `apply from` line on Android, one build phase on iOS), so to disable the upload you
+  remove the wiring rather than toggle an env var. This drops the control the original
+  `2026-06-24` design listed; it is redundant given how small the wiring is.
 - No JSC-specific handling. Hermes is the RN default; a JSC build still produces a
   plain `.map` the same hooks upload, just without special treatment.
 - No Debug-build uploads. Release variants/configurations only.
 
 ## Configuration — `flare.json`
 
-A committed JSON file at the project root, read by both platform hooks:
+A committed JSON file at the project root, read **only by the upload hooks** (never
+by the Babel plugin):
 
 ```json
 {
     "apiKey": "...",
-    "apiEndpoint": "https://flareapp.io/api/sourcemaps",
-    "version": "optional-explicit-version"
+    "apiEndpoint": "https://flareapp.io/api/sourcemaps"
 }
 ```
+
+`flare.json` carries only the API key and endpoint. It deliberately does **not**
+carry a `version` key (reasons in "Version resolution in the auto path" below) nor a
+`relative_filename` override (reasons in "`relative_filename` and the deferred
+override" below).
 
 The Flare project API key is already embedded in the shipped app for error
 reporting, so committing it here is not a meaningful secret leak.
 
 Per-field resolution, **env var wins**, then file, then default:
 
-| Field        | Env override              | `flare.json` key | Default                                 |
-| ------------ | ------------------------- | ---------------- | --------------------------------------- |
-| API key      | `FLARE_API_KEY`           | `apiKey`         | (none — skip upload with banner)        |
-| API endpoint | `FLARE_API_ENDPOINT`      | `apiEndpoint`    | `https://flareapp.io/api/sourcemaps`    |
-| Version      | `FLARE_SOURCEMAP_VERSION` | `version`        | `resolveVersion()` chain (package.json) |
+| Field        | Env override         | `flare.json` key | Default                              |
+| ------------ | -------------------- | ---------------- | ------------------------------------ |
+| API key      | `FLARE_API_KEY`      | `apiKey`         | (none — skip upload with banner)     |
+| API endpoint | `FLARE_API_ENDPOINT` | `apiEndpoint`    | `https://flareapp.io/api/sourcemaps` |
 
 The env-first rule lets CI inject the key without editing files, while `flare.json`
 is the single committed source of truth the later Expo plugin will reuse.
 
-The `version` must match what the babel plugin inlined into the bundle
-(`flareSourcemapVersion`). Both sides flow through the same `resolveVersion()` chain
-(flag/`version` > `FLARE_SOURCEMAP_VERSION` > package.json `version`), and the babel
-transform and the native upload run inside the same build invocation, so they see
-the same env and the same package.json. This coupling is a correctness invariant:
-if they diverge, the backend version match fails and frames stay unresolved.
+### `relative_filename` and the deferred override
+
+`--bundle-filename` sets the `relative_filename` the backend matches against runtime
+stack frames. The hooks do **not** hardcode it; the CLI defaults it to the map
+basename minus `.map`, which is correct for a stock build and follows a renamed bundle
+automatically. The manual `--bundle-filename` flag remains the override for the manual
+CLI flow.
+
+There is **no auto-path override in v1** (no `flare.json` key, no `--platform` flag).
+An override would only matter if a production frame's `fileName` differs from the map
+basename, which is still unverified (`2026-06-24` open risks), and the step that would
+prove it — end-to-end symbolication on the bare playground — is in this plan's
+verification task. So the override is deferred: ship the basename default, let
+verification be the gate, and add an override only if a real mismatch appears, shaped
+by the real data (including whether it even needs to be per-platform). Because each
+hook already knows its platform, that knowledge is available at the point of need
+without a generic CLI flag.
+
+### Locating `flare.json` (no cwd guessing)
+
+The hooks run with a platform-specific working directory (`android/` for Gradle,
+`ios/` for the Xcode phase), not the project root, so the reader must NOT resolve
+`flare.json` relative to `process.cwd()`. Each hook computes the project root from
+its own known location and passes it explicitly:
+
+- The CLI gains a `--config <path-to-flare.json>` flag; the hooks always pass it.
+- Android: the Gradle script derives the root from `rootProject.projectDir` (the RN
+  project root) and passes `--config "$rootDir/flare.json"`.
+- iOS: `flare-xcode.sh` runs in `ios/`, so it passes `--config "$SRCROOT/../flare.json"`.
+
+A missing `flare.json` is not an error: the reader returns an empty config and
+resolution falls through to env, then to the no-key skip-with-banner.
+
+### Version resolution in the auto path
+
+The version inlined into the bundle (by the Babel plugin, during Metro bundling) and
+the version the map is uploaded under (by the hook) **must be identical**, or the
+backend match fails and frames stay minified. This is a correctness invariant, not a
+convenience.
+
+The two halves run as **separate processes with different working directories**
+(Metro at the project root; the hook in `android/` or `ios/`). The only input
+guaranteed identical to both is an **environment variable** in the shared build
+environment. `package.json` is not: it is resolved cwd-relative by `resolveVersion()`
+(`src/version.ts`), so Metro and the hook would read different files (and the hook
+would read a non-existent `ios/package.json` and throw). `flare.json` is not either:
+the Babel plugin never reads it. Therefore, in the auto path:
+
+- **Version flows exclusively through `FLARE_SOURCEMAP_VERSION`.** Both the Babel
+  plugin and the upload hook read the same env var from the same build invocation.
+  `flare.json` has no `version` key.
+- **The hooks disable the `package.json` fallback.** The CLI gains an `--auto` flag
+  the hooks pass; in that mode `resolveVersion()` does not fall back to `package.json`.
+  The fallback remains available only for the **manual CLI flow** (PR #66), where the
+  user controls both sides and resolves the same value themselves.
+- **Key present but `FLARE_SOURCEMAP_VERSION` unset → skip the upload and print the
+  failure banner** with reason `FLARE_SOURCEMAP_VERSION is not set`. Do not fall back
+  to `package.json`, and do not fail the build. Skipping is the safe choice: uploading
+  a map we cannot guarantee matches the bundle is worse than not uploading, and the
+  loud banner names exactly what to set. (The no-key contributor build already skipped
+  one check earlier, so this only fires on a real, keyed release that forgot the
+  version.)
+
+This restores the hard guarantee from the original design (`2026-06-24`: "the
+automatic native wiring must NOT rely on the fallback") while honouring the non-goal
+of never failing the build. A version misconfiguration degrades to skip-with-banner,
+not a build break.
 
 ## Android — `flare.gradle`
 
@@ -76,11 +145,17 @@ apply from: "../../node_modules/@flareapp/react-native-sourcemaps/flare.gradle"
 `flare.gradle`:
 
 - Hooks each **release** `bundle{Variant}JsAndAssets` task with a `doLast` action.
-- Resolves the composed map RN already generated at
+- Reads the map path **off the task** (`sourcemapOutput`, falling back to
+  `bundleOutput + ".map"`) rather than a literal path, so a custom `bundleAssetName`
+  flows through. For a stock app this resolves to
   `android/app/build/generated/sourcemaps/react/release/index.android.bundle.map`.
-- Reads `flare.json` / env (via the CLI's self-config — see Shared internals).
-- Shells out to `flare-rn-sourcemaps upload --sourcemap <map>
---bundle-filename index.android.bundle`.
+- Does **not** hardcode `--bundle-filename`; the CLI defaults it to the map basename
+  minus `.map`, so a renamed bundle is handled for free (no auto-path override in v1,
+  see "`relative_filename` and the deferred override").
+- Invokes the CLI through `npx` (or the resolved `node_modules/.bin` path), because a
+  bare `flare-rn-sourcemaps` is not on `PATH` inside a Gradle `exec`:
+  `npx flare-rn-sourcemaps upload --sourcemap <map> --config "$rootDir/flare.json"
+--auto`.
 - Is guarded to release variants only; debug builds do nothing.
 
 The exact task-graph wiring (variant iteration, task-name resolution across RN
@@ -99,22 +174,40 @@ We get that without touching RN's stock build phase. Two documented manual edits
     export SOURCEMAP_FILE="$CONFIGURATION_BUILD_DIR/main.jsbundle.map"
     ```
 
-    The stock "Bundle React Native code and images" phase now emits the map.
+    The stock "Bundle React Native code and images" phase sources `.xcode.env`
+    through `with-environment.sh` and now emits the map at that path.
 
-2. Add a new "Upload Flare sourcemaps" build phase **after** the bundle phase,
-   running:
+2. Add a new "Upload Flare sourcemaps" build phase **after** the bundle phase. It
+   must source the **same** environment the bundle phase used, so it sees
+   `SOURCEMAP_FILE` (and any `FLARE_*` exports in `.xcode.env` / `.xcode.env.local`).
+   Wrap it in `with-environment.sh`, exactly as RN's own bundle phase does:
 
     ```sh
-    ../node_modules/@flareapp/react-native-sourcemaps/scripts/flare-xcode.sh
+    set -e
+    WITH_ENVIRONMENT="../node_modules/react-native/scripts/xcode/with-environment.sh"
+    FLARE_XCODE="../node_modules/@flareapp/react-native-sourcemaps/scripts/flare-xcode.sh"
+    /bin/sh -c "$WITH_ENVIRONMENT $FLARE_XCODE"
     ```
+
+    Invoking `flare-xcode.sh` directly (without `with-environment.sh`) is wrong: a
+    separate run-script phase does not inherit the shell exports `.xcode.env` set for
+    the bundle phase, so `SOURCEMAP_FILE` and any `FLARE_*` vars would be absent.
 
 `flare-xcode.sh`:
 
 - Guards on `CONFIGURATION == Release` (no-op otherwise).
-- Locates the map at the `SOURCEMAP_FILE` path the bundle phase just wrote.
-- Reads `flare.json` / env.
-- Calls `flare-rn-sourcemaps upload --sourcemap <map>
---bundle-filename main.jsbundle`.
+- Resolves the map path. Prefer `$SOURCEMAP_FILE` (present now that the phase is
+  wrapped in `with-environment.sh`); if it is unset, reconstruct
+  `$CONFIGURATION_BUILD_DIR/main.jsbundle.map` (Xcode build settings like
+  `CONFIGURATION_BUILD_DIR` are auto-exported to run-script phases even without
+  `.xcode.env`). Banner-and-skip if neither yields an existing file.
+- Reads `flare.json` via `--config "$SRCROOT/../flare.json"`, with env overrides.
+- Does **not** hardcode `--bundle-filename`; the CLI defaults it to the map basename
+  minus `.map` (`main.jsbundle` for a stock app). A renamed iOS bundle means editing the
+  `SOURCEMAP_FILE` line above to match, after which the basename default follows
+  automatically.
+- Calls `flare-rn-sourcemaps upload --sourcemap "$SOURCEMAP_FILE"
+--config "$SRCROOT/../flare.json" --auto`.
 
 The stock RN bundle phase is never modified, so RN upgrades that touch it don't
 break Flare (upgrade-safe).
@@ -122,20 +215,29 @@ break Flare (upgrade-safe).
 ## Shared internals
 
 Both hooks ultimately invoke the same CLI / `uploadSourcemaps()` path already
-verified end-to-end. The one new shared piece is a small **`flare.json` reader**
-that merges env overrides over file values (precedence table above).
+verified end-to-end. Two small new shared pieces:
 
-The CLI (`flare-rn-sourcemaps upload`) gains an implicit "read `flare.json` if a flag
-is absent" behaviour so the hooks can call it with minimal flags and let it
-self-configure. Existing explicit flags keep working unchanged and still take
-precedence over `flare.json` (explicit flag > env > file > default). This keeps the
-manual/verification CLI flow from PR #66 fully backward compatible.
+1. A **`flare.json` reader** that takes an explicit path (`--config <path>`, never
+   cwd-relative — see "Locating `flare.json`") and merges env overrides over file
+   values for `apiKey` and `apiEndpoint`.
+2. An **`--auto` flag** on `flare-rn-sourcemaps upload` that the hooks pass. In auto
+   mode the CLI: (a) reads `--config` for key/endpoint,
+   (b) resolves the version from `FLARE_SOURCEMAP_VERSION` only, with the
+   `package.json` fallback disabled, and (c) when a key is present but the version is
+   unresolved, skips the upload and prints the failure banner instead of uploading a
+   guaranteed-mismatched map.
+
+Per-flag precedence stays `explicit flag > env > file (flare.json) > default`, except
+version in auto mode, which is env-only by design (the desync hazard above). Existing
+explicit flags keep working unchanged, so the manual/verification CLI flow from
+PR #66 — and its `package.json` version fallback — is fully backward compatible.
 
 ## Failure behaviour & the banner
 
-Uploads **never fail the build**. On no-key or upload error (timeout, 5xx, missing
-map, etc.), print a multi-line boxed banner to stderr — deliberately large so it is
-not overlooked in a long CI log:
+Uploads **never fail the build**. On no-key, **version unset** (auto mode with a key
+but no `FLARE_SOURCEMAP_VERSION`), or an upload error (timeout, 5xx, unreadable map,
+etc.), print a multi-line boxed banner to stderr — deliberately large so it is not
+overlooked in a long CI log:
 
 ```
 
@@ -145,16 +247,39 @@ not overlooked in a long CI log:
   Your release will report minified stack traces until the
   sourcemap is uploaded. Re-run manually:
     npx flare-rn-sourcemaps upload --sourcemap <path> \
-      --bundle-filename <name> --api-key <key>
+      --bundle-filename <name> --version <version> --api-key <key>
 ============================================================
 
 ```
 
-(blank line above and below the box.) Rationale: a transient upload failure should
-not block shipping a working app — only symbolication is delayed and is recoverable
-with a manual re-run. The no-key case especially must never break a build (e.g. a
-contributor building without Flare credentials). A one-line "failed to upload"
-message is too easy to miss, hence the banner.
+(blank line above and below the box.) The `<path>`, `<name>`, `<version>`, and
+`<key>` in the re-run command are **interpolated with the real resolved values**
+where known, falling back to labelled placeholders otherwise (e.g. `<version>` stays
+a placeholder in the version-unset case, which is the value the user must supply), so
+the user can copy-paste the recovery command.
+
+**No map produced is a skip, not a banner.** If the build emitted no sourcemap at all
+(e.g. Hermes disabled, or a misconfigured bundle step), the hook logs a single-line
+skip ("no sourcemap at `<path>`, skipping upload") rather than the loud banner, and
+never invokes the CLI. That is a distinct condition from a failed upload: there is
+nothing to upload, so the banner's "re-run manually" recovery would not apply. The
+banner is reserved for the cases where a map exists but the upload cannot complete
+(no-key, version-unset, network/5xx, unreadable map handed to the CLI).
+
+**Exit-code contract** (this is what makes "never fail the build" real — a Gradle
+`doLast` and an Xcode run-script phase both abort the build on a non-zero child
+exit): in auto mode the CLI **always exits 0** for no-key, version-unset, and upload
+errors, printing the banner. The only non-zero exit is genuine CLI misuse (unknown
+command, missing `--sourcemap`), which a correctly wired hook never triggers. Note
+this is a change from the current code: `uploadSourcemaps()` lets `FlareApi` errors
+propagate (which would exit non-zero), so the CLI must catch them in auto mode,
+banner, and exit 0.
+
+Rationale: a transient upload failure should not block shipping a working app — only
+symbolication is delayed and is recoverable with a manual re-run. The no-key case
+especially must never break a build (e.g. a contributor building without Flare
+credentials). A one-line "failed to upload" message is too easy to miss, hence the
+banner.
 
 Successful uploads keep the existing concise success log
 (`@flareapp/react-native-sourcemaps: Successfully uploaded sourcemap to Flare.`).
@@ -162,12 +287,22 @@ Successful uploads keep the existing concise success log
 ## Testing
 
 - **Unit (Vitest, same as the rest of the package):**
-    - `flare.json` reader: env-override precedence, missing file, malformed JSON,
-      partial file (some keys present), and the explicit-flag > env > file > default
-      chain.
-    - Banner formatter: shape, reason interpolation, surrounding blank lines.
-    - CLI self-config path: flags still win; falls back to `flare.json`; falls back to
-      env; skip-with-banner when no key resolvable.
+    - `flare.json` reader: explicit `--config <path>` (no cwd dependence — assert it
+      reads the passed path, not `process.cwd()`), env-override precedence for
+      `apiKey`/`apiEndpoint`, missing file (returns empty config), malformed JSON,
+      partial file, and that it ignores any `version` key if present.
+    - `relative_filename` resolution: with no `--bundle-filename`, the CLI defaults to
+      the map basename minus `.map` (there is no auto-path override in v1).
+    - Banner formatter: shape, reason interpolation, real path/name/key interpolation
+      (not literal placeholders), surrounding blank lines.
+    - CLI config path: explicit flags still win; falls back to `flare.json`; falls
+      back to env; skip-with-banner when no key resolvable.
+    - `--auto` mode version handling: uses `FLARE_SOURCEMAP_VERSION`; does **not**
+      fall back to `package.json`; key-present-but-version-unset skips the upload and
+      banners. Non-auto (manual) mode keeps the `package.json` fallback.
+    - Exit-code contract: auto-mode no-key / version-unset / upload error all exit 0
+      (assert `process.exitCode` is unset/0 and `FlareApi` rejections are caught);
+      arg misuse exits 1.
 - **Not unit-tested:** the Gradle and shell glue (no RN/Android/Xcode toolchain in
   CI). Correctness is verified via a manual runbook against the bare playground
   (`playgrounds/react-native-bare`) on an Android emulator and an iOS simulator,

--- a/docs/superpowers/specs/2026-06-26-expo-config-plugin-sourcemap-upload-design.md
+++ b/docs/superpowers/specs/2026-06-26-expo-config-plugin-sourcemap-upload-design.md
@@ -26,6 +26,15 @@ plugin has concrete hooks to inject.
 It ships **inside the existing `@flareapp/react-native-sourcemaps` package** as a new
 `./expo` subpath export. No new npm package.
 
+**Scope of "automatic".** The plugin automates only the **native-wiring** third of
+the flow. The user still does three things by hand: add
+`@flareapp/react-native-sourcemaps/babel` to `babel.config.js`, pass
+`flareSourcemapVersion` to `flare.configure()`, and set `FLARE_SOURCEMAP_VERSION` in
+the build environment (see "Version & EAS"). And it covers **native release builds
+only** (`expo run:* --variant/--configuration Release`, EAS Build) — **not** OTA /
+EAS Update (see Out of scope). The docs must list the steps that remain so the plugin
+is not mistaken for drop-in symbolication.
+
 ## Out of scope (non-goals)
 
 - **No Babel auto-wiring.** Adding `@flareapp/react-native-sourcemaps/babel` to
@@ -38,7 +47,16 @@ It ships **inside the existing `@flareapp/react-native-sourcemaps` package** as 
   silently desync the inlined and uploaded versions. This is the exact footgun the
   bare design eliminated.
 - **No bare-style installer**, no classic eject-and-hand-edit flow (that is just the
-  bare path), no `expo export` changes (the manual CLI flow already covers it).
+  bare path).
+- **No OTA / EAS Update coverage.** The injected hooks fire only during a **native**
+  build (`expo run:*`, EAS Build). `eas update` ships a JS bundle via `expo export`
+  with no Gradle/Xcode phase, so it uploads **no map** and those frames stay minified
+  even with the plugin installed. OTA releases must upload sourcemaps with the manual
+  CLI (`flare-rn-sourcemaps upload`), setting the **same** `FLARE_SOURCEMAP_VERSION`
+  used for the export so the inlined and uploaded versions match — the exact desync
+  hazard the native path eliminates, now the user's responsibility on the export path.
+  EAS Update is a primary reason teams choose managed Expo, so this gap must be called
+  out prominently in the docs, not left implicit.
 
 ## Plugin API
 
@@ -59,10 +77,10 @@ Added to `app.json` (or `app.config.js`):
 
 Props:
 
-| Prop          | Required | Default                              | Notes                                           |
-| ------------- | -------- | ------------------------------------ | ----------------------------------------------- |
-| `apiKey`      | no\*     | (none)                               | Falls back to the `FLARE_API_KEY` env at build. |
-| `apiEndpoint` | no       | `https://flareapp.io/api/sourcemaps` | For self-hosted Flare.                          |
+| Prop          | Required | Default                              | Notes                                                                         |
+| ------------- | -------- | ------------------------------------ | ----------------------------------------------------------------------------- |
+| `apiKey`      | no\*     | (none)                               | Falls back to the `FLARE_API_KEY` env at build.                               |
+| `apiEndpoint` | no       | `https://flareapp.io/api/sourcemaps` | Self-hosted Flare. `FLARE_API_ENDPOINT` env still overrides it at build time. |
 
 \* If neither the prop nor `FLARE_API_KEY` is set at build time, the injected hook
 skips the upload and prints the banner — the build still succeeds.
@@ -71,7 +89,9 @@ The Flare project API key is already embedded in the shipped app for error
 reporting, so putting it in the committed `app.json` is not a meaningful secret leak.
 
 The plugin is default-exported as a `createRunOncePlugin`-wrapped `ConfigPlugin`, so
-applying it twice (e.g. transitively) is a no-op.
+applying it twice (e.g. transitively) is a no-op. `createRunOncePlugin` needs a name
+and version; read the version from the package's own `package.json` (the
+`./package.json` export already exists, so it is resolvable from `src/expo.ts`).
 
 ## What it injects at prebuild
 
@@ -84,21 +104,37 @@ applying it twice (e.g. transitively) is a no-op.
    `flare.gradle` reads `rootProject.projectDir.parentFile/flare.json`, iOS
    `flare-xcode.sh` reads `$SRCROOT/../flare.json` — both the project root.
 
-2. **Android — `withAppBuildGradle`.** Appends
-   `apply from: "../../node_modules/@flareapp/react-native-sourcemaps/flare.gradle"`
-   to the generated `android/app/build.gradle`, using `mergeContents` with an anchor
-   tag so it is idempotent.
+2. **Android — `withAppBuildGradle`.** Appends an `apply from: "<path>/flare.gradle"`
+   line to the generated `android/app/build.gradle`, using `mergeContents` with an
+   anchor tag so it is idempotent. `<path>` is **resolved at prebuild via
+   `require.resolve('@flareapp/react-native-sourcemaps/package.json')`** and expressed
+   relative to `android/app/`, not hardcoded as `../../node_modules/...`. A bare user
+   types that relative string by hand and can fix it; the plugin writes it where the
+   user cannot, so under npm workspaces / hoisting a literal `../../node_modules`
+   would silently point at nothing. Resolving the real install location keeps the
+   plugin correct in monorepos. (The mod only adds the `apply from` line; all the
+   task wiring lives inside `flare.gradle` itself, unchanged.)
 
 3. **iOS (a) — `.xcode.env`.** Ensures `ios/.xcode.env` contains
    `export SOURCEMAP_FILE="$CONFIGURATION_BUILD_DIR/main.jsbundle.map"` (idempotent
-   merge), so Expo's stock bundle phase emits the composed map. (Editing `.xcode.env`
-   via the plugin is CNG-correct because the plugin re-applies it on every prebuild —
-   unlike a one-off manual edit, which prebuild would discard.)
+   merge), so Expo's stock bundle phase emits the composed map. Confirmed against
+   RN 0.85: `react-native-xcode.sh` emits and Hermes-composes the map only when
+   `SOURCEMAP_FILE` is set (its `EMIT_SOURCEMAP` path), and `with-environment.sh`
+   sources `ios/.xcode.env` before the phased command runs. The mod must treat a
+   **missing** `ios/.xcode.env` as empty input (read `''` before merging) rather than
+   assuming the prebuild template emitted one. (Editing `.xcode.env` via the plugin is
+   CNG-correct because the plugin re-applies it on every prebuild — unlike a one-off
+   manual edit, which prebuild would discard.)
 
 4. **iOS (b) — `withXcodeProject`.** Adds an "Upload Flare sourcemaps"
-   `PBXShellScriptBuildPhase` to the app target, ordered **after** the bundle phase,
-   running the `with-environment.sh`-wrapped `flare-xcode.sh` (the same snippet bare
-   users add by hand). Guarded against adding a duplicate phase by name.
+   `PBXShellScriptBuildPhase` to the app target, running the
+   `with-environment.sh`-wrapped `flare-xcode.sh` (the same snippet bare users add by
+   hand). It is **appended to the end of the target's build phases**, not anchored
+   after a phase located by name. The JS bundle phase ("Bundle React Native code and
+   images") is never the last phase in the RN/Expo template, so appending is
+   unconditionally after it — the plugin therefore does not depend on that phase's
+   name or index staying stable across Expo SDKs. Idempotency is the only guard: skip
+   if a phase named "Upload Flare sourcemaps" already exists.
 
 The injected shell snippet (matching the bare iOS setup):
 
@@ -109,7 +145,22 @@ FLARE_XCODE="../node_modules/@flareapp/react-native-sourcemaps/scripts/flare-xco
 /bin/sh -c "$WITH_ENVIRONMENT $FLARE_XCODE"
 ```
 
+Both paths in the snippet are subject to the same hoisting concern as Android: resolve
+`react-native` and `@flareapp/react-native-sourcemaps` via `require.resolve` at
+prebuild and emit the resulting paths relative to `ios/`, rather than baking in the
+literal `../node_modules/...` strings shown above (which are the bare, hand-typed
+form).
+
 ## Idempotency & CNG behaviour
+
+**Precondition: prebuild runs before every native build.** The injected hooks and the
+generated `flare.json` exist only after `expo prebuild`. Pure-CNG apps (no committed
+`android/`/`ios/`) and EAS Build satisfy this automatically. A team that **commits**
+the native dirs and then builds without re-running prebuild gets no regenerated
+`flare.json` (it is gitignored) and possibly stale wiring — the upload then skips with
+the banner and frames stay minified, with no build failure to flag it. Documenting the
+gitignore is what makes this committed-native-dirs path a deliberate, visible choice
+rather than a silent degradation.
 
 `expo prebuild --clean` regenerates the native dirs from scratch, but plain
 `expo prebuild` applies mods **on top of existing** native files. So every mod must
@@ -118,7 +169,9 @@ be guarded or it duplicates on repeated prebuilds:
 - `build.gradle` and `.xcode.env`: `mergeContents` with a stable anchor tag (insert
   once; a second run detects the tag and no-ops).
 - The Xcode build phase: check the app target's existing phases and skip if an
-  "Upload Flare sourcemaps" phase already exists.
+  "Upload Flare sourcemaps" phase already exists (the phase is appended, so this
+  name check is the whole idempotency guard — there is no insert-after-index to
+  re-derive).
 - `flare.json`: overwrite on each write (always reflects current props).
 - `.gitignore`: append the `flare.json` line only if absent.
 
@@ -132,7 +185,11 @@ To make this testable, the transformations are **pure functions** wrapped by thi
 - `ensureGitignored(gitignore: string): string`
 
 Each is unit-testable in isolation (string in / string out, or a fixture
-`XcodeProject` in/out), and each is idempotent.
+`XcodeProject` in/out), and each is idempotent. Note `addUploadBuildPhase` is not
+literally "pure": the `xcode` library mutates the `XcodeProject` in place. Test its
+contract by asserting on the mutated project — after one call exactly one
+"Upload Flare sourcemaps" phase exists; after a second call still exactly one — not by
+referential purity.
 
 ## Version & EAS
 
@@ -191,8 +248,13 @@ auto path has no `package.json` fallback) and the build stays green.
   the interim Step 4 callout wording with a real **Expo (CNG)** subsection — plugin
   install, the `app.json` `plugins` entry, the `eas.json` env placement, and a note
   that the plugin writes a generated `flare.json` and gitignores it (expected
-  behaviour). Coordinate with the package release (docs reference an installed
-  version), as for the bare work.
+  behaviour). The subsection must also: (a) list the steps that stay **manual** (babel
+  plugin, `flare.configure({ flareSourcemapVersion })`, `FLARE_SOURCEMAP_VERSION`), so
+  the plugin is not read as drop-in; and (b) carry a prominent **OTA / EAS Update**
+  callout — the plugin does not cover `eas update`, which needs a manual
+  `flare-rn-sourcemaps upload` under the same `FLARE_SOURCEMAP_VERSION` as the export.
+  Coordinate with the package release (docs reference an installed version), as for the
+  bare work.
 - Update the package `README.md` with the Expo plugin usage alongside the bare
   section.
 
@@ -202,8 +264,15 @@ auto path has no `package.json` fallback) and the build stays green.
   build. Confirm the `./expo` export's `require` condition and that the emitted
   `dist/expo.cjs` loads cleanly under `require` (no ESM-only `node:` shim breakage,
   the same class of issue the RN client hit — see the RN packaging notes).
-- The exact name/position of Expo's iOS bundle build phase (to insert the Flare phase
-  _after_ it) and that Expo's bundle phase honours `SOURCEMAP_FILE` from `.xcode.env`
-  are confirmed on the playground at the ship gate (the bare iOS verification already
-  showed `SOURCEMAP_FILE` works under Expo's `react-native-xcode.sh`/`export:embed`
-  path; re-confirm via the plugin).
+- **iOS bundle-phase shape (de-risked on SDK 56 / RN 0.85).** RN 0.85's
+  `react-native-xcode.sh` still emits and Hermes-composes the map when `SOURCEMAP_FILE`
+  is set (its `EMIT_SOURCEMAP` path), and `with-environment.sh` sources `ios/.xcode.env`
+  before running the phased command, so the wrapped Flare phase sees `SOURCEMAP_FILE`.
+  Expo's own CLI still references the phase as "Bundle React Native code and images" on
+  SDK 56, but the plugin does **not** rely on that name: **appending** the Flare phase
+  (see iOS (b)) sidesteps the name/position question entirely. The only remaining
+  ship-gate check is that the appended phase finds the composed map at runtime on the
+  actually-prebuilt project (the bundle phase having run earlier in the same build).
+- That `@flareapp/react-native-sourcemaps/expo` and `react-native` resolve via
+  `require.resolve` from the prebuild context so the injected relative paths are
+  correct under hoisting (the monorepo playground is itself a hoisting case to verify).

--- a/docs/superpowers/specs/2026-06-26-expo-config-plugin-sourcemap-upload-design.md
+++ b/docs/superpowers/specs/2026-06-26-expo-config-plugin-sourcemap-upload-design.md
@@ -116,7 +116,7 @@ and version; read the version from the package's own `package.json` (the
    task wiring lives inside `flare.gradle` itself, unchanged.)
 
 3. **iOS (a) — `.xcode.env`.** Ensures `ios/.xcode.env` contains
-   `export SOURCEMAP_FILE="$CONFIGURATION_BUILD_DIR/main.jsbundle.map"` (idempotent
+   `export SOURCEMAP_FILE="$TARGET_TEMP_DIR/main.jsbundle.map"` (idempotent
    merge), so Expo's stock bundle phase emits the composed map. Confirmed against
    RN 0.85: `react-native-xcode.sh` emits and Hermes-composes the map only when
    `SOURCEMAP_FILE` is set (its `EMIT_SOURCEMAP` path), and `with-environment.sh`

--- a/docs/superpowers/specs/2026-06-26-expo-config-plugin-sourcemap-upload-design.md
+++ b/docs/superpowers/specs/2026-06-26-expo-config-plugin-sourcemap-upload-design.md
@@ -77,10 +77,10 @@ Added to `app.json` (or `app.config.js`):
 
 Props:
 
-| Prop          | Required | Default                              | Notes                                                                         |
-| ------------- | -------- | ------------------------------------ | ----------------------------------------------------------------------------- |
-| `apiKey`      | no\*     | (none)                               | Falls back to the `FLARE_API_KEY` env at build.                               |
-| `apiEndpoint` | no       | `https://flareapp.io/api/sourcemaps` | Self-hosted Flare. `FLARE_API_ENDPOINT` env still overrides it at build time. |
+| Prop          | Required | Default                              | Notes                                                                                                                |
+| ------------- | -------- | ------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
+| `apiKey`      | no\*     | (none)                               | Falls back to the `FLARE_API_KEY` env at build.                                                                      |
+| `apiEndpoint` | no       | `https://flareapp.io/api/sourcemaps` | Override the upload endpoint (rarely needed; e.g. tests). `FLARE_API_ENDPOINT` env still overrides it at build time. |
 
 \* If neither the prop nor `FLARE_API_KEY` is set at build time, the injected hook
 skips the upload and prints the banner — the build still succeeds.

--- a/docs/superpowers/specs/2026-06-26-expo-config-plugin-sourcemap-upload-design.md
+++ b/docs/superpowers/specs/2026-06-26-expo-config-plugin-sourcemap-upload-design.md
@@ -1,0 +1,209 @@
+# Expo config plugin for automatic sourcemap upload (CNG) — design
+
+Date: 2026-06-26
+Package: `@flareapp/react-native-sourcemaps` (new `./expo` subpath)
+Status: approved, ready for implementation planning
+
+## Goal
+
+Give an **Expo CNG / managed** React Native project the same automatic
+release-build sourcemap upload that bare RN already has, without the user
+hand-editing native files — because `expo prebuild` regenerates `android/` and
+`ios/`, so manual edits to `build.gradle`, `.xcode.env`, or the `.pbxproj` do not
+survive.
+
+The plugin is a thin **native-wiring layer**: on every prebuild it re-injects
+exactly the bare hooks already shipped and verified end-to-end
+(`flare.gradle`, `scripts/flare-xcode.sh`) and reuses the existing CLI
+(`flare-rn-sourcemaps upload --config <flare.json> --auto`), banner, and env-only
+version logic unchanged. The only new code is the plugin and its pure
+transformation helpers.
+
+This is "Plan 2, part 2" — the follow-on to the bare-RN auto-upload work
+(`2026-06-25-rn-bare-sourcemap-auto-upload-design.md`), which was built first so the
+plugin has concrete hooks to inject.
+
+It ships **inside the existing `@flareapp/react-native-sourcemaps` package** as a new
+`./expo` subpath export. No new npm package.
+
+## Out of scope (non-goals)
+
+- **No Babel auto-wiring.** Adding `@flareapp/react-native-sourcemaps/babel` to
+  `babel.config.js` and passing `flareSourcemapVersion` to `flare.configure()` stay
+  manual (docs steps 1-2), identical to bare. `babel.config.js` is bundler config,
+  not a native project, so a config plugin is the wrong tool for it.
+- **No `version` prop.** Version stays the `FLARE_SOURCEMAP_VERSION` env var (see
+  "Version & EAS"). A static, committed `version` in `app.json` would upload every
+  build under the same id, and — because Babel reads the env var, not the prop — would
+  silently desync the inlined and uploaded versions. This is the exact footgun the
+  bare design eliminated.
+- **No bare-style installer**, no classic eject-and-hand-edit flow (that is just the
+  bare path), no `expo export` changes (the manual CLI flow already covers it).
+
+## Plugin API
+
+Added to `app.json` (or `app.config.js`):
+
+```json
+{
+    "expo": {
+        "plugins": [
+            [
+                "@flareapp/react-native-sourcemaps/expo",
+                { "apiKey": "YOUR_KEY", "apiEndpoint": "https://flareapp.io/api/sourcemaps" }
+            ]
+        ]
+    }
+}
+```
+
+Props:
+
+| Prop          | Required | Default                              | Notes                                           |
+| ------------- | -------- | ------------------------------------ | ----------------------------------------------- |
+| `apiKey`      | no\*     | (none)                               | Falls back to the `FLARE_API_KEY` env at build. |
+| `apiEndpoint` | no       | `https://flareapp.io/api/sourcemaps` | For self-hosted Flare.                          |
+
+\* If neither the prop nor `FLARE_API_KEY` is set at build time, the injected hook
+skips the upload and prints the banner — the build still succeeds.
+
+The Flare project API key is already embedded in the shipped app for error
+reporting, so putting it in the committed `app.json` is not a meaningful secret leak.
+
+The plugin is default-exported as a `createRunOncePlugin`-wrapped `ConfigPlugin`, so
+applying it twice (e.g. transitively) is a no-op.
+
+## What it injects at prebuild
+
+1. **`flare.json` (project root).** Written from the props via a `withDangerousMod`,
+   so the reused bare hooks read it through `--config`. The plugin **also appends
+   `flare.json` to `.gitignore`** idempotently: it is a generated artifact derived
+   from `app.json`, not a second source of truth. (This is documented as normal,
+   expected behaviour so users are not surprised to see the plugin write a root file
+   and touch `.gitignore`.) The bare hooks resolve this exact path already: Android
+   `flare.gradle` reads `rootProject.projectDir.parentFile/flare.json`, iOS
+   `flare-xcode.sh` reads `$SRCROOT/../flare.json` — both the project root.
+
+2. **Android — `withAppBuildGradle`.** Appends
+   `apply from: "../../node_modules/@flareapp/react-native-sourcemaps/flare.gradle"`
+   to the generated `android/app/build.gradle`, using `mergeContents` with an anchor
+   tag so it is idempotent.
+
+3. **iOS (a) — `.xcode.env`.** Ensures `ios/.xcode.env` contains
+   `export SOURCEMAP_FILE="$CONFIGURATION_BUILD_DIR/main.jsbundle.map"` (idempotent
+   merge), so Expo's stock bundle phase emits the composed map. (Editing `.xcode.env`
+   via the plugin is CNG-correct because the plugin re-applies it on every prebuild —
+   unlike a one-off manual edit, which prebuild would discard.)
+
+4. **iOS (b) — `withXcodeProject`.** Adds an "Upload Flare sourcemaps"
+   `PBXShellScriptBuildPhase` to the app target, ordered **after** the bundle phase,
+   running the `with-environment.sh`-wrapped `flare-xcode.sh` (the same snippet bare
+   users add by hand). Guarded against adding a duplicate phase by name.
+
+The injected shell snippet (matching the bare iOS setup):
+
+```sh
+set -e
+WITH_ENVIRONMENT="../node_modules/react-native/scripts/xcode/with-environment.sh"
+FLARE_XCODE="../node_modules/@flareapp/react-native-sourcemaps/scripts/flare-xcode.sh"
+/bin/sh -c "$WITH_ENVIRONMENT $FLARE_XCODE"
+```
+
+## Idempotency & CNG behaviour
+
+`expo prebuild --clean` regenerates the native dirs from scratch, but plain
+`expo prebuild` applies mods **on top of existing** native files. So every mod must
+be guarded or it duplicates on repeated prebuilds:
+
+- `build.gradle` and `.xcode.env`: `mergeContents` with a stable anchor tag (insert
+  once; a second run detects the tag and no-ops).
+- The Xcode build phase: check the app target's existing phases and skip if an
+  "Upload Flare sourcemaps" phase already exists.
+- `flare.json`: overwrite on each write (always reflects current props).
+- `.gitignore`: append the `flare.json` line only if absent.
+
+To make this testable, the transformations are **pure functions** wrapped by thin
+`withXxx` adapters:
+
+- `flareJsonContents(props): string`
+- `addFlareGradleApply(buildGradle: string): string`
+- `addSourcemapFileEnv(xcodeEnv: string): string`
+- `addUploadBuildPhase(project: XcodeProject): XcodeProject`
+- `ensureGitignored(gitignore: string): string`
+
+Each is unit-testable in isolation (string in / string out, or a fixture
+`XcodeProject` in/out), and each is idempotent.
+
+## Version & EAS
+
+The plugin does **not** manage the version. `FLARE_SOURCEMAP_VERSION` is read by the
+Babel plugin at bundle time and by the injected upload hook at upload time; because
+both run in the same build environment they see the same value and match.
+
+Documented placement:
+
+- **Local:** `export FLARE_SOURCEMAP_VERSION="$(git rev-parse --short HEAD)"` before
+  `expo run:android --variant release` / `expo run:ios --configuration Release`.
+- **EAS Build:** set it in `eas.json` under `build.<profile>.env`, e.g.
+  `"env": { "FLARE_SOURCEMAP_VERSION": "..." }`, or as an EAS environment variable.
+  Both the JS bundling and the native build on the EAS machine read it.
+
+If `FLARE_SOURCEMAP_VERSION` is unset, the injected hook skips with the banner (the
+auto path has no `package.json` fallback) and the build stays green.
+
+## Packaging
+
+- New `src/expo.ts`, added to the tsdown `entry` list.
+- New `./expo` export in `package.json`, with `require → ./dist/expo.cjs` first
+  (the Expo CLI loads config plugins via Node `require`, so CJS resolution matters),
+  plus the ESM/types conditions like the other subpaths.
+- `@expo/config-plugins` added as an **optional `peerDependency` + `devDependency`**,
+  mirroring the existing `@babel/core` pattern — only Expo users load `./expo`, and
+  Expo apps already have `@expo/config-plugins` via `expo`. `xcode` types for dev as
+  needed (the `XcodeProject` API comes through `@expo/config-plugins`).
+- `flare.gradle` and `scripts/` are already in the package `files` allowlist from the
+  bare work, so no `files` change is needed.
+
+## Testing
+
+- **Unit (Vitest, same as the rest of the package):**
+    - `flareJsonContents`: shape from props; `apiEndpoint` defaulting; omitted `apiKey`.
+    - `addFlareGradleApply`: inserts the `apply from` line; idempotent on a second run;
+      leaves an unrelated `build.gradle` otherwise intact.
+    - `addSourcemapFileEnv`: inserts the `SOURCEMAP_FILE` export; idempotent.
+    - `addUploadBuildPhase`: against a fixture `.pbxproj`, adds exactly one
+      "Upload Flare sourcemaps" phase; a second run adds none; the phase runs after the
+      bundle phase.
+    - `ensureGitignored`: appends `flare.json` once; no duplicate on re-run.
+- **Not unit-tested:** the actual `expo prebuild` + native build (no Expo/Android/
+  Xcode toolchain in CI). Correctness is the **ship gate**: on the
+  `playgrounds/react-native-expo` app, `expo prebuild` then a release build on **both**
+  Android and iOS must resolve a real minified frame to source in Flare under the
+  build's `FLARE_SOURCEMAP_VERSION` (the "uploaded" log alone is insufficient), plus
+  the negative check (build green with the banner when the version is unset). This
+  mirrors bare Task 9. Runbook → `.context/rn-expo-auto-upload-runbook.md` (gitignored).
+
+## Docs
+
+- Update the flareapp.io RN sourcemaps doc
+  (`resources/views/front/docs/react/react-native/resolving-bundled-code.md`,
+  branch `docs/react-native`): replace the "Expo config plugin … on the way" note and
+  the interim Step 4 callout wording with a real **Expo (CNG)** subsection — plugin
+  install, the `app.json` `plugins` entry, the `eas.json` env placement, and a note
+  that the plugin writes a generated `flare.json` and gitignores it (expected
+  behaviour). Coordinate with the package release (docs reference an installed
+  version), as for the bare work.
+- Update the package `README.md` with the Expo plugin usage alongside the bare
+  section.
+
+## Build / packaging risks to confirm during implementation
+
+- The Expo CLI must resolve `@flareapp/react-native-sourcemaps/expo` to the **CJS**
+  build. Confirm the `./expo` export's `require` condition and that the emitted
+  `dist/expo.cjs` loads cleanly under `require` (no ESM-only `node:` shim breakage,
+  the same class of issue the RN client hit — see the RN packaging notes).
+- The exact name/position of Expo's iOS bundle build phase (to insert the Flare phase
+  _after_ it) and that Expo's bundle phase honours `SOURCEMAP_FILE` from `.xcode.env`
+  are confirmed on the playground at the ship gate (the bare iOS verification already
+  showed `SOURCEMAP_FILE` works under Expo's `react-native-xcode.sh`/`export:embed`
+  path; re-confirm via the plugin).

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,9 @@
             "name": "flare-client-js",
             "workspaces": [
                 "packages/*",
-                "playgrounds/*"
+                "playgrounds/*",
+                "!playgrounds/react-native-bare",
+                "!playgrounds/react-native-expo"
             ],
             "devDependencies": {
                 "@hono/node-server": "^1.19.14",
@@ -1433,6 +1435,10 @@
         },
         "node_modules/@flareapp/react-native": {
             "resolved": "packages/react-native",
+            "link": true
+        },
+        "node_modules/@flareapp/react-native-sourcemaps": {
+            "resolved": "packages/react-native-sourcemaps",
             "link": true
         },
         "node_modules/@flareapp/svelte": {
@@ -17315,6 +17321,33 @@
                 "@flareapp/react": "^2.5.0",
                 "react": "^18.0.0||^19.0.0",
                 "react-native": ">=0.79.0"
+            }
+        },
+        "packages/react-native-sourcemaps": {
+            "name": "@flareapp/react-native-sourcemaps",
+            "version": "0.1.0",
+            "license": "MIT",
+            "bin": {
+                "flare-rn-sourcemaps": "dist/bin.cjs"
+            },
+            "devDependencies": {
+                "@babel/core": "^7.0.0",
+                "@flareapp/flare-api": "*",
+                "@types/babel__core": "^7.0.0",
+                "tsdown": "^0.20.3",
+                "typescript": "^5.7.0",
+                "vitest": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@babel/core": ">=7.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@babel/core": {
+                    "optional": true
+                }
             }
         },
         "packages/svelte": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -507,6 +507,23 @@
                 "@babel/core": "^7.0.0-0"
             }
         },
+        "node_modules/@babel/plugin-transform-modules-commonjs": {
+            "version": "7.29.7",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-commonjs/-/plugin-transform-modules-commonjs-7.29.7.tgz",
+            "integrity": "sha512-j0vCldybPC5b5dwCQOJ21uKtHzt7hxLygJTg9eF1ScfaikEDNfzn94XoW5Fi+seBR0nCyL23xaBFFkq7dTM8XQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/helper-module-transforms": "^7.29.7",
+                "@babel/helper-plugin-utils": "^7.29.7"
+            },
+            "engines": {
+                "node": ">=6.9.0"
+            },
+            "peerDependencies": {
+                "@babel/core": "^7.0.0-0"
+            }
+        },
         "node_modules/@babel/plugin-transform-react-jsx-self": {
             "version": "7.29.7",
             "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
@@ -1263,6 +1280,215 @@
             "engines": {
                 "node": ">=18"
             }
+        },
+        "node_modules/@expo/config-plugins": {
+            "version": "56.0.9",
+            "resolved": "https://registry.npmjs.org/@expo/config-plugins/-/config-plugins-56.0.9.tgz",
+            "integrity": "sha512-/6a/S9USwx8OC9tGjHxbviLFiBHyueN3aoNWMLvWDEJoZ1CIVW800ZBzwXq/FYNK2qzcN1LxFmQtzD1zeFQKNA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@expo/config-types": "^56.0.6",
+                "@expo/json-file": "~10.2.0",
+                "@expo/plist": "^0.7.0",
+                "@expo/require-utils": "^56.1.3",
+                "@expo/sdk-runtime-versions": "^1.0.0",
+                "chalk": "^4.1.2",
+                "debug": "^4.3.5",
+                "getenv": "^2.0.0",
+                "glob": "^13.0.0",
+                "semver": "^7.5.4",
+                "slugify": "^1.6.6",
+                "xcode": "^3.0.1",
+                "xml2js": "0.6.0"
+            }
+        },
+        "node_modules/@expo/config-plugins/node_modules/ansi-styles": {
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+            "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+            }
+        },
+        "node_modules/@expo/config-plugins/node_modules/balanced-match": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+            "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/@expo/config-plugins/node_modules/brace-expansion": {
+            "version": "5.0.7",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+            "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "balanced-match": "^4.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            }
+        },
+        "node_modules/@expo/config-plugins/node_modules/chalk": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+            "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^4.1.0",
+                "supports-color": "^7.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/@expo/config-plugins/node_modules/glob": {
+            "version": "13.0.6",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+            "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "minimatch": "^10.2.2",
+                "minipass": "^7.1.3",
+                "path-scurry": "^2.0.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@expo/config-plugins/node_modules/lru-cache": {
+            "version": "11.5.1",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
+            "integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
+        "node_modules/@expo/config-plugins/node_modules/minimatch": {
+            "version": "10.2.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+            "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "brace-expansion": "^5.0.5"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@expo/config-plugins/node_modules/path-scurry": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+            "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "dependencies": {
+                "lru-cache": "^11.0.0",
+                "minipass": "^7.1.2"
+            },
+            "engines": {
+                "node": "18 || 20 || >=22"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
+            }
+        },
+        "node_modules/@expo/config-plugins/node_modules/supports-color": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+            "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/@expo/config-types": {
+            "version": "56.0.6",
+            "resolved": "https://registry.npmjs.org/@expo/config-types/-/config-types-56.0.6.tgz",
+            "integrity": "sha512-4Y6Aum5J4Re5NnxGVofRNe1aDwUBOmWhQYkynZsqzRtX/zEA1ADUeyHXuEckv9YD9djiyT7bKtLt5gKL3mA6VQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@expo/json-file": {
+            "version": "10.2.0",
+            "resolved": "https://registry.npmjs.org/@expo/json-file/-/json-file-10.2.0.tgz",
+            "integrity": "sha512-S6XzKe3R9GQeHiUPXc3xJjOv2VJhOEwFYf7xdC2z2cUqt3kZJ9mSO877sNQloVdnW/SUCtPY3bexlM7nwq+CAQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.20.0",
+                "json5": "^2.2.3"
+            }
+        },
+        "node_modules/@expo/plist": {
+            "version": "0.7.0",
+            "resolved": "https://registry.npmjs.org/@expo/plist/-/plist-0.7.0.tgz",
+            "integrity": "sha512-vrpryU1GoqSIRNqRB2D3IjXDmzNYfiQpEF6AH/xknlD7eiYmEDt3mb26V7cLcedcPG8PY/1xWHdBXVQJfEAh6Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@xmldom/xmldom": "^0.8.8",
+                "base64-js": "^1.5.1",
+                "xmlbuilder": "^15.1.1"
+            }
+        },
+        "node_modules/@expo/require-utils": {
+            "version": "56.1.3",
+            "resolved": "https://registry.npmjs.org/@expo/require-utils/-/require-utils-56.1.3.tgz",
+            "integrity": "sha512-KyLeOn/zzQSvuPpV5YhB/FPKnpQytno4luN918bGdPDssLBoS3N/0UbC3W0rJAn9kSFu+XpfR81eABRVsSdfgQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@babel/code-frame": "^7.20.0",
+                "@babel/core": "^7.25.2",
+                "@babel/plugin-transform-modules-commonjs": "^7.24.8"
+            },
+            "peerDependencies": {
+                "typescript": "^5.0.0 || ^5.0.0-0 || ^6.0.0"
+            },
+            "peerDependenciesMeta": {
+                "typescript": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@expo/sdk-runtime-versions": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@expo/sdk-runtime-versions/-/sdk-runtime-versions-1.0.0.tgz",
+            "integrity": "sha512-Doz2bfiPndXYFPMRwPyGa1k5QaKDVpY806UJj570epIiMzWaYyCtobasyfC++qfIXVb5Ocy7r3tP9d62hAQ7IQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@fastify/ajv-compiler": {
             "version": "4.0.5",
@@ -6390,6 +6616,16 @@
                 "@xtuc/long": "4.2.2"
             }
         },
+        "node_modules/@xmldom/xmldom": {
+            "version": "0.8.13",
+            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+            "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
         "node_modules/@xtuc/ieee754": {
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
@@ -6985,6 +7221,16 @@
             "dev": true,
             "license": "Apache-2.0"
         },
+        "node_modules/big-integer": {
+            "version": "1.6.52",
+            "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
+            "integrity": "sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==",
+            "dev": true,
+            "license": "Unlicense",
+            "engines": {
+                "node": ">=0.6"
+            }
+        },
         "node_modules/birpc": {
             "version": "2.9.0",
             "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
@@ -7027,6 +7273,29 @@
             "dev": true,
             "license": "MIT",
             "optional": true
+        },
+        "node_modules/bplist-creator": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/bplist-creator/-/bplist-creator-0.1.0.tgz",
+            "integrity": "sha512-sXaHZicyEEmY86WyueLTQesbeoH/mquvarJaQNbjuOQO+7gbFcDEWqKmcWA4cOTLzFlfgvkiVxolk1k5bBIpmg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "stream-buffers": "2.2.x"
+            }
+        },
+        "node_modules/bplist-parser": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/bplist-parser/-/bplist-parser-0.3.1.tgz",
+            "integrity": "sha512-PyJxiNtA5T2PlLIeBot4lbp7rj4OadzjnMZD/G5zuBNt8ei/yCU7+wW0h2bag9vr8c+/WuRWmSxbqAl9hL1rBA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "big-integer": "1.6.x"
+            },
+            "engines": {
+                "node": ">= 5.10.0"
+            }
         },
         "node_modules/brace-expansion": {
             "version": "2.1.1",
@@ -9313,6 +9582,16 @@
             },
             "engines": {
                 "node": ">= 14"
+            }
+        },
+        "node_modules/getenv": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/getenv/-/getenv-2.0.0.tgz",
+            "integrity": "sha512-VilgtJj/ALgGY77fiLam5iD336eSWi96Q15JSAG1zi8NRBysm3LXKdGnHb4m5cuyxvOLQQKWpBZAT6ni4FI2iQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
             }
         },
         "node_modules/giget": {
@@ -13066,6 +13345,31 @@
                 "node": ">=18"
             }
         },
+        "node_modules/plist": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/plist/-/plist-3.1.1.tgz",
+            "integrity": "sha512-ZIfcLJC+7E7FBFnDxm9MPmt7D+DidyQ26lewieO75AdhA2ayMtsJSES0iWzqJQbcVRSrTufQoy0DR94xHue0oA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@xmldom/xmldom": "^0.9.10",
+                "base64-js": "^1.5.1",
+                "xmlbuilder": "^15.1.1"
+            },
+            "engines": {
+                "node": ">=10.4.0"
+            }
+        },
+        "node_modules/plist/node_modules/@xmldom/xmldom": {
+            "version": "0.9.10",
+            "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+            "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.6"
+            }
+        },
         "node_modules/postcss": {
             "version": "8.5.15",
             "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
@@ -14218,6 +14522,16 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/sax": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
+            "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=11.0.0"
+            }
+        },
         "node_modules/saxes": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
@@ -14609,6 +14923,18 @@
                 "url": "https://github.com/sponsors/isaacs"
             }
         },
+        "node_modules/simple-plist": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/simple-plist/-/simple-plist-1.3.1.tgz",
+            "integrity": "sha512-iMSw5i0XseMnrhtIzRb7XpQEXepa9xhWxGUojHBL43SIpQuDQkh3Wpy67ZbDzZVr6EKxvwVChnVpdl8hEVLDiw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "bplist-creator": "0.1.0",
+                "bplist-parser": "0.3.1",
+                "plist": "^3.0.5"
+            }
+        },
         "node_modules/sirv": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/sirv/-/sirv-3.0.2.tgz",
@@ -14649,6 +14975,16 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+            }
+        },
+        "node_modules/slugify": {
+            "version": "1.6.9",
+            "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.9.tgz",
+            "integrity": "sha512-vZ7rfeehZui7wQs438JXBckYLkIIdfHOXsaVEUMyS5fHo1483l1bMdo0EDSWYclY0yZKFOipDy4KHuKs6ssvdg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.0.0"
             }
         },
         "node_modules/smart-buffer": {
@@ -14837,6 +15173,16 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/stream-buffers": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/stream-buffers/-/stream-buffers-2.2.0.tgz",
+            "integrity": "sha512-uyQK/mx5QjHun80FLJTfaWE7JtwfRMKBLkMne6udYOmvH0CawotVa7TfgYHzAnpphn4+TweIx1QKMnRIbipmUg==",
+            "dev": true,
+            "license": "Unlicense",
+            "engines": {
+                "node": ">= 0.10.0"
             }
         },
         "node_modules/string-argv": {
@@ -16298,6 +16644,17 @@
                 "node": ">= 0.4.0"
             }
         },
+        "node_modules/uuid": {
+            "version": "7.0.3",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.3.tgz",
+            "integrity": "sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==",
+            "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "uuid": "dist/bin/uuid"
+            }
+        },
         "node_modules/vary": {
             "version": "1.1.2",
             "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -16998,6 +17355,20 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/xcode": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/xcode/-/xcode-3.0.1.tgz",
+            "integrity": "sha512-kCz5k7J7XbJtjABOvkc5lJmkiDh8VhjVCGNiqdKCscmVpdVUpEAyXv1xmCLkQJ5dsHqx3IPO4XW+NTDhU/fatA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "simple-plist": "^1.1.0",
+                "uuid": "^7.0.3"
+            },
+            "engines": {
+                "node": ">=10.0.0"
+            }
+        },
         "node_modules/xml-name-validator": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
@@ -17006,6 +17377,40 @@
             "license": "Apache-2.0",
             "engines": {
                 "node": ">=18"
+            }
+        },
+        "node_modules/xml2js": {
+            "version": "0.6.0",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.0.tgz",
+            "integrity": "sha512-eLTh0kA8uHceqesPqSE+VvO1CDDJWMwlQfB6LuN6T8w6MaDJ8Txm8P7s5cHD0miF0V+GGTZrDQfxPZQVsur33w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "sax": ">=0.6.0",
+                "xmlbuilder": "~11.0.0"
+            },
+            "engines": {
+                "node": ">=4.0.0"
+            }
+        },
+        "node_modules/xml2js/node_modules/xmlbuilder": {
+            "version": "11.0.1",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+            "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=4.0"
+            }
+        },
+        "node_modules/xmlbuilder": {
+            "version": "15.1.1",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+            "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.0"
             }
         },
         "node_modules/xmlchars": {
@@ -17332,11 +17737,13 @@
             },
             "devDependencies": {
                 "@babel/core": "^7.0.0",
+                "@expo/config-plugins": "^56.0.9",
                 "@flareapp/flare-api": "*",
                 "@types/babel__core": "^7.0.0",
                 "tsdown": "^0.20.3",
                 "typescript": "^5.7.0",
-                "vitest": "^4.0.0"
+                "vitest": "^4.0.0",
+                "xcode": "^3.0.1"
             },
             "engines": {
                 "node": ">=18"

--- a/packages/core/src/stacktrace/createStackTrace.ts
+++ b/packages/core/src/stacktrace/createStackTrace.ts
@@ -25,20 +25,34 @@ export function createStackTrace(error: Error, debug: boolean, fileReader: FileR
 
         Promise.all(
             parsedFrames.map((frame) => {
-                return getCodeSnippet(fileReader, frame.fileName, frame.lineNumber, frame.columnNumber).then(
-                    (snippet) => ({
-                        lineNumber: frame.lineNumber || 1,
-                        columnNumber: frame.columnNumber || 1,
-                        method: frame.functionName || 'Anonymous or unknown function',
-                        file: frame.fileName || 'Unknown file',
-                        codeSnippet: snippet.codeSnippet,
-                        class: '',
-                        isApplicationFrame: isApplicationFrame(frame.fileName),
-                    }),
-                );
+                const fileName = normalizeFileName(frame.fileName);
+                return getCodeSnippet(fileReader, fileName, frame.lineNumber, frame.columnNumber).then((snippet) => ({
+                    lineNumber: frame.lineNumber || 1,
+                    columnNumber: frame.columnNumber || 1,
+                    method: frame.functionName || 'Anonymous or unknown function',
+                    file: fileName || 'Unknown file',
+                    codeSnippet: snippet.codeSnippet,
+                    class: '',
+                    isApplicationFrame: isApplicationFrame(fileName),
+                }));
             }),
         ).then(resolve);
     });
+}
+
+// Hermes (React Native's default engine) emits stack frames like
+// `onPress@address at index.android.bundle:1:1234`. error-stack-parser keeps the
+// `address at ` literal as part of the fileName, which breaks both sourcemap matching
+// (the backend matches the bundle path against the uploaded relative_filename) and
+// source display. Strip the prefix so `file` is the real bundle path. No real file
+// path begins with `address at `, so this is a no-op on other engines.
+const HERMES_ADDRESS_PREFIX = 'address at ';
+
+function normalizeFileName(fileName: string | undefined): string | undefined {
+    if (fileName?.startsWith(HERMES_ADDRESS_PREFIX)) {
+        return fileName.slice(HERMES_ADDRESS_PREFIX.length);
+    }
+    return fileName;
 }
 
 function fallbackFrame(reason: string): StackFrame {

--- a/packages/core/tests/createStackTrace.test.ts
+++ b/packages/core/tests/createStackTrace.test.ts
@@ -33,6 +33,24 @@ test('returns a fallback frame array when ErrorStackParser throws', async () => 
     expect(frames.length).toBeGreaterThan(0);
 });
 
+test('strips the Hermes "address at " prefix from frame file names', async () => {
+    (ErrorStackParser.parse as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(() => [
+        {
+            fileName: 'address at index.android.bundle',
+            lineNumber: 1,
+            columnNumber: 12345,
+            functionName: 'onPress',
+        },
+    ]);
+
+    const error = new Error('boom');
+    error.stack = 'Error: boom\n    at fn (file.js:1:1)';
+
+    const frames = await createStackTrace(error, false, nullReader);
+
+    expect(frames[0].file).toBe('index.android.bundle');
+});
+
 test('marks node_modules frames as non-application', async () => {
     (ErrorStackParser.parse as unknown as ReturnType<typeof vi.fn>).mockImplementationOnce(() => [
         {

--- a/packages/react-native-sourcemaps/.oxlintrc.json
+++ b/packages/react-native-sourcemaps/.oxlintrc.json
@@ -1,0 +1,7 @@
+{
+    "$schema": "../../node_modules/oxlint/configuration_schema.json",
+    "extends": ["../../.oxlintrc.json"],
+    "env": {
+        "node": true
+    }
+}

--- a/packages/react-native-sourcemaps/.release-it.json
+++ b/packages/react-native-sourcemaps/.release-it.json
@@ -1,0 +1,19 @@
+{
+    "git": {
+        "tagName": "@flareapp/react-native-sourcemaps@${version}",
+        "tagAnnotation": "Release @flareapp/react-native-sourcemaps@${version}",
+        "commitMessage": "chore: release @flareapp/react-native-sourcemaps@${version}",
+        "requireBranch": "main",
+        "requireCleanWorkingDir": true,
+        "push": true
+    },
+    "npm": {
+        "publish": true
+    },
+    "github": {
+        "release": false
+    },
+    "hooks": {
+        "before:release": "npm test --if-present"
+    }
+}

--- a/packages/react-native-sourcemaps/README.md
+++ b/packages/react-native-sourcemaps/README.md
@@ -99,8 +99,7 @@ hooks read a committed `flare.json` at your project root:
 
 ```json
 {
-    "apiKey": "your-flare-api-key",
-    "apiEndpoint": "https://flareapp.io/api/sourcemaps"
+    "apiKey": "your-flare-api-key"
 }
 ```
 
@@ -120,7 +119,8 @@ large warning banner** — your build never fails because of a sourcemap problem
 
 ### Android
 
-Add one line to `android/app/build.gradle` (after the `react` block):
+Add this line to `android/app/build.gradle`. It can go anywhere in the file — the script
+hooks the build lazily, so the order doesn't matter:
 
 ```gradle
 apply from: "../../node_modules/@flareapp/react-native-sourcemaps/flare.gradle"
@@ -150,7 +150,23 @@ This uploads the Hermes-composed map after every `release` JS-bundle task.
     The `with-environment.sh` wrapper is required so the phase sees `SOURCEMAP_FILE`
     (and any `FLARE_*` vars) exported by `.xcode.env`.
 
-Both hooks only run for **Release** builds; debug builds do nothing.
+#### Custom build configurations (bare / brownfield)
+
+Your build configuration doesn't have to be called `Release`.
+
+The hooks upload whenever a build makes a JavaScript bundle. They skip a build only when
+its name contains `debug` (any casing).
+
+- Uploads: `Release`, `Staging`, `Production`, `AppStore`, your own Android build type
+- Skipped: `Debug`, `debug`, `StagingDebug`
+
+A debug build runs from Metro and makes no bundle, so there's nothing to upload. The hook
+skips it and your dev builds stay fast.
+
+Want a bundling config to skip the upload anyway? Put `debug` in its name. Or remove the
+Flare setup you added above — the `apply from "…/flare.gradle"` line in
+`android/app/build.gradle` on Android, or the **Upload Flare sourcemaps** build phase in
+Xcode on iOS — which turns the automatic upload off completely.
 
 ### Expo (CNG / managed)
 
@@ -167,8 +183,9 @@ it injects the same native wiring on every prebuild, so it survives regeneration
 
 You still add the Babel plugin and pass `flareSourcemapVersion` (steps above), and you
 still set `FLARE_SOURCEMAP_VERSION` in the build environment (locally, or in
-`eas.json`'s `build.<profile>.env` for EAS Build). The plugin writes a generated
-`flare.json` and adds it to `.gitignore` — that is expected.
+`eas.json`'s `build.<profile>.env` for EAS Build). The plugin creates a `flare.json` at
+your project root and adds it to `.gitignore`. That's expected. You don't edit it; it's
+generated from your `app.json`.
 
 > **OTA / EAS Update is not covered.** The plugin only runs during a native build
 > (`expo run:*`, EAS Build). `eas update` ships JS via `expo export` with no native

--- a/packages/react-native-sourcemaps/README.md
+++ b/packages/react-native-sourcemaps/README.md
@@ -150,6 +150,11 @@ This uploads the Hermes-composed map after every `release` JS-bundle task.
     The `with-environment.sh` wrapper is required so the phase sees `SOURCEMAP_FILE`
     (and any `FLARE_*` vars) exported by `.xcode.env`.
 
+3. In that build phase, **uncheck "Based on Dependency Analysis"**. With no input/output
+   files, Xcode otherwise warns that the script has ambiguous dependencies and runs on
+   every build — which is what you want for a release upload. (The Expo config plugin
+   sets this automatically.)
+
 > The phase reads `FLARE_SOURCEMAP_VERSION` (and `FLARE_API_KEY`, if the key isn't in
 > `flare.json`) from the **build's** environment, which it inherits from whatever
 > launched the build. `react-native run-ios`, `xcodebuild`, or Fastlane from a terminal

--- a/packages/react-native-sourcemaps/README.md
+++ b/packages/react-native-sourcemaps/README.md
@@ -9,8 +9,10 @@ It has two halves that share one version string:
 2. A **CLI** (`flare-rn-sourcemaps upload`) that uploads the `.map` under that
    same version.
 
-> Native auto-wiring (Android Gradle, iOS Xcode, Expo config plugin) ships
-> separately. This package covers the manual and `expo export` flows.
+> The manual CLI flow below works everywhere. For **bare React Native** you can also
+> wire the upload into the native release build so it happens automatically — see
+> "Automatic upload (bare React Native)" near the end. The Expo config plugin ships
+> separately.
 
 ## Install
 
@@ -89,6 +91,66 @@ Flags:
 | `--api-endpoint`    | no       | Defaults to `https://flareapp.io/api/sourcemaps`.                                              |
 
 \* Without a key the command warns and does nothing.
+
+## Automatic upload (bare React Native)
+
+Instead of running the CLI by hand, wire it into your native release build. Both
+hooks read a committed `flare.json` at your project root:
+
+```json
+{
+    "apiKey": "your-flare-api-key",
+    "apiEndpoint": "https://flareapp.io/api/sourcemaps"
+}
+```
+
+`apiKey` may also come from the `FLARE_API_KEY` environment variable (which wins over
+the file, so CI can inject it without committing a key).
+
+The version is taken **only** from `FLARE_SOURCEMAP_VERSION` here (the same variable
+the Babel plugin reads), so the inlined version and the uploaded version always match.
+Set it in your build environment:
+
+```bash
+export FLARE_SOURCEMAP_VERSION="$(git rev-parse --short HEAD)"
+```
+
+If the key or `FLARE_SOURCEMAP_VERSION` is missing, the upload is **skipped with a
+large warning banner** — your build never fails because of a sourcemap problem.
+
+### Android
+
+Add one line to `android/app/build.gradle` (after the `react` block):
+
+```gradle
+apply from: "../../node_modules/@flareapp/react-native-sourcemaps/flare.gradle"
+```
+
+This uploads the Hermes-composed map after every `release` JS-bundle task.
+
+### iOS
+
+1. Tell the stock React Native bundle phase to emit a sourcemap by adding this line
+   to `ios/.xcode.env`:
+
+    ```sh
+    export SOURCEMAP_FILE="$CONFIGURATION_BUILD_DIR/main.jsbundle.map"
+    ```
+
+2. In Xcode, add a new "Run Script" build phase named **Upload Flare sourcemaps**,
+   placed **after** "Bundle React Native code and images", with this script:
+
+    ```sh
+    set -e
+    WITH_ENVIRONMENT="../node_modules/react-native/scripts/xcode/with-environment.sh"
+    FLARE_XCODE="../node_modules/@flareapp/react-native-sourcemaps/scripts/flare-xcode.sh"
+    /bin/sh -c "$WITH_ENVIRONMENT $FLARE_XCODE"
+    ```
+
+    The `with-environment.sh` wrapper is required so the phase sees `SOURCEMAP_FILE`
+    (and any `FLARE_*` vars) exported by `.xcode.env`.
+
+Both hooks only run for **Release** builds; debug builds do nothing.
 
 ## Expo (`expo export`)
 

--- a/packages/react-native-sourcemaps/README.md
+++ b/packages/react-native-sourcemaps/README.md
@@ -150,6 +150,12 @@ This uploads the Hermes-composed map after every `release` JS-bundle task.
     The `with-environment.sh` wrapper is required so the phase sees `SOURCEMAP_FILE`
     (and any `FLARE_*` vars) exported by `.xcode.env`.
 
+> The phase reads `FLARE_SOURCEMAP_VERSION` (and `FLARE_API_KEY`, if the key isn't in
+> `flare.json`) from the **build's** environment, not your shell. `react-native run-ios`
+> from a terminal that exported them works; an Xcode build or Archive doesn't inherit
+> your shell, so set the variables in the scheme's environment (or CI). If they're
+> missing, the upload skips with the banner and the build still succeeds.
+
 #### Custom build configurations (bare / brownfield)
 
 Your build configuration doesn't have to be called `Release`.
@@ -186,6 +192,13 @@ still set `FLARE_SOURCEMAP_VERSION` in the build environment (locally, or in
 `eas.json`'s `build.<profile>.env` for EAS Build). The plugin creates a `flare.json` at
 your project root and adds it to `.gitignore`. That's expected. You don't edit it; it's
 generated from your `app.json`.
+
+> **Build from the command line, not the IDE.** The upload reads `FLARE_SOURCEMAP_VERSION`
+> (and `FLARE_API_KEY`, if it isn't in `flare.json`) from the build's environment. A build
+> started from Xcode or Android Studio doesn't inherit your shell or `.env`, so the
+> variables are missing and the upload skips with the banner. Run
+> `expo run:ios --configuration Release` / `expo run:android --variant release` (or EAS
+> Build) from a shell where they're set.
 
 > **OTA / EAS Update is not covered.** The plugin only runs during a native build
 > (`expo run:*`, EAS Build). `eas update` ships JS via `expo export` with no native

--- a/packages/react-native-sourcemaps/README.md
+++ b/packages/react-native-sourcemaps/README.md
@@ -1,0 +1,100 @@
+# @flareapp/react-native-sourcemaps
+
+Upload React Native (Metro) JavaScript sourcemaps to Flare so production stack
+traces are symbolicated.
+
+It has two halves that share one version string:
+
+1. A **Babel plugin** that inlines a build-time version into your app bundle.
+2. A **CLI** (`flare-rn-sourcemaps upload`) that uploads the `.map` under that
+   same version.
+
+> Native auto-wiring (Android Gradle, iOS Xcode, Expo config plugin) ships
+> separately. This package covers the manual and `expo export` flows.
+
+## Install
+
+```bash
+npm install --save-dev @flareapp/react-native-sourcemaps
+```
+
+## 1. Inline the version into your app
+
+Add the Babel plugin to `babel.config.js`:
+
+```js
+module.exports = {
+    presets: ['module:@react-native/babel-preset'],
+    plugins: ['@flareapp/react-native-sourcemaps/babel'],
+};
+```
+
+Then read the inlined value when configuring Flare:
+
+```js
+import { flare } from '@flareapp/react-native';
+
+flare.light(FLARE_KEY).configure({ sourcemapVersionId: process.env.FLARE_SOURCEMAP_VERSION });
+```
+
+The plugin replaces `process.env.FLARE_SOURCEMAP_VERSION` with the version it
+resolves at bundle time. Set that version in your build environment:
+
+```bash
+export FLARE_SOURCEMAP_VERSION="$(git rev-parse --short HEAD)"
+```
+
+If unset, it falls back to your app's `package.json` version (with a warning). Use the
+**same** version when you build the bundle and when you upload the map. If the two
+differ (for example the env var is set during the build but not during a later upload
+step, so one side falls back to `package.json`), the map will not match and
+symbolication silently fails.
+
+If your Babel config adds a generic `process.env` inliner (such as
+`babel-plugin-transform-inline-environment-variables`), list this plugin before it so
+the version token is not rewritten first. The default React Native and Expo presets do
+not inline `process.env`, so no ordering change is needed for a stock setup.
+
+## 2. Upload the sourcemap
+
+Generate a bundle + map, then upload the map under the **same** version:
+
+> Release builds use Hermes, which compiles your JS to bytecode. The map that
+> symbolicates production frames is the **Hermes-composed** map, not the plain Metro JS
+> map. Point `--sourcemap` at the composed `.map` your build emits (the one next to the
+> shipped bundle), not an intermediate Metro map.
+
+```bash
+# Example: Android, Hermes-composed map produced by your build
+npx flare-rn-sourcemaps upload \
+  --api-key "$FLARE_KEY" \
+  --sourcemap android/app/build/.../index.android.bundle.map \
+  --bundle-filename index.android.bundle \
+  --version "$FLARE_SOURCEMAP_VERSION"
+```
+
+Flags:
+
+| Flag                | Required | Description                                                                                    |
+| ------------------- | -------- | ---------------------------------------------------------------------------------------------- |
+| `--sourcemap`       | yes      | Path to the composed `.map` file.                                                              |
+| `--api-key`         | yes\*    | Flare API key. Falls back to `FLARE_API_KEY`.                                                  |
+| `--bundle-filename` | no       | `relative_filename` matched against runtime frames. Defaults to the map basename minus `.map`. |
+| `--version`         | no       | Defaults to `FLARE_SOURCEMAP_VERSION`, then `package.json` version.                            |
+| `--api-endpoint`    | no       | Defaults to `https://flareapp.io/api/sourcemaps`.                                              |
+
+\* Without a key the command warns and does nothing.
+
+## Expo (`expo export`)
+
+```bash
+FLARE_SOURCEMAP_VERSION="$(git rev-parse --short HEAD)" npx expo export
+npx flare-rn-sourcemaps upload \
+  --api-key "$FLARE_KEY" \
+  --sourcemap dist/_expo/static/js/ios/index-*.hbc.map \
+  --bundle-filename main.jsbundle \
+  --version "$FLARE_SOURCEMAP_VERSION"
+```
+
+> `--bundle-filename` must match how frames appear in your Flare reports. If
+> traces are not symbolicating, that is the value to adjust.

--- a/packages/react-native-sourcemaps/README.md
+++ b/packages/react-native-sourcemaps/README.md
@@ -152,6 +152,30 @@ This uploads the Hermes-composed map after every `release` JS-bundle task.
 
 Both hooks only run for **Release** builds; debug builds do nothing.
 
+### Expo (CNG / managed)
+
+For an Expo project that uses prebuild (CNG), add the config plugin to `app.json` —
+it injects the same native wiring on every prebuild, so it survives regeneration:
+
+```json
+{
+    "expo": {
+        "plugins": [["@flareapp/react-native-sourcemaps/expo", { "apiKey": "YOUR PROJECT KEY" }]]
+    }
+}
+```
+
+You still add the Babel plugin and pass `flareSourcemapVersion` (steps above), and you
+still set `FLARE_SOURCEMAP_VERSION` in the build environment (locally, or in
+`eas.json`'s `build.<profile>.env` for EAS Build). The plugin writes a generated
+`flare.json` and adds it to `.gitignore` — that is expected.
+
+> **OTA / EAS Update is not covered.** The plugin only runs during a native build
+> (`expo run:*`, EAS Build). `eas update` ships JS via `expo export` with no native
+> build phase, so it uploads no map. For OTA releases, upload the map yourself with
+> `flare-rn-sourcemaps upload` under the **same** `FLARE_SOURCEMAP_VERSION` you exported
+> with.
+
 ## Expo (`expo export`)
 
 ```bash

--- a/packages/react-native-sourcemaps/README.md
+++ b/packages/react-native-sourcemaps/README.md
@@ -134,8 +134,14 @@ This uploads the Hermes-composed map after every `release` JS-bundle task.
    to `ios/.xcode.env`:
 
     ```sh
-    export SOURCEMAP_FILE="$CONFIGURATION_BUILD_DIR/main.jsbundle.map"
+    export SOURCEMAP_FILE="$TARGET_TEMP_DIR/main.jsbundle.map"
     ```
+
+    Use `$TARGET_TEMP_DIR`, **not** `$CONFIGURATION_BUILD_DIR`. With Hermes,
+    `react-native-xcode.sh` writes an intermediate map to
+    `$CONFIGURATION_BUILD_DIR/main.jsbundle.map` and then deletes it after composing the
+    final map — so pointing `SOURCEMAP_FILE` there would have the composed map deleted
+    out from under the upload.
 
 2. In Xcode, add a new "Run Script" build phase named **Upload Flare sourcemaps**,
    placed **after** "Bundle React Native code and images", with this script:

--- a/packages/react-native-sourcemaps/README.md
+++ b/packages/react-native-sourcemaps/README.md
@@ -151,10 +151,11 @@ This uploads the Hermes-composed map after every `release` JS-bundle task.
     (and any `FLARE_*` vars) exported by `.xcode.env`.
 
 > The phase reads `FLARE_SOURCEMAP_VERSION` (and `FLARE_API_KEY`, if the key isn't in
-> `flare.json`) from the **build's** environment, not your shell. `react-native run-ios`
-> from a terminal that exported them works; an Xcode build or Archive doesn't inherit
-> your shell, so set the variables in the scheme's environment (or CI). If they're
-> missing, the upload skips with the banner and the build still succeeds.
+> `flare.json`) from the **build's** environment, which it inherits from whatever
+> launched the build. `react-native run-ios`, `xcodebuild`, or Fastlane from a terminal
+> that exported them works; a build from the Xcode GUI (including Product > Archive)
+> doesn't have them, so archive from the command line or in CI for releases. The upload
+> skips with the banner if they're missing, and the build still succeeds.
 
 #### Custom build configurations (bare / brownfield)
 
@@ -193,12 +194,16 @@ still set `FLARE_SOURCEMAP_VERSION` in the build environment (locally, or in
 your project root and adds it to `.gitignore`. That's expected. You don't edit it; it's
 generated from your `app.json`.
 
-> **Build from the command line, not the IDE.** The upload reads `FLARE_SOURCEMAP_VERSION`
-> (and `FLARE_API_KEY`, if it isn't in `flare.json`) from the build's environment. A build
-> started from Xcode or Android Studio doesn't inherit your shell or `.env`, so the
-> variables are missing and the upload skips with the banner. Run
-> `expo run:ios --configuration Release` / `expo run:android --variant release` (or EAS
-> Build) from a shell where they're set.
+**Releasing without EAS?** You don't have to. The upload reads `FLARE_SOURCEMAP_VERSION`
+(and `FLARE_API_KEY`, if it isn't in `flare.json`) from the build's environment, which is
+inherited from whatever **launches** the build. So EAS Build (`eas.json` env),
+`eas build --local`, or a command-line archive (`xcodebuild` / Fastlane on iOS,
+`./gradlew bundleRelease` on Android) all work, as long as you exported the variables in
+that shell.
+
+> The one exception is the **Xcode / Android Studio GUI** (including Product > Archive):
+> it was launched by the OS, not your shell, so it doesn't have your variables and the
+> upload skips with the banner. Archive from the command line, or use EAS, for releases.
 
 > **OTA / EAS Update is not covered.** The plugin only runs during a native build
 > (`expo run:*`, EAS Build). `eas update` ships JS via `expo export` with no native

--- a/packages/react-native-sourcemaps/README.md
+++ b/packages/react-native-sourcemaps/README.md
@@ -29,16 +29,21 @@ module.exports = {
 };
 ```
 
-Then read the inlined value when configuring Flare:
+Then pass the inlined version when configuring Flare. Import `flareSourcemapVersion`
+from the package's runtime entry — it's a typed `string`, so there is no `process`
+global to type and no `@types/node` to add:
 
-```js
+```ts
 import { flare } from '@flareapp/react-native';
+import { flareSourcemapVersion } from '@flareapp/react-native-sourcemaps/runtime';
 
-flare.light(FLARE_KEY).configure({ sourcemapVersionId: process.env.FLARE_SOURCEMAP_VERSION });
+flare.light(FLARE_KEY).configure({ sourcemapVersionId: flareSourcemapVersion });
 ```
 
-The plugin replaces `process.env.FLARE_SOURCEMAP_VERSION` with the version it
-resolves at bundle time. Set that version in your build environment:
+The plugin replaces every reference to `flareSourcemapVersion` with the version it
+resolves at bundle time (and removes the import, so nothing of this package ships in
+your app bundle). Without the plugin the value is an empty string, which is harmless.
+Set the version in your build environment:
 
 ```bash
 export FLARE_SOURCEMAP_VERSION="$(git rev-parse --short HEAD)"

--- a/packages/react-native-sourcemaps/README.md
+++ b/packages/react-native-sourcemaps/README.md
@@ -227,6 +227,15 @@ that shell.
 > `FLARE_SOURCEMAP_VERSION` and the upload skips with the banner. Archive from the
 > command line, or use EAS, for releases.
 
+> **`expo run:android` / `expo run:ios` are not a reliable upload path.** Both
+> eager-bundle the JS to a temp dir, and the native bundle task our hook runs after can
+> be reported **up-to-date** and skipped — so you get an installed app but no upload.
+> Changing only `FLARE_SOURCEMAP_VERSION` doesn't re-trigger it (it isn't a build
+> input). Use `expo run:*` for development, but **release and verify** through
+> `eas build` / `eas build --local` or a direct native build (`./gradlew
+:app:assembleRelease`, `xcodebuild`). When testing locally, add `--rerun-tasks` to the
+> Gradle command to force a fresh bundle and upload.
+
 > **OTA / EAS Update is not covered.** The plugin only runs during a native build
 > (`expo run:*`, EAS Build). `eas update` ships JS via `expo export` with no native
 > build phase, so it uploads no map. For OTA releases, upload the map yourself with

--- a/packages/react-native-sourcemaps/README.md
+++ b/packages/react-native-sourcemaps/README.md
@@ -103,8 +103,17 @@ hooks read a committed `flare.json` at your project root:
 }
 ```
 
-`apiKey` may also come from the `FLARE_API_KEY` environment variable (which wins over
-the file, so CI can inject it without committing a key).
+To keep the key out of version control, drop it in a gitignored `.env.local` (or
+`.env`) next to `flare.json` instead — the hooks auto-load `FLARE_API_KEY` from there
+at build time:
+
+```bash
+# .env.local (gitignored)
+FLARE_API_KEY=your-flare-api-key
+```
+
+Precedence: shell env > `.env.local` > `.env` > `flare.json`. An explicit
+`FLARE_API_KEY` in the build environment wins over all of them.
 
 The version is taken **only** from `FLARE_SOURCEMAP_VERSION` here (the same variable
 the Babel plugin reads), so the inlined version and the uploaded version always match.
@@ -161,12 +170,13 @@ This uploads the Hermes-composed map after every `release` JS-bundle task.
    every build — which is what you want for a release upload. (The Expo config plugin
    sets this automatically.)
 
-> The phase reads `FLARE_SOURCEMAP_VERSION` (and `FLARE_API_KEY`, if the key isn't in
-> `flare.json`) from the **build's** environment, which it inherits from whatever
-> launched the build. `react-native run-ios`, `xcodebuild`, or Fastlane from a terminal
-> that exported them works; a build from the Xcode GUI (including Product > Archive)
-> doesn't have them, so archive from the command line or in CI for releases. The upload
-> skips with the banner if they're missing, and the build still succeeds.
+> The key comes from `flare.json` or the auto-loaded `.env.local`, so it's there even
+> for a GUI build. The **version** (`FLARE_SOURCEMAP_VERSION`) is the one variable the
+> phase still reads from the **build's** environment, inherited from whatever launched
+> the build. `react-native run-ios`, `xcodebuild`, or Fastlane from a terminal that
+> exported it works; a build from the Xcode GUI (including Product > Archive) doesn't
+> have it, so archive from the command line or in CI for releases. The upload skips with
+> the banner if it's missing, and the build still succeeds.
 
 #### Custom build configurations (bare / brownfield)
 
@@ -205,16 +215,17 @@ still set `FLARE_SOURCEMAP_VERSION` in the build environment (locally, or in
 your project root and adds it to `.gitignore`. That's expected. You don't edit it; it's
 generated from your `app.json`.
 
-**Releasing without EAS?** You don't have to. The upload reads `FLARE_SOURCEMAP_VERSION`
-(and `FLARE_API_KEY`, if it isn't in `flare.json`) from the build's environment, which is
-inherited from whatever **launches** the build. So EAS Build (`eas.json` env),
-`eas build --local`, or a command-line archive (`xcodebuild` / Fastlane on iOS,
-`./gradlew bundleRelease` on Android) all work, as long as you exported the variables in
+**Releasing without EAS?** You don't have to. The key comes from `flare.json` or the
+auto-loaded `.env.local`; the upload reads `FLARE_SOURCEMAP_VERSION` from the build's
+environment, inherited from whatever **launches** the build. So EAS Build (`eas.json`
+env), `eas build --local`, or a command-line archive (`xcodebuild` / Fastlane on iOS,
+`./gradlew bundleRelease` on Android) all work, as long as you exported the version in
 that shell.
 
-> The one exception is the **Xcode / Android Studio GUI** (including Product > Archive):
-> it was launched by the OS, not your shell, so it doesn't have your variables and the
-> upload skips with the banner. Archive from the command line, or use EAS, for releases.
+> The one exception is the version under the **Xcode / Android Studio GUI** (including
+> Product > Archive): it was launched by the OS, not your shell, so it doesn't have
+> `FLARE_SOURCEMAP_VERSION` and the upload skips with the banner. Archive from the
+> command line, or use EAS, for releases.
 
 > **OTA / EAS Update is not covered.** The plugin only runs during a native build
 > (`expo run:*`, EAS Build). `eas update` ships JS via `expo export` with no native

--- a/packages/react-native-sourcemaps/flare.gradle
+++ b/packages/react-native-sourcemaps/flare.gradle
@@ -19,25 +19,37 @@ gradle.projectsEvaluated {
         def name = task.name
         def isBundleTask = (name.startsWith("createBundle") || name.startsWith("bundle")) &&
             name.endsWith("JsAndAssets")
-        def isRelease = name.toLowerCase().contains("release")
-        if (!isBundleTask || !isRelease) {
+        // Don't require the variant name to contain "release". Brownfield/bare apps
+        // rename the release build type (Production, AppStore, ...), so requiring
+        // "release" would silently skip the upload on exactly the builds that ship.
+        // Skip only the dev (debug) variants, matched case-insensitively as a
+        // substring (symmetric with the iOS hook); the "no sourcemap -> skip" guard
+        // below then handles any non-bundling variant for free.
+        def isDebug = name.toLowerCase().contains("debug")
+        if (!isBundleTask || isDebug) {
             return
         }
 
         task.doLast {
-            // Prefer the map path the task itself exposes (handles a custom
-            // bundleAssetName); fall back to the stock generated location.
+            // Prefer the map path the task itself exposes (authoritative for any
+            // variant and a custom bundleAssetName); fall back to the stock generated
+            // location otherwise. Derive the variant subdir from the task name rather
+            // than hardcoding "release", so a renamed build type (Production, ...)
+            // still resolves. `project` is the module this file is applied from — the
+            // documented usage is android/app/build.gradle, so project.projectDir is
+            // android/app.
             def sourcemapPath = null
             if (task.hasProperty("sourcemapOutput") && task.sourcemapOutput != null) {
                 sourcemapPath = task.sourcemapOutput.toString()
             } else {
-                // Stock generated location. `project` is the module this file is
-                // applied from — the documented usage is android/app/build.gradle,
-                // so project.projectDir is android/app and this resolves to
-                // android/app/build/generated/sourcemaps/react/release/.
+                // createBundle<Variant>JsAndAssets / bundle<Variant>JsAndAssets ->
+                // <variant>, decapitalised to match Gradle's camelCase variant name
+                // (e.g. "Release" -> "release", "StagingRelease" -> "stagingRelease").
+                def raw = name.replaceFirst(/^(createBundle|bundle)/, "").replaceFirst(/JsAndAssets$/, "")
+                def variant = raw.isEmpty() ? raw : raw.substring(0, 1).toLowerCase() + raw.substring(1)
                 sourcemapPath = new File(
                     project.projectDir,
-                    "build/generated/sourcemaps/react/release/index.android.bundle.map"
+                    "build/generated/sourcemaps/react/${variant}/index.android.bundle.map"
                 ).absolutePath
             }
 

--- a/packages/react-native-sourcemaps/flare.gradle
+++ b/packages/react-native-sourcemaps/flare.gradle
@@ -31,26 +31,33 @@ gradle.projectsEvaluated {
         }
 
         task.doLast {
-            // Prefer the map path the task itself exposes (authoritative for any
-            // variant and a custom bundleAssetName); fall back to the stock generated
-            // location otherwise. Derive the variant subdir from the task name rather
-            // than hardcoding "release", so a renamed build type (Production, ...)
-            // still resolves. `project` is the module this file is applied from — the
-            // documented usage is android/app/build.gradle, so project.projectDir is
+            // Variant subdir (e.g. "release", "stagingRelease"), derived from the task
+            // name rather than hardcoded "release" so a renamed build type (Production,
+            // ...) still resolves. createBundle<Variant>JsAndAssets /
+            // bundle<Variant>JsAndAssets -> <variant>, decapitalised to match Gradle's
+            // camelCase variant name. `project` is the module this file is applied from;
+            // the documented usage is android/app/build.gradle, so project.projectDir is
             // android/app.
-            def sourcemapPath = null
-            if (task.hasProperty("sourcemapOutput") && task.sourcemapOutput != null) {
+            def raw = name.replaceFirst(/^(createBundle|bundle)/, "").replaceFirst(/JsAndAssets$/, "")
+            def variant = raw.isEmpty() ? raw : raw.substring(0, 1).toLowerCase() + raw.substring(1)
+
+            // With Hermes, the map that resolves against the shipped bytecode is the
+            // COMPOSED map at build/generated/sourcemaps/react/<variant>/index.android.bundle.map.
+            // The packager map exposed via task.sourcemapOutput is the pre-Hermes metro
+            // map and would NOT line up, so prefer the composed map whenever it exists.
+            // Only fall back to sourcemapOutput for a non-Hermes (JSC) build, where the
+            // packager map IS the final map.
+            def composed = new File(
+                project.projectDir,
+                "build/generated/sourcemaps/react/${variant}/index.android.bundle.map"
+            )
+            def sourcemapPath
+            if (composed.exists()) {
+                sourcemapPath = composed.absolutePath
+            } else if (task.hasProperty("sourcemapOutput") && task.sourcemapOutput != null) {
                 sourcemapPath = task.sourcemapOutput.toString()
             } else {
-                // createBundle<Variant>JsAndAssets / bundle<Variant>JsAndAssets ->
-                // <variant>, decapitalised to match Gradle's camelCase variant name
-                // (e.g. "Release" -> "release", "StagingRelease" -> "stagingRelease").
-                def raw = name.replaceFirst(/^(createBundle|bundle)/, "").replaceFirst(/JsAndAssets$/, "")
-                def variant = raw.isEmpty() ? raw : raw.substring(0, 1).toLowerCase() + raw.substring(1)
-                sourcemapPath = new File(
-                    project.projectDir,
-                    "build/generated/sourcemaps/react/${variant}/index.android.bundle.map"
-                ).absolutePath
+                sourcemapPath = composed.absolutePath
             }
 
             if (!new File(sourcemapPath).exists()) {
@@ -60,25 +67,29 @@ gradle.projectsEvaluated {
 
             // Prefer the resolved .bin; fall back to npx (Windows, or a missing bin).
             def baseCommand = flareCli.exists() ? [flareCli.absolutePath] : ["npx", "flare-rn-sourcemaps"]
+            def command = baseCommand + [
+                "upload",
+                "--sourcemap", sourcemapPath,
+                "--config", flareConfig.absolutePath,
+                "--auto",
+            ]
 
+            // Run via ProcessBuilder, NOT Gradle's `exec {}`. Inside a task action the
+            // closure delegate is the task, so a bare `exec {}` fails to resolve ("Could
+            // not find method exec()"), and `project.exec` is flagged by the
+            // configuration cache. ProcessBuilder has neither problem and inherits the
+            // build environment (FLARE_SOURCEMAP_VERSION / FLARE_API_KEY flow through; the
+            // CLI also auto-loads them from .env.local at the project root). The CLI exits
+            // 0 on every upload failure mode, so this can never break the build; the catch
+            // guards only a failure to launch the process (e.g. node not on PATH).
             try {
-                exec {
-                    workingDir flareProjectRoot
-                    commandLine(baseCommand + [
-                        "upload",
-                        "--sourcemap", sourcemapPath,
-                        "--config", flareConfig.absolutePath,
-                        "--auto",
-                    ])
-                    // The CLI already exits 0 on every upload failure mode; this
-                    // ignores a non-zero exit as a second guard.
-                    ignoreExitValue true
-                }
+                def process = new ProcessBuilder(command)
+                    .directory(flareProjectRoot)
+                    .redirectErrorStream(true)
+                    .start()
+                process.inputStream.eachLine { line -> logger.lifecycle(line) }
+                process.waitFor()
             } catch (Exception e) {
-                // ignoreExitValue covers a non-zero exit but NOT a failure to launch
-                // the process (e.g. `npx`/node not on PATH for a GUI-triggered
-                // build), which throws an ExecException. Catch it so a sourcemap
-                // problem can never break the release build.
                 logger.warn("@flareapp/react-native-sourcemaps: could not run the upload CLI (${e.message}); skipping. Your release will report minified stack traces until the sourcemap is uploaded.")
             }
         }

--- a/packages/react-native-sourcemaps/flare.gradle
+++ b/packages/react-native-sourcemaps/flare.gradle
@@ -1,0 +1,70 @@
+// Flare automatic sourcemap upload for bare React Native (Android).
+//
+// Apply from android/app/build.gradle:
+//   apply from: "../../node_modules/@flareapp/react-native-sourcemaps/flare.gradle"
+//
+// Hooks the release JS-bundle task and, after it runs, uploads the Hermes-composed
+// sourcemap to Flare. Never fails the build: the CLI exits 0 in --auto mode and the
+// exec ignores its exit value as a belt-and-braces guard.
+
+def flareProjectRoot = rootProject.projectDir.parentFile // android/ -> project root
+def flareConfig = new File(flareProjectRoot, "flare.json")
+// Prefer the resolved bin over `npx` (avoids npx's PATH ambiguity and any network
+// fetch), matching the iOS hook. The no-extension unix bin is checked here; on
+// Windows it is a `.cmd` this misses, so we fall back to `npx` there.
+def flareCli = new File(flareProjectRoot, "node_modules/.bin/flare-rn-sourcemaps")
+
+gradle.projectsEvaluated {
+    tasks.configureEach { task ->
+        def name = task.name
+        def isBundleTask = (name.startsWith("createBundle") || name.startsWith("bundle")) &&
+            name.endsWith("JsAndAssets")
+        def isRelease = name.toLowerCase().contains("release")
+        if (!isBundleTask || !isRelease) {
+            return
+        }
+
+        task.doLast {
+            // Prefer the map path the task itself exposes (handles a custom
+            // bundleAssetName); fall back to the stock generated location.
+            def sourcemapPath = null
+            if (task.hasProperty("sourcemapOutput") && task.sourcemapOutput != null) {
+                sourcemapPath = task.sourcemapOutput.toString()
+            } else {
+                sourcemapPath = new File(
+                    project.projectDir,
+                    "build/generated/sourcemaps/react/release/index.android.bundle.map"
+                ).absolutePath
+            }
+
+            if (!new File(sourcemapPath).exists()) {
+                logger.warn("@flareapp/react-native-sourcemaps: no sourcemap at ${sourcemapPath}, skipping upload.")
+                return
+            }
+
+            // Prefer the resolved .bin; fall back to npx (Windows, or a missing bin).
+            def baseCommand = flareCli.exists() ? [flareCli.absolutePath] : ["npx", "flare-rn-sourcemaps"]
+
+            try {
+                exec {
+                    workingDir flareProjectRoot
+                    commandLine(baseCommand + [
+                        "upload",
+                        "--sourcemap", sourcemapPath,
+                        "--config", flareConfig.absolutePath,
+                        "--auto",
+                    ])
+                    // The CLI already exits 0 on every upload failure mode; this
+                    // ignores a non-zero exit as a second guard.
+                    ignoreExitValue true
+                }
+            } catch (Exception e) {
+                // ignoreExitValue covers a non-zero exit but NOT a failure to launch
+                // the process (e.g. `npx`/node not on PATH for a GUI-triggered
+                // build), which throws an ExecException. Catch it so a sourcemap
+                // problem can never break the release build.
+                logger.warn("@flareapp/react-native-sourcemaps: could not run the upload CLI (${e.message}); skipping. Your release will report minified stack traces until the sourcemap is uploaded.")
+            }
+        }
+    }
+}

--- a/packages/react-native-sourcemaps/flare.gradle
+++ b/packages/react-native-sourcemaps/flare.gradle
@@ -31,6 +31,10 @@ gradle.projectsEvaluated {
             if (task.hasProperty("sourcemapOutput") && task.sourcemapOutput != null) {
                 sourcemapPath = task.sourcemapOutput.toString()
             } else {
+                // Stock generated location. `project` is the module this file is
+                // applied from — the documented usage is android/app/build.gradle,
+                // so project.projectDir is android/app and this resolves to
+                // android/app/build/generated/sourcemaps/react/release/.
                 sourcemapPath = new File(
                     project.projectDir,
                     "build/generated/sourcemaps/react/release/index.android.bundle.map"

--- a/packages/react-native-sourcemaps/package.json
+++ b/packages/react-native-sourcemaps/package.json
@@ -60,7 +60,7 @@
     },
     "scripts": {
         "prepublishOnly": "npm run build",
-        "build": "tsdown src/index.ts src/babel.ts src/bin.ts src/runtime.ts --format cjs,esm --dts --clean --noExternal @flareapp/flare-api",
+        "build": "tsdown",
         "test": "vitest run",
         "typescript": "tsc --noEmit",
         "release": "release-it"

--- a/packages/react-native-sourcemaps/package.json
+++ b/packages/react-native-sourcemaps/package.json
@@ -1,0 +1,77 @@
+{
+    "name": "@flareapp/react-native-sourcemaps",
+    "version": "0.1.0",
+    "description": "Upload React Native (Metro) sourcemaps to Flare",
+    "homepage": "https://flareapp.io",
+    "bugs": "https://github.com/spatie/flare-client-js/issues",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/spatie/flare-client-js.git"
+    },
+    "license": "MIT",
+    "author": {
+        "name": "Spatie",
+        "email": "info@spatie.be"
+    },
+    "files": [
+        "dist"
+    ],
+    "main": "./dist/index.cjs",
+    "module": "./dist/index.mjs",
+    "types": "./dist/index.d.cts",
+    "bin": {
+        "flare-rn-sourcemaps": "./dist/bin.cjs"
+    },
+    "exports": {
+        ".": {
+            "import": {
+                "types": "./dist/index.d.mts",
+                "default": "./dist/index.mjs"
+            },
+            "require": {
+                "types": "./dist/index.d.cts",
+                "default": "./dist/index.cjs"
+            }
+        },
+        "./babel": {
+            "import": {
+                "types": "./dist/babel.d.mts",
+                "default": "./dist/babel.mjs"
+            },
+            "require": {
+                "types": "./dist/babel.d.cts",
+                "default": "./dist/babel.cjs"
+            }
+        },
+        "./package.json": "./package.json"
+    },
+    "engines": {
+        "node": ">=18"
+    },
+    "scripts": {
+        "prepublishOnly": "npm run build",
+        "build": "tsdown src/index.ts src/babel.ts src/bin.ts --format cjs,esm --dts --clean --noExternal @flareapp/flare-api",
+        "test": "vitest run",
+        "typescript": "tsc --noEmit",
+        "release": "release-it"
+    },
+    "devDependencies": {
+        "@flareapp/flare-api": "*",
+        "@babel/core": "^7.0.0",
+        "@types/babel__core": "^7.0.0",
+        "tsdown": "^0.20.3",
+        "typescript": "^5.7.0",
+        "vitest": "^4.0.0"
+    },
+    "peerDependencies": {
+        "@babel/core": ">=7.0.0"
+    },
+    "peerDependenciesMeta": {
+        "@babel/core": {
+            "optional": true
+        }
+    },
+    "publishConfig": {
+        "access": "public"
+    }
+}

--- a/packages/react-native-sourcemaps/package.json
+++ b/packages/react-native-sourcemaps/package.json
@@ -43,6 +43,16 @@
                 "default": "./dist/babel.cjs"
             }
         },
+        "./runtime": {
+            "import": {
+                "types": "./dist/runtime.d.mts",
+                "default": "./dist/runtime.mjs"
+            },
+            "require": {
+                "types": "./dist/runtime.d.cts",
+                "default": "./dist/runtime.cjs"
+            }
+        },
         "./package.json": "./package.json"
     },
     "engines": {
@@ -50,7 +60,7 @@
     },
     "scripts": {
         "prepublishOnly": "npm run build",
-        "build": "tsdown src/index.ts src/babel.ts src/bin.ts --format cjs,esm --dts --clean --noExternal @flareapp/flare-api",
+        "build": "tsdown src/index.ts src/babel.ts src/bin.ts src/runtime.ts --format cjs,esm --dts --clean --noExternal @flareapp/flare-api",
         "test": "vitest run",
         "typescript": "tsc --noEmit",
         "release": "release-it"

--- a/packages/react-native-sourcemaps/package.json
+++ b/packages/react-native-sourcemaps/package.json
@@ -55,6 +55,11 @@
                 "default": "./dist/runtime.cjs"
             }
         },
+        "./expo": {
+            "types": "./dist/expo.d.cts",
+            "require": "./dist/expo.cjs",
+            "default": "./dist/expo.cjs"
+        },
         "./package.json": "./package.json"
     },
     "engines": {

--- a/packages/react-native-sourcemaps/package.json
+++ b/packages/react-native-sourcemaps/package.json
@@ -14,7 +14,9 @@
         "email": "info@spatie.be"
     },
     "files": [
-        "dist"
+        "dist",
+        "flare.gradle",
+        "scripts"
     ],
     "main": "./dist/index.cjs",
     "module": "./dist/index.mjs",

--- a/packages/react-native-sourcemaps/package.json
+++ b/packages/react-native-sourcemaps/package.json
@@ -68,18 +68,24 @@
         "release": "release-it"
     },
     "devDependencies": {
-        "@flareapp/flare-api": "*",
         "@babel/core": "^7.0.0",
+        "@expo/config-plugins": "^56.0.9",
+        "@flareapp/flare-api": "*",
         "@types/babel__core": "^7.0.0",
         "tsdown": "^0.20.3",
         "typescript": "^5.7.0",
-        "vitest": "^4.0.0"
+        "vitest": "^4.0.0",
+        "xcode": "^3.0.1"
     },
     "peerDependencies": {
-        "@babel/core": ">=7.0.0"
+        "@babel/core": ">=7.0.0",
+        "@expo/config-plugins": ">=7.0.0"
     },
     "peerDependenciesMeta": {
         "@babel/core": {
+            "optional": true
+        },
+        "@expo/config-plugins": {
             "optional": true
         }
     },

--- a/packages/react-native-sourcemaps/scripts/flare-xcode.sh
+++ b/packages/react-native-sourcemaps/scripts/flare-xcode.sh
@@ -35,7 +35,7 @@ esac
 # layout; if SOURCEMAP_FILE is unset and no map exists there, we skip below.
 SOURCEMAP_PATH="$SOURCEMAP_FILE"
 if [ -z "$SOURCEMAP_PATH" ]; then
-    SOURCEMAP_PATH="$CONFIGURATION_BUILD_DIR/main.jsbundle.map"
+    SOURCEMAP_PATH="$TARGET_TEMP_DIR/main.jsbundle.map"
 fi
 
 # Xcode hides build-phase stdout (and `expo run` condenses it), so emit the outcome

--- a/packages/react-native-sourcemaps/scripts/flare-xcode.sh
+++ b/packages/react-native-sourcemaps/scripts/flare-xcode.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+# Flare automatic sourcemap upload for bare React Native (iOS).
+#
+# Invoked from an Xcode "Upload Flare sourcemaps" build phase placed AFTER the stock
+# "Bundle React Native code and images" phase, wrapped in with-environment.sh so it
+# sees SOURCEMAP_FILE (and any FLARE_* exports) from .xcode.env:
+#
+#   set -e
+#   WITH_ENVIRONMENT="../node_modules/react-native/scripts/xcode/with-environment.sh"
+#   FLARE_XCODE="../node_modules/@flareapp/react-native-sourcemaps/scripts/flare-xcode.sh"
+#   /bin/sh -c "$WITH_ENVIRONMENT $FLARE_XCODE"
+#
+# Never fails the build: the CLI exits 0 in --auto mode, and the upload call is
+# guarded with `|| true`.
+
+if [ "$CONFIGURATION" != "Release" ]; then
+    echo "@flareapp/react-native-sourcemaps: CONFIGURATION=$CONFIGURATION, skipping (Release only)."
+    exit 0
+fi
+
+# Prefer the path the bundle phase wrote (SOURCEMAP_FILE from .xcode.env); otherwise
+# reconstruct the stock location from Xcode's auto-exported build settings.
+SOURCEMAP_PATH="$SOURCEMAP_FILE"
+if [ -z "$SOURCEMAP_PATH" ]; then
+    SOURCEMAP_PATH="$CONFIGURATION_BUILD_DIR/main.jsbundle.map"
+fi
+
+if [ ! -f "$SOURCEMAP_PATH" ]; then
+    echo "@flareapp/react-native-sourcemaps: no sourcemap at $SOURCEMAP_PATH, skipping upload."
+    exit 0
+fi
+
+CONFIG_PATH="$SRCROOT/../flare.json"
+
+CLI="$SRCROOT/../node_modules/.bin/flare-rn-sourcemaps"
+if [ -x "$CLI" ]; then
+    "$CLI" upload --sourcemap "$SOURCEMAP_PATH" --config "$CONFIG_PATH" --auto || true
+else
+    npx flare-rn-sourcemaps upload --sourcemap "$SOURCEMAP_PATH" --config "$CONFIG_PATH" --auto || true
+fi
+
+exit 0

--- a/packages/react-native-sourcemaps/scripts/flare-xcode.sh
+++ b/packages/react-native-sourcemaps/scripts/flare-xcode.sh
@@ -18,8 +18,9 @@ if [ "$CONFIGURATION" != "Release" ]; then
     exit 0
 fi
 
-# Prefer the path the bundle phase wrote (SOURCEMAP_FILE from .xcode.env); otherwise
-# reconstruct the stock location from Xcode's auto-exported build settings.
+# Prefer the path the bundle phase wrote (SOURCEMAP_FILE from .xcode.env, the
+# documented setup). The fallback is a best-effort heuristic for the stock iOS
+# layout; if SOURCEMAP_FILE is unset and no map exists there, we skip below.
 SOURCEMAP_PATH="$SOURCEMAP_FILE"
 if [ -z "$SOURCEMAP_PATH" ]; then
     SOURCEMAP_PATH="$CONFIGURATION_BUILD_DIR/main.jsbundle.map"

--- a/packages/react-native-sourcemaps/scripts/flare-xcode.sh
+++ b/packages/react-native-sourcemaps/scripts/flare-xcode.sh
@@ -38,8 +38,11 @@ if [ -z "$SOURCEMAP_PATH" ]; then
     SOURCEMAP_PATH="$CONFIGURATION_BUILD_DIR/main.jsbundle.map"
 fi
 
+# Xcode hides build-phase stdout (and `expo run` condenses it), so emit the outcome
+# with `warning:` / `note:` prefixes — Xcode surfaces those in the build results even
+# when the rest of the log is hidden.
 if [ ! -f "$SOURCEMAP_PATH" ]; then
-    echo "@flareapp/react-native-sourcemaps: no sourcemap at $SOURCEMAP_PATH, skipping upload."
+    echo "warning: Flare: no sourcemap at $SOURCEMAP_PATH — skipping upload. Was the bundle built with Hermes and SOURCEMAP_FILE set in ios/.xcode.env?"
     exit 0
 fi
 
@@ -47,9 +50,21 @@ CONFIG_PATH="$SRCROOT/../flare.json"
 
 CLI="$SRCROOT/../node_modules/.bin/flare-rn-sourcemaps"
 if [ -x "$CLI" ]; then
-    "$CLI" upload --sourcemap "$SOURCEMAP_PATH" --config "$CONFIG_PATH" --auto || true
+    FLARE_OUTPUT=$("$CLI" upload --sourcemap "$SOURCEMAP_PATH" --config "$CONFIG_PATH" --auto 2>&1)
 else
-    npx flare-rn-sourcemaps upload --sourcemap "$SOURCEMAP_PATH" --config "$CONFIG_PATH" --auto || true
+    FLARE_OUTPUT=$(npx flare-rn-sourcemaps upload --sourcemap "$SOURCEMAP_PATH" --config "$CONFIG_PATH" --auto 2>&1)
 fi
+
+# Echo the full detail (banner / success line) for anyone reading the raw log...
+echo "$FLARE_OUTPUT"
+# ...then a one-line Xcode-visible summary so you can tell from the build results alone.
+case "$FLARE_OUTPUT" in
+    *"Successfully uploaded"*)
+        echo "note: Flare: sourcemap uploaded ($SOURCEMAP_PATH)."
+        ;;
+    *)
+        echo "warning: Flare: sourcemap was NOT uploaded — see the Flare banner in the log above (usually a missing API key or FLARE_SOURCEMAP_VERSION)."
+        ;;
+esac
 
 exit 0

--- a/packages/react-native-sourcemaps/scripts/flare-xcode.sh
+++ b/packages/react-native-sourcemaps/scripts/flare-xcode.sh
@@ -13,10 +13,22 @@
 # Never fails the build: the CLI exits 0 in --auto mode, and the upload call is
 # guarded with `|| true`.
 
-if [ "$CONFIGURATION" != "Release" ]; then
-    echo "@flareapp/react-native-sourcemaps: CONFIGURATION=$CONFIGURATION, skipping (Release only)."
-    exit 0
-fi
+# Don't gate on the configuration NAME being "Release". Brownfield and bare apps rename
+# it or add release-style configurations (Staging, Production, AppStore, ...), none of
+# which equal "Release" — requiring that literal name would silently skip the upload on
+# exactly the builds that ship. The real signal is whether a composed sourcemap was
+# produced: only a bundled + Hermes-compiled (release-style) build emits one, and a
+# Debug/Metro build emits none, so the SOURCEMAP_PATH check below skips it for free.
+# We only fast-path the dev config, matched case-insensitively as a substring so
+# "Debug", "debug", "StagingDebug", etc. are all caught (POSIX sh: tr + case, no
+# bashisms).
+CONFIGURATION_LC=$(printf '%s' "$CONFIGURATION" | tr '[:upper:]' '[:lower:]')
+case "$CONFIGURATION_LC" in
+    *debug*)
+        echo "@flareapp/react-native-sourcemaps: CONFIGURATION=$CONFIGURATION, skipping (dev build)."
+        exit 0
+        ;;
+esac
 
 # Prefer the path the bundle phase wrote (SOURCEMAP_FILE from .xcode.env, the
 # documented setup). The fallback is a best-effort heuristic for the stock iOS

--- a/packages/react-native-sourcemaps/src/babel.ts
+++ b/packages/react-native-sourcemaps/src/babel.ts
@@ -1,0 +1,65 @@
+import type * as Babel from '@babel/core';
+
+import { resolveVersion } from './version';
+
+const ENV_TOKEN = 'FLARE_SOURCEMAP_VERSION';
+
+// Type queries on dynamic imports: no runtime import of @babel/* is emitted.
+// `Types` is the shape of the `t` helper object; `MemberExpressionNode` is the
+// AST interface. The types resolve via @types/babel__core (dev dependency).
+type Types = typeof import('@babel/types');
+type MemberExpressionNode = import('@babel/types').MemberExpression;
+
+/**
+ * Babel plugin that replaces `process.env.FLARE_SOURCEMAP_VERSION` with the
+ * resolved version string at bundle time. Metro does not inline arbitrary
+ * `process.env` reads, so without this the value is `undefined` at runtime in a
+ * bare RN app. The version is resolved once per plugin instance (lazily, on the
+ * first match) via the shared `resolveVersion()`.
+ */
+export default function flareSourcemapsBabelPlugin({ types: t }: { types: Types }): Babel.PluginObj {
+    let version: string | undefined;
+
+    return {
+        name: '@flareapp/react-native-sourcemaps',
+        visitor: {
+            MemberExpression(path: Babel.NodePath<MemberExpressionNode>) {
+                if (!isFlareVersionAccess(path.node, t)) {
+                    return;
+                }
+                // Resolve lazily: once per babel plugin instance. Babel caches the
+                // plugin instance across transformSync calls with the same function
+                // reference, so version is resolved on the first matching node only.
+                // For real builds this is fine: FLARE_SOURCEMAP_VERSION is stable
+                // for the entire Metro bundler run.
+                if (version === undefined) {
+                    version = resolveVersion();
+                }
+                path.replaceWith(t.stringLiteral(version));
+            },
+        },
+        // Reset per-file so the env var is re-read on each transformSync call
+        // (needed for test isolation and supports incremental rebuild scenarios).
+        pre() {
+            version = undefined;
+        },
+    };
+}
+
+/** Matches `process.env.FLARE_SOURCEMAP_VERSION` and `process.env["FLARE_SOURCEMAP_VERSION"]`. */
+function isFlareVersionAccess(node: MemberExpressionNode, t: Types): boolean {
+    const object = node.object;
+    if (!t.isMemberExpression(object) || object.computed) {
+        return false;
+    }
+    if (!t.isIdentifier(object.object, { name: 'process' })) {
+        return false;
+    }
+    if (!t.isIdentifier(object.property, { name: 'env' })) {
+        return false;
+    }
+    if (node.computed) {
+        return t.isStringLiteral(node.property, { value: ENV_TOKEN });
+    }
+    return t.isIdentifier(node.property, { name: ENV_TOKEN });
+}

--- a/packages/react-native-sourcemaps/src/babel.ts
+++ b/packages/react-native-sourcemaps/src/babel.ts
@@ -2,64 +2,93 @@ import type * as Babel from '@babel/core';
 
 import { resolveVersion } from './version';
 
-const ENV_TOKEN = 'FLARE_SOURCEMAP_VERSION';
+// The app imports `flareSourcemapVersion` from this runtime entry; the plugin
+// inlines it. A typed import (rather than `process.env.FLARE_SOURCEMAP_VERSION`)
+// means no Node types, no ambient declarations, and no "looks like a runtime env
+// var but isn't" confusion for app authors.
+const RUNTIME_SOURCE = '@flareapp/react-native-sourcemaps/runtime';
+const EXPORT_NAME = 'flareSourcemapVersion';
 
 // Type queries on dynamic imports: no runtime import of @babel/* is emitted.
-// `Types` is the shape of the `t` helper object; `MemberExpressionNode` is the
-// AST interface. The types resolve via @types/babel__core (dev dependency).
+// `Types` is the shape of the `t` helper object; the others are AST interfaces.
+// They resolve via @types/babel__core (dev dependency).
 type Types = typeof import('@babel/types');
-type MemberExpressionNode = import('@babel/types').MemberExpression;
+type ImportDeclarationNode = import('@babel/types').ImportDeclaration;
+type ImportSpecifierNode = import('@babel/types').ImportSpecifier;
 
 /**
- * Babel plugin that replaces `process.env.FLARE_SOURCEMAP_VERSION` with the
- * resolved version string at bundle time. Metro does not inline arbitrary
- * `process.env` reads, so without this the value is `undefined` at runtime in a
- * bare RN app. The version is resolved once per plugin instance (lazily, on the
- * first match) via the shared `resolveVersion()`.
+ * Babel plugin that inlines `flareSourcemapVersion` (imported from
+ * `@flareapp/react-native-sourcemaps/runtime`) with the resolved version string at
+ * bundle time, then removes the now-dead import so nothing of this package ships at
+ * runtime. The version is resolved once per file (lazily, only when the import is
+ * present) via the shared `resolveVersion()`.
  */
 export default function flareSourcemapsBabelPlugin({ types: t }: { types: Types }): Babel.PluginObj {
     let version: string | undefined;
 
     return {
         name: '@flareapp/react-native-sourcemaps',
-        // Reset per-file so the env var is re-read on each transformSync call
-        // (needed for test isolation and supports incremental rebuild scenarios).
+        // Babel caches plugin instances across files/transforms, so reset the
+        // per-file resolved version before each file (also correct for rebuilds
+        // where FLARE_SOURCEMAP_VERSION changes between runs).
         pre() {
             version = undefined;
         },
         visitor: {
-            MemberExpression(path: Babel.NodePath<MemberExpressionNode>) {
-                if (!isFlareVersionAccess(path.node, t)) {
+            ImportDeclaration(path: Babel.NodePath<ImportDeclarationNode>) {
+                if (path.node.source.value !== RUNTIME_SOURCE) {
                     return;
                 }
-                // Resolve lazily: once per babel plugin instance. Babel caches the
-                // plugin instance across transformSync calls with the same function
-                // reference, so version is resolved on the first matching node only.
-                // For real builds this is fine: FLARE_SOURCEMAP_VERSION is stable
-                // for the entire Metro bundler run.
-                if (version === undefined) {
-                    version = resolveVersion();
+
+                const remaining = [];
+                let inlinedAny = false;
+
+                for (const specifier of path.node.specifiers) {
+                    if (!isFlareVersionSpecifier(specifier, t)) {
+                        remaining.push(specifier);
+                        continue;
+                    }
+
+                    const binding = path.scope.getBinding(specifier.local.name);
+                    if (!binding) {
+                        remaining.push(specifier);
+                        continue;
+                    }
+
+                    if (version === undefined) {
+                        version = resolveVersion();
+                    }
+                    for (const reference of binding.referencePaths) {
+                        reference.replaceWith(t.stringLiteral(version));
+                    }
+                    inlinedAny = true;
                 }
-                path.replaceWith(t.stringLiteral(version));
+
+                if (!inlinedAny) {
+                    return;
+                }
+
+                // Drop the import: either the whole declaration, or just the
+                // specifiers we inlined if the user imported other names too.
+                if (remaining.length === 0) {
+                    path.remove();
+                } else {
+                    path.node.specifiers = remaining;
+                }
             },
         },
     };
 }
 
-/** Matches `process.env.FLARE_SOURCEMAP_VERSION` and `process.env["FLARE_SOURCEMAP_VERSION"]`. */
-function isFlareVersionAccess(node: MemberExpressionNode, t: Types): boolean {
-    const object = node.object;
-    if (!t.isMemberExpression(object) || object.computed) {
+/** Matches `import { flareSourcemapVersion } from '.../runtime'` (named, possibly aliased). */
+function isFlareVersionSpecifier(
+    specifier: ImportDeclarationNode['specifiers'][number],
+    t: Types,
+): specifier is ImportSpecifierNode {
+    if (!t.isImportSpecifier(specifier)) {
         return false;
     }
-    if (!t.isIdentifier(object.object, { name: 'process' })) {
-        return false;
-    }
-    if (!t.isIdentifier(object.property, { name: 'env' })) {
-        return false;
-    }
-    if (node.computed) {
-        return t.isStringLiteral(node.property, { value: ENV_TOKEN });
-    }
-    return t.isIdentifier(node.property, { name: ENV_TOKEN });
+    const imported = specifier.imported;
+    const importedName = t.isIdentifier(imported) ? imported.name : imported.value;
+    return importedName === EXPORT_NAME;
 }

--- a/packages/react-native-sourcemaps/src/babel.ts
+++ b/packages/react-native-sourcemaps/src/babel.ts
@@ -22,6 +22,11 @@ export default function flareSourcemapsBabelPlugin({ types: t }: { types: Types 
 
     return {
         name: '@flareapp/react-native-sourcemaps',
+        // Reset per-file so the env var is re-read on each transformSync call
+        // (needed for test isolation and supports incremental rebuild scenarios).
+        pre() {
+            version = undefined;
+        },
         visitor: {
             MemberExpression(path: Babel.NodePath<MemberExpressionNode>) {
                 if (!isFlareVersionAccess(path.node, t)) {
@@ -37,11 +42,6 @@ export default function flareSourcemapsBabelPlugin({ types: t }: { types: Types 
                 }
                 path.replaceWith(t.stringLiteral(version));
             },
-        },
-        // Reset per-file so the env var is re-read on each transformSync call
-        // (needed for test isolation and supports incremental rebuild scenarios).
-        pre() {
-            version = undefined;
         },
     };
 }

--- a/packages/react-native-sourcemaps/src/banner.ts
+++ b/packages/react-native-sourcemaps/src/banner.ts
@@ -9,7 +9,7 @@ export type FailureBannerInfo = {
     version?: string;
     /** Resolved API key, interpolated into the recovery command. */
     apiKey?: string;
-    /** Resolved API endpoint; only included in the recovery command when set (custom/self-hosted). */
+    /** Resolved API endpoint; only included in the recovery command when set (custom endpoint). */
     apiEndpoint?: string;
 };
 

--- a/packages/react-native-sourcemaps/src/banner.ts
+++ b/packages/react-native-sourcemaps/src/banner.ts
@@ -9,6 +9,8 @@ export type FailureBannerInfo = {
     version?: string;
     /** Resolved API key, interpolated into the recovery command. */
     apiKey?: string;
+    /** Resolved API endpoint; only included in the recovery command when set (custom/self-hosted). */
+    apiEndpoint?: string;
 };
 
 const BORDER = '='.repeat(60);
@@ -25,6 +27,7 @@ export function formatFailureBanner(info: FailureBannerInfo): string {
     const bundleFilename = info.bundleFilename ?? '<bundle-filename>';
     const version = info.version && info.version.length > 0 ? info.version : '<flare-sourcemap-version>';
     const apiKey = info.apiKey && info.apiKey.length > 0 ? info.apiKey : '<your-flare-api-key>';
+    const endpointFlag = info.apiEndpoint ? ` --api-endpoint ${info.apiEndpoint}` : '';
 
     return [
         '',
@@ -34,7 +37,7 @@ export function formatFailureBanner(info: FailureBannerInfo): string {
         '  Your release will report minified stack traces until the',
         '  sourcemap is uploaded. Re-run manually:',
         `    npx flare-rn-sourcemaps upload --sourcemap ${sourcemap} \\`,
-        `      --bundle-filename ${bundleFilename} --version ${version} --api-key ${apiKey}`,
+        `      --bundle-filename ${bundleFilename} --version ${version} --api-key ${apiKey}${endpointFlag}`,
         BORDER,
         '',
     ].join('\n');

--- a/packages/react-native-sourcemaps/src/banner.ts
+++ b/packages/react-native-sourcemaps/src/banner.ts
@@ -1,0 +1,45 @@
+export type FailureBannerInfo = {
+    /** Human-readable reason shown after "Reason:". */
+    reason: string;
+    /** Resolved sourcemap path, interpolated into the recovery command. */
+    sourcemap?: string;
+    /** Resolved relative_filename, interpolated into the recovery command. */
+    bundleFilename?: string;
+    /** Resolved version, interpolated into the recovery command. */
+    version?: string;
+    /** Resolved API key, interpolated into the recovery command. */
+    apiKey?: string;
+};
+
+const BORDER = '='.repeat(60);
+
+/**
+ * The deliberately large failure banner. A one-line "failed to upload" is too easy
+ * to miss in a long native-build log, so this is a bordered block surrounded by
+ * blank lines. Real resolved values are interpolated into the re-run command so the
+ * user can copy-paste it; unknown values show a labelled placeholder (in the
+ * version-unset case `version` stays a placeholder — it is the value to supply).
+ */
+export function formatFailureBanner(info: FailureBannerInfo): string {
+    const sourcemap = info.sourcemap ?? '<path-to-map>';
+    const bundleFilename = info.bundleFilename ?? '<bundle-filename>';
+    const version = info.version && info.version.length > 0 ? info.version : '<flare-sourcemap-version>';
+    const apiKey = info.apiKey && info.apiKey.length > 0 ? info.apiKey : '<your-flare-api-key>';
+
+    return [
+        '',
+        BORDER,
+        '  FLARE SOURCEMAP UPLOAD FAILED',
+        `  Reason: ${info.reason}`,
+        '  Your release will report minified stack traces until the',
+        '  sourcemap is uploaded. Re-run manually:',
+        `    npx flare-rn-sourcemaps upload --sourcemap ${sourcemap} \\`,
+        `      --bundle-filename ${bundleFilename} --version ${version} --api-key ${apiKey}`,
+        BORDER,
+        '',
+    ].join('\n');
+}
+
+export function printFailureBanner(info: FailureBannerInfo): void {
+    console.error(formatFailureBanner(info));
+}

--- a/packages/react-native-sourcemaps/src/bin.ts
+++ b/packages/react-native-sourcemaps/src/bin.ts
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+import { runCli } from './cli';
+
+runCli(process.argv.slice(2)).catch((error: unknown) => {
+    console.error(error);
+    process.exitCode = 1;
+});

--- a/packages/react-native-sourcemaps/src/cli.ts
+++ b/packages/react-native-sourcemaps/src/cli.ts
@@ -1,0 +1,65 @@
+import { uploadSourcemaps } from './uploadSourcemaps';
+
+const LOG_PREFIX = '@flareapp/react-native-sourcemaps';
+const USAGE =
+    'Usage: flare-rn-sourcemaps upload --sourcemap <path> [--api-key <key>] ' +
+    '[--bundle-filename <name>] [--version <v>] [--api-endpoint <url>]';
+
+export type ParsedArgs = {
+    command: string | undefined;
+    flags: Record<string, string>;
+};
+
+/** Minimal `--flag value` / `--flag` parser. No external dependency. */
+export function parseArgs(argv: string[]): ParsedArgs {
+    const [command, ...rest] = argv;
+    const flags: Record<string, string> = {};
+
+    for (let i = 0; i < rest.length; i++) {
+        const arg = rest[i];
+        if (!arg.startsWith('--')) {
+            continue;
+        }
+        const body = arg.slice(2);
+        const eq = body.indexOf('=');
+        if (eq !== -1) {
+            flags[body.slice(0, eq)] = body.slice(eq + 1);
+            continue;
+        }
+        const key = body;
+        const next = rest[i + 1];
+        if (next !== undefined && !next.startsWith('--')) {
+            flags[key] = next;
+            i++;
+        } else {
+            flags[key] = 'true';
+        }
+    }
+
+    return { command, flags };
+}
+
+export async function runCli(argv: string[]): Promise<void> {
+    const { command, flags } = parseArgs(argv);
+
+    if (command !== 'upload') {
+        console.error(`${LOG_PREFIX}: Unknown command "${command ?? ''}".\n${USAGE}`);
+        process.exitCode = 1;
+        return;
+    }
+
+    const sourcemap = flags.sourcemap;
+    if (!sourcemap) {
+        console.error(`${LOG_PREFIX}: --sourcemap is required.\n${USAGE}`);
+        process.exitCode = 1;
+        return;
+    }
+
+    await uploadSourcemaps({
+        apiKey: flags['api-key'] ?? process.env.FLARE_API_KEY ?? '',
+        sourcemap,
+        bundleFilename: flags['bundle-filename'],
+        version: flags.version,
+        apiEndpoint: flags['api-endpoint'],
+    });
+}

--- a/packages/react-native-sourcemaps/src/cli.ts
+++ b/packages/react-native-sourcemaps/src/cli.ts
@@ -99,6 +99,7 @@ async function runAutoUpload(options: AutoUploadOptions): Promise<void> {
             sourcemap,
             bundleFilename,
             apiKey,
+            apiEndpoint,
         });
         return;
     }
@@ -110,6 +111,7 @@ async function runAutoUpload(options: AutoUploadOptions): Promise<void> {
             sourcemap,
             bundleFilename,
             apiKey,
+            apiEndpoint,
         });
         return;
     }
@@ -118,6 +120,6 @@ async function runAutoUpload(options: AutoUploadOptions): Promise<void> {
         await uploadSourcemaps({ apiKey, sourcemap, bundleFilename, version, apiEndpoint });
     } catch (error: unknown) {
         const message = error instanceof Error ? error.message : String(error);
-        printFailureBanner({ reason: message, sourcemap, bundleFilename, version, apiKey });
+        printFailureBanner({ reason: message, sourcemap, bundleFilename, version, apiKey, apiEndpoint });
     }
 }

--- a/packages/react-native-sourcemaps/src/cli.ts
+++ b/packages/react-native-sourcemaps/src/cli.ts
@@ -1,8 +1,13 @@
+import { printFailureBanner } from './banner';
+import { readFlareConfig } from './config';
 import { LOG_PREFIX } from './constants';
 import { uploadSourcemaps } from './uploadSourcemaps';
+import { resolveAutoVersion } from './version';
+
 const USAGE =
     'Usage: flare-rn-sourcemaps upload --sourcemap <path> [--api-key <key>] ' +
-    '[--bundle-filename <name>] [--version <v>] [--api-endpoint <url>]';
+    '[--bundle-filename <name>] [--version <v>] [--api-endpoint <url>] ' +
+    '[--config <flare.json>] [--auto]';
 
 export type ParsedArgs = {
     command: string | undefined;
@@ -54,11 +59,65 @@ export async function runCli(argv: string[]): Promise<void> {
         return;
     }
 
-    await uploadSourcemaps({
-        apiKey: flags['api-key'] ?? process.env.FLARE_API_KEY ?? '',
-        sourcemap,
-        bundleFilename: flags['bundle-filename'],
-        version: flags.version,
-        apiEndpoint: flags['api-endpoint'],
-    });
+    // Precedence per field: explicit flag > env > flare.json > default. The
+    // relative_filename has no flare.json/env override in v1; `--bundle-filename`
+    // (manual) or the map-basename default (in uploadSourcemaps) cover it.
+    const config = readFlareConfig(flags.config);
+    const apiKey = flags['api-key'] ?? process.env.FLARE_API_KEY ?? config.apiKey ?? '';
+    const apiEndpoint = flags['api-endpoint'] ?? process.env.FLARE_API_ENDPOINT ?? config.apiEndpoint;
+    const bundleFilename = flags['bundle-filename'];
+
+    if (flags.auto === 'true') {
+        await runAutoUpload({ apiKey, sourcemap, bundleFilename, apiEndpoint, version: flags.version });
+        return;
+    }
+
+    await uploadSourcemaps({ apiKey, sourcemap, bundleFilename, version: flags.version, apiEndpoint });
+}
+
+type AutoUploadOptions = {
+    apiKey: string;
+    sourcemap: string;
+    bundleFilename: string | undefined;
+    apiEndpoint: string | undefined;
+    version: string | undefined;
+};
+
+/**
+ * The build-hook upload path. It NEVER throws and NEVER sets a non-zero exit code
+ * (a Gradle doLast / Xcode run-script phase would abort the build on a non-zero
+ * child). Every failure mode — no key, unresolved version, upload error — prints the
+ * loud banner and returns, leaving the build green. Only arg misuse (handled in
+ * runCli before we get here) exits non-zero.
+ */
+async function runAutoUpload(options: AutoUploadOptions): Promise<void> {
+    const { apiKey, sourcemap, bundleFilename, apiEndpoint } = options;
+
+    if (!apiKey) {
+        printFailureBanner({
+            reason: 'No Flare API key. Set FLARE_API_KEY or add "apiKey" to flare.json.',
+            sourcemap,
+            bundleFilename,
+            apiKey,
+        });
+        return;
+    }
+
+    const version = resolveAutoVersion(options.version);
+    if (!version) {
+        printFailureBanner({
+            reason: 'FLARE_SOURCEMAP_VERSION is not set (required for the automatic upload).',
+            sourcemap,
+            bundleFilename,
+            apiKey,
+        });
+        return;
+    }
+
+    try {
+        await uploadSourcemaps({ apiKey, sourcemap, bundleFilename, version, apiEndpoint });
+    } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        printFailureBanner({ reason: message, sourcemap, bundleFilename, version, apiKey });
+    }
 }

--- a/packages/react-native-sourcemaps/src/cli.ts
+++ b/packages/react-native-sourcemaps/src/cli.ts
@@ -1,6 +1,5 @@
+import { LOG_PREFIX } from './constants';
 import { uploadSourcemaps } from './uploadSourcemaps';
-
-const LOG_PREFIX = '@flareapp/react-native-sourcemaps';
 const USAGE =
     'Usage: flare-rn-sourcemaps upload --sourcemap <path> [--api-key <key>] ' +
     '[--bundle-filename <name>] [--version <v>] [--api-endpoint <url>]';

--- a/packages/react-native-sourcemaps/src/cli.ts
+++ b/packages/react-native-sourcemaps/src/cli.ts
@@ -1,6 +1,9 @@
+import { dirname } from 'node:path';
+
 import { printFailureBanner } from './banner';
 import { readFlareConfig } from './config';
 import { LOG_PREFIX } from './constants';
+import { loadEnvFiles } from './env';
 import { uploadSourcemaps } from './uploadSourcemaps';
 import { resolveAutoVersion } from './version';
 
@@ -59,6 +62,18 @@ export async function runCli(argv: string[]): Promise<void> {
         return;
     }
 
+    // Auto mode is the native build-hook path. The hook process often lacks FLARE_*
+    // in its environment (the app's .env files are a JS-runtime concern, an IDE build
+    // doesn't inherit your shell, and a reused Gradle daemon can serve a stale env),
+    // so load .env.local / .env from the project root — the directory that holds
+    // flare.json — before resolving the key. Existing env values are never
+    // overwritten, so an explicit export (or an EAS env var) still wins. The manual
+    // path is left untouched: there the caller is explicit and shouldn't be surprised
+    // by ambient .env loading.
+    if (flags.auto === 'true') {
+        loadEnvFiles(flags.config ? dirname(flags.config) : process.cwd());
+    }
+
     // Precedence per field: explicit flag > env > flare.json > default. The
     // relative_filename has no flare.json/env override in v1; `--bundle-filename`
     // (manual) or the map-basename default (in uploadSourcemaps) cover it.
@@ -95,7 +110,7 @@ async function runAutoUpload(options: AutoUploadOptions): Promise<void> {
 
     if (!apiKey) {
         printFailureBanner({
-            reason: 'No Flare API key. Set FLARE_API_KEY or add "apiKey" to flare.json.',
+            reason: 'No Flare API key. Set FLARE_API_KEY (shell, .env.local, or .env) or add "apiKey" to flare.json.',
             sourcemap,
             bundleFilename,
             apiKey,

--- a/packages/react-native-sourcemaps/src/config.ts
+++ b/packages/react-native-sourcemaps/src/config.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from 'node:fs';
+
+export type FlareConfig = {
+    apiKey?: string;
+    apiEndpoint?: string;
+};
+
+/**
+ * Read flare.json from an EXPLICIT path. The hooks run from android/ or ios/, so
+ * resolving relative to process.cwd() would read the wrong file — callers always
+ * pass --config. Missing or malformed file → empty config, so resolution falls
+ * through to env, then to the no-key skip-with-banner. Any `version` key is
+ * deliberately ignored: in the auto path the version flows only through
+ * FLARE_SOURCEMAP_VERSION (see resolveAutoVersion / the design doc).
+ */
+export function readFlareConfig(configPath?: string): FlareConfig {
+    if (!configPath) {
+        return {};
+    }
+
+    try {
+        const raw = JSON.parse(readFileSync(configPath, 'utf8')) as Record<string, unknown>;
+        const config: FlareConfig = {};
+        const apiKey = asString(raw.apiKey);
+        const apiEndpoint = asString(raw.apiEndpoint);
+        if (apiKey !== undefined) {
+            config.apiKey = apiKey;
+        }
+        if (apiEndpoint !== undefined) {
+            config.apiEndpoint = apiEndpoint;
+        }
+        return config;
+    } catch {
+        return {};
+    }
+}
+
+function asString(value: unknown): string | undefined {
+    return typeof value === 'string' && value.length > 0 ? value : undefined;
+}

--- a/packages/react-native-sourcemaps/src/constants.ts
+++ b/packages/react-native-sourcemaps/src/constants.ts
@@ -1,0 +1,1 @@
+export const LOG_PREFIX = '@flareapp/react-native-sourcemaps';

--- a/packages/react-native-sourcemaps/src/env.ts
+++ b/packages/react-native-sourcemaps/src/env.ts
@@ -1,0 +1,74 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// Highest precedence first: a value in .env.local wins over the same key in .env.
+// An already-set process.env value (an explicit shell export, or an EAS env var)
+// wins over both, because we never overwrite a key that already exists.
+const ENV_FILES = ['.env.local', '.env'];
+
+/**
+ * Load FLARE_* variables from .env.local / .env in `rootDir` into process.env,
+ * without overwriting anything already set.
+ *
+ * The native build hooks run in a fresh process whose environment often does NOT
+ * carry the upload key: the app's .env files are loaded by Metro at JS runtime, not
+ * at native build time, and a build launched from an IDE — or served by a reused
+ * Gradle daemon with a stale environment — won't see a key you exported in your
+ * shell. Reading the key from the FILE here makes "drop FLARE_API_KEY in .env.local"
+ * work the way developers expect, on both platforms, without re-exporting it per
+ * build.
+ *
+ * Only FLARE_-prefixed keys are read, so this never pulls unrelated secrets from the
+ * file into the process. Minimal parser (no dependency): `KEY=value`, an optional
+ * `export ` prefix, surrounding single/double quotes stripped, blank and `#` comment
+ * lines ignored. Inline comments are NOT stripped (a `#` is treated as part of the
+ * value), which is fine for the alphanumeric keys Flare issues.
+ */
+export function loadEnvFiles(rootDir: string): void {
+    for (const file of ENV_FILES) {
+        let raw: string;
+        try {
+            raw = readFileSync(join(rootDir, file), 'utf8');
+        } catch {
+            continue; // absent or unreadable — nothing to load from this file
+        }
+
+        for (const [key, value] of parseFlareEnv(raw)) {
+            if (process.env[key] === undefined) {
+                process.env[key] = value;
+            }
+        }
+    }
+}
+
+function parseFlareEnv(raw: string): Array<[string, string]> {
+    const out: Array<[string, string]> = [];
+
+    for (const line of raw.split(/\r?\n/)) {
+        const trimmed = line.trim();
+        if (trimmed === '' || trimmed.startsWith('#')) {
+            continue;
+        }
+
+        const body = trimmed.startsWith('export ') ? trimmed.slice('export '.length).trim() : trimmed;
+        const eq = body.indexOf('=');
+        if (eq === -1) {
+            continue;
+        }
+
+        const key = body.slice(0, eq).trim();
+        if (!key.startsWith('FLARE_')) {
+            continue;
+        }
+
+        let value = body.slice(eq + 1).trim();
+        const quoted = (value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"));
+        if (quoted && value.length >= 2) {
+            value = value.slice(1, -1);
+        }
+
+        out.push([key, value]);
+    }
+
+    return out;
+}

--- a/packages/react-native-sourcemaps/src/expo.ts
+++ b/packages/react-native-sourcemaps/src/expo.ts
@@ -1,0 +1,123 @@
+import { promises as fs } from 'node:fs';
+import { dirname, join } from 'node:path';
+
+import {
+    type ConfigPlugin,
+    createRunOncePlugin,
+    withAppBuildGradle,
+    withDangerousMod,
+    withXcodeProject,
+} from '@expo/config-plugins';
+
+import {
+    addFlareGradleApply,
+    addSourcemapFileEnv,
+    ensureGitignored,
+    type FlarePluginProps,
+    flareJsonContents,
+    flareXcodeShellScript,
+    toPosixRelative,
+} from './expoTransforms';
+import { addUploadBuildPhase } from './expoXcode';
+
+// Resolve real install locations (correct under monorepo hoisting). Called only
+// during prebuild, never at import time.
+function packageDir(): string {
+    return dirname(require.resolve('@flareapp/react-native-sourcemaps/package.json'));
+}
+function flareGradlePath(): string {
+    return join(packageDir(), 'flare.gradle');
+}
+function flareXcodeScriptPath(): string {
+    return join(packageDir(), 'scripts', 'flare-xcode.sh');
+}
+function withEnvironmentScriptPath(): string {
+    return join(dirname(require.resolve('react-native/package.json')), 'scripts', 'xcode', 'with-environment.sh');
+}
+
+async function writeFlareConfigFiles(projectRoot: string, props: FlarePluginProps): Promise<void> {
+    await fs.writeFile(join(projectRoot, 'flare.json'), flareJsonContents(props), 'utf8');
+
+    const gitignorePath = join(projectRoot, '.gitignore');
+    let gitignore = '';
+    try {
+        gitignore = await fs.readFile(gitignorePath, 'utf8');
+    } catch {
+        gitignore = '';
+    }
+    await fs.writeFile(gitignorePath, ensureGitignored(gitignore), 'utf8');
+}
+
+// flare.json must exist whichever platform builds. EAS prebuilds ONE platform at a
+// time, so register the write for both — it is idempotent (overwrites identical
+// content).
+const withFlareConfigFiles: ConfigPlugin<FlarePluginProps> = (config, props) => {
+    for (const platform of ['ios', 'android'] as const) {
+        config = withDangerousMod(config, [
+            platform,
+            async (cfg) => {
+                await writeFlareConfigFiles(cfg.modRequest.projectRoot, props);
+                return cfg;
+            },
+        ]);
+    }
+    return config;
+};
+
+const withFlareAndroidGradle: ConfigPlugin = (config) =>
+    withAppBuildGradle(config, (cfg) => {
+        const appDir = join(cfg.modRequest.platformProjectRoot, 'app');
+        cfg.modResults.contents = addFlareGradleApply(
+            cfg.modResults.contents,
+            toPosixRelative(appDir, flareGradlePath()),
+        );
+        return cfg;
+    });
+
+const withFlareXcodeEnv: ConfigPlugin = (config) =>
+    withDangerousMod(config, [
+        'ios',
+        async (cfg) => {
+            const xcodeEnvPath = join(cfg.modRequest.platformProjectRoot, '.xcode.env');
+            let contents = '';
+            try {
+                contents = await fs.readFile(xcodeEnvPath, 'utf8');
+            } catch {
+                contents = '';
+            }
+            await fs.writeFile(xcodeEnvPath, addSourcemapFileEnv(contents), 'utf8');
+            return cfg;
+        },
+    ]);
+
+const withFlareIosBuildPhase: ConfigPlugin = (config) =>
+    withXcodeProject(config, (cfg) => {
+        const iosRoot = cfg.modRequest.platformProjectRoot;
+        const shellScript = flareXcodeShellScript(
+            toPosixRelative(iosRoot, withEnvironmentScriptPath()),
+            toPosixRelative(iosRoot, flareXcodeScriptPath()),
+        );
+        cfg.modResults = addUploadBuildPhase(cfg.modResults, shellScript);
+        return cfg;
+    });
+
+const withFlareSourcemaps: ConfigPlugin<FlarePluginProps | undefined> = (config, props) => {
+    const resolved = props ?? {};
+    config = withFlareConfigFiles(config, resolved);
+    config = withFlareAndroidGradle(config);
+    config = withFlareXcodeEnv(config);
+    config = withFlareIosBuildPhase(config);
+    return config;
+};
+
+// createRunOncePlugin dedupes a transitively-doubled application. Read name/version
+// from our own package.json; never throw at import if it is somehow unresolvable.
+const pkg = ((): { name: string; version: string } => {
+    try {
+        return require('@flareapp/react-native-sourcemaps/package.json') as { name: string; version: string };
+    } catch {
+        return { name: '@flareapp/react-native-sourcemaps', version: '0.0.0' };
+    }
+})();
+
+export default createRunOncePlugin(withFlareSourcemaps, pkg.name, pkg.version);

--- a/packages/react-native-sourcemaps/src/expoTransforms.ts
+++ b/packages/react-native-sourcemaps/src/expoTransforms.ts
@@ -1,0 +1,79 @@
+import { relative, sep } from 'node:path';
+
+export type FlarePluginProps = {
+    apiKey?: string;
+    apiEndpoint?: string;
+};
+
+export const FLARE_GRADLE_MARKER = '@flareapp/react-native-sourcemaps Expo config plugin';
+export const SOURCEMAP_FILE_LINE = 'export SOURCEMAP_FILE="$CONFIGURATION_BUILD_DIR/main.jsbundle.map"';
+export const GITIGNORE_ENTRY = 'flare.json';
+
+/** Serialise the plugin props into the flare.json the native hooks read. Absent
+ * props are omitted so the CLI applies its own defaults (endpoint) and env fallback
+ * (FLARE_API_KEY). No `version` key — version flows only through FLARE_SOURCEMAP_VERSION. */
+export function flareJsonContents(props: FlarePluginProps): string {
+    const config: Record<string, string> = {};
+    if (props.apiKey) {
+        config.apiKey = props.apiKey;
+    }
+    if (props.apiEndpoint) {
+        config.apiEndpoint = props.apiEndpoint;
+    }
+    return `${JSON.stringify(config, null, 4)}\n`;
+}
+
+/** Append `apply from: "<path>"` to android/app/build.gradle. Idempotent via a marker
+ * comment, so a re-prebuild without --clean does not duplicate it. */
+export function addFlareGradleApply(buildGradle: string, applyFromPath: string): string {
+    if (buildGradle.includes(FLARE_GRADLE_MARKER)) {
+        return buildGradle;
+    }
+    const base = buildGradle.endsWith('\n') ? buildGradle : `${buildGradle}\n`;
+    return `${base}\n// ${FLARE_GRADLE_MARKER}\napply from: ${JSON.stringify(applyFromPath)}\n`;
+}
+
+/** Ensure ios/.xcode.env exports SOURCEMAP_FILE so the stock bundle phase emits the
+ * composed map. Idempotent, and treats a missing file (empty string) as valid input.
+ * The guard is line-based and ignores comments, so a commented-out `# SOURCEMAP_FILE=`
+ * does not suppress injection while a real `export SOURCEMAP_FILE=`/`SOURCEMAP_FILE=`
+ * (a user's custom map path) is left untouched. */
+export function addSourcemapFileEnv(xcodeEnv: string): string {
+    const alreadySet = xcodeEnv.split('\n').some((line) => {
+        const trimmed = line.trim();
+        return !trimmed.startsWith('#') && /^(export\s+)?SOURCEMAP_FILE=/.test(trimmed);
+    });
+    if (alreadySet) {
+        return xcodeEnv;
+    }
+    const base = xcodeEnv.length === 0 || xcodeEnv.endsWith('\n') ? xcodeEnv : `${xcodeEnv}\n`;
+    return `${base}# Flare: emit the composed Hermes sourcemap so the upload phase can find it\n${SOURCEMAP_FILE_LINE}\n`;
+}
+
+/** Append `flare.json` to .gitignore once (the file is generated from app.json props). */
+export function ensureGitignored(gitignore: string, entry: string = GITIGNORE_ENTRY): string {
+    const present = gitignore.split('\n').some((line) => line.trim() === entry);
+    if (present) {
+        return gitignore;
+    }
+    const base = gitignore.length === 0 || gitignore.endsWith('\n') ? gitignore : `${gitignore}\n`;
+    return `${base}${entry}\n`;
+}
+
+/** The shell body of the iOS "Upload Flare sourcemaps" phase: source RN's
+ * with-environment.sh (so SOURCEMAP_FILE/FLARE_* are present), then run flare-xcode.sh. */
+export function flareXcodeShellScript(withEnvironmentPath: string, flareXcodePath: string): string {
+    return [
+        'set -e',
+        `WITH_ENVIRONMENT="${withEnvironmentPath}"`,
+        `FLARE_XCODE="${flareXcodePath}"`,
+        '/bin/sh -c "$WITH_ENVIRONMENT $FLARE_XCODE"',
+        '',
+    ].join('\n');
+}
+
+/** path.relative, normalised to forward slashes (Gradle/Xcode script paths are posix
+ * even when prebuild runs on Windows). */
+export function toPosixRelative(fromDir: string, target: string): string {
+    return relative(fromDir, target).split(sep).join('/');
+}

--- a/packages/react-native-sourcemaps/src/expoTransforms.ts
+++ b/packages/react-native-sourcemaps/src/expoTransforms.ts
@@ -6,7 +6,13 @@ export type FlarePluginProps = {
 };
 
 export const FLARE_GRADLE_MARKER = '@flareapp/react-native-sourcemaps Expo config plugin';
-export const SOURCEMAP_FILE_LINE = 'export SOURCEMAP_FILE="$CONFIGURATION_BUILD_DIR/main.jsbundle.map"';
+// Must NOT live in $CONFIGURATION_BUILD_DIR. With Hermes, react-native-xcode.sh writes
+// its intermediate "packager" sourcemap to `$CONFIGURATION_BUILD_DIR/<basename of
+// SOURCEMAP_FILE>`, composes the final map into SOURCEMAP_FILE, then `rm`s that
+// intermediate — so if SOURCEMAP_FILE is `$CONFIGURATION_BUILD_DIR/main.jsbundle.map`
+// the cleanup deletes the composed map we need. $TARGET_TEMP_DIR is per-target (shared
+// by the bundle phase and the upload phase) and lives elsewhere, so the map survives.
+export const SOURCEMAP_FILE_LINE = 'export SOURCEMAP_FILE="$TARGET_TEMP_DIR/main.jsbundle.map"';
 export const GITIGNORE_ENTRY = 'flare.json';
 
 /** Serialise the plugin props into the flare.json the native hooks read. Absent

--- a/packages/react-native-sourcemaps/src/expoXcode.ts
+++ b/packages/react-native-sourcemaps/src/expoXcode.ts
@@ -1,0 +1,45 @@
+import type { XcodeProject } from '@expo/config-plugins';
+
+export const FLARE_PHASE_NAME = 'Upload Flare sourcemaps';
+
+// The `xcode` runtime API (mutated in place) is broader than the published type, so
+// access the parts we need through a minimal structural view.
+type ShellScriptPhase = { name?: string };
+type XcodeInternal = {
+    hash: { project: { objects: Record<string, Record<string, ShellScriptPhase | string>> } };
+    addBuildPhase: (
+        filePaths: string[],
+        isa: string,
+        comment: string,
+        target: string | null,
+        options: { shellPath: string; shellScript: string },
+    ) => unknown;
+};
+
+/**
+ * Append an "Upload Flare sourcemaps" shell-script phase to the app target. The phase
+ * is APPENDED (so it always runs after the JS bundle phase, whatever that phase is
+ * named or wherever it sits across Expo SDKs). Idempotency guard: skip if a phase with
+ * our name already exists. Note this mutates `project` in place (the `xcode` lib's
+ * contract) and returns the same instance for convenience.
+ */
+export function addUploadBuildPhase(project: XcodeProject, shellScript: string): XcodeProject {
+    const internal = project as unknown as XcodeInternal;
+    const phases = internal.hash.project.objects.PBXShellScriptBuildPhase ?? {};
+    const alreadyPresent = Object.values(phases).some(
+        (phase) =>
+            typeof phase === 'object' &&
+            phase !== null &&
+            typeof phase.name === 'string' &&
+            phase.name.replace(/^"|"$/g, '') === FLARE_PHASE_NAME,
+    );
+    if (alreadyPresent) {
+        return project;
+    }
+
+    internal.addBuildPhase([], 'PBXShellScriptBuildPhase', FLARE_PHASE_NAME, null, {
+        shellPath: '/bin/sh',
+        shellScript,
+    });
+    return project;
+}

--- a/packages/react-native-sourcemaps/src/expoXcode.ts
+++ b/packages/react-native-sourcemaps/src/expoXcode.ts
@@ -4,7 +4,7 @@ export const FLARE_PHASE_NAME = 'Upload Flare sourcemaps';
 
 // The `xcode` runtime API (mutated in place) is broader than the published type, so
 // access the parts we need through a minimal structural view.
-type ShellScriptPhase = { name?: string };
+type ShellScriptPhase = { name?: string; alwaysOutOfDate?: number };
 type XcodeInternal = {
     hash: { project: { objects: Record<string, Record<string, ShellScriptPhase | string>> } };
     addBuildPhase: (
@@ -13,7 +13,7 @@ type XcodeInternal = {
         comment: string,
         target: string | null,
         options: { shellPath: string; shellScript: string },
-    ) => unknown;
+    ) => { buildPhase: ShellScriptPhase };
 };
 
 /**
@@ -37,9 +37,14 @@ export function addUploadBuildPhase(project: XcodeProject, shellScript: string):
         return project;
     }
 
-    internal.addBuildPhase([], 'PBXShellScriptBuildPhase', FLARE_PHASE_NAME, null, {
+    const { buildPhase } = internal.addBuildPhase([], 'PBXShellScriptBuildPhase', FLARE_PHASE_NAME, null, {
         shellPath: '/bin/sh',
         shellScript,
     });
+    // Uncheck "Based on dependency analysis": the phase has no input/output files, so
+    // without this Xcode warns ("ambiguous dependencies ... runs on every build") on
+    // every build. We *want* it to run every release build — it self-skips when there
+    // is no map, no key, or no version.
+    buildPhase.alwaysOutOfDate = 1;
     return project;
 }

--- a/packages/react-native-sourcemaps/src/index.ts
+++ b/packages/react-native-sourcemaps/src/index.ts
@@ -1,0 +1,5 @@
+export { uploadSourcemaps } from './uploadSourcemaps';
+export type { UploadSourcemapsOptions } from './uploadSourcemaps';
+export { resolveVersion } from './version';
+export type { ResolveVersionOptions } from './version';
+export { default as flareSourcemapsBabelPlugin } from './babel';

--- a/packages/react-native-sourcemaps/src/runtime.ts
+++ b/packages/react-native-sourcemaps/src/runtime.ts
@@ -1,0 +1,12 @@
+/**
+ * The build-time sourcemap version, for `flare.configure({ sourcemapVersionId })`.
+ *
+ * `@flareapp/react-native-sourcemaps/babel` replaces every reference to this
+ * binding with the resolved version string literal at bundle time, then drops the
+ * import. Without that Babel plugin it stays an empty string (meaning "no version"),
+ * which is harmless because sourcemaps are only uploaded for release builds.
+ *
+ * This module is runtime-safe: it has no Node imports, so it is safe to import into
+ * app code that Metro bundles (unlike the package root, which pulls in the uploader).
+ */
+export const flareSourcemapVersion: string = '';

--- a/packages/react-native-sourcemaps/src/uploadSourcemaps.ts
+++ b/packages/react-native-sourcemaps/src/uploadSourcemaps.ts
@@ -3,10 +3,10 @@ import { basename } from 'node:path';
 
 import { FlareApi } from '@flareapp/flare-api';
 
+import { LOG_PREFIX } from './constants';
 import { resolveVersion } from './version';
 
 const DEFAULT_ENDPOINT = 'https://flareapp.io/api/sourcemaps';
-const LOG_PREFIX = '@flareapp/react-native-sourcemaps';
 
 export type UploadSourcemapsOptions = {
     /** Flare project API key. */

--- a/packages/react-native-sourcemaps/src/uploadSourcemaps.ts
+++ b/packages/react-native-sourcemaps/src/uploadSourcemaps.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from 'node:fs';
+import { basename } from 'node:path';
+
+import { FlareApi } from '@flareapp/flare-api';
+
+import { resolveVersion } from './version';
+
+const DEFAULT_ENDPOINT = 'https://flareapp.io/api/sourcemaps';
+const LOG_PREFIX = '@flareapp/react-native-sourcemaps';
+
+export type UploadSourcemapsOptions = {
+    /** Flare project API key. */
+    apiKey: string;
+    /** Path to the composed `.map` file to upload. */
+    sourcemap: string;
+    /**
+     * The `relative_filename` the backend matches against runtime stack frames.
+     * Defaults to the map's basename minus `.map` (e.g. `index.android.bundle`).
+     */
+    bundleFilename?: string;
+    /** Explicit version; otherwise resolved from env/package.json. */
+    version?: string;
+    /** Override the Flare sourcemaps endpoint. */
+    apiEndpoint?: string;
+};
+
+export async function uploadSourcemaps(options: UploadSourcemapsOptions): Promise<void> {
+    const { apiKey, sourcemap, apiEndpoint = DEFAULT_ENDPOINT } = options;
+
+    if (!apiKey) {
+        console.warn(`${LOG_PREFIX}: No Flare API key provided, not uploading sourcemaps.`);
+        return;
+    }
+
+    const version = resolveVersion({ version: options.version });
+    const bundleFilename = options.bundleFilename ?? defaultBundleFilename(sourcemap);
+    const content = readFileSync(sourcemap, 'utf8');
+
+    const flare = new FlareApi(apiEndpoint, apiKey, version);
+
+    log(`Uploading sourcemap "${bundleFilename}" (version ${version}) to Flare.`);
+    await flare.uploadSourcemap({ originalFile: bundleFilename, content });
+    log('Successfully uploaded sourcemap to Flare.');
+}
+
+function defaultBundleFilename(sourcemapPath: string): string {
+    return basename(sourcemapPath).replace(/\.map$/, '');
+}
+
+function log(message: string): void {
+    console.log(`${LOG_PREFIX}: ${message}`);
+}

--- a/packages/react-native-sourcemaps/src/version.ts
+++ b/packages/react-native-sourcemaps/src/version.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+export type ResolveVersionOptions = {
+    /** Explicit version (e.g. CLI `--version`). Highest precedence. */
+    version?: string;
+    /** Directory whose package.json is read as the last-resort fallback. */
+    cwd?: string;
+};
+
+const LOG_PREFIX = '@flareapp/react-native-sourcemaps';
+
+/**
+ * Resolve the sourcemap version shared by the Babel plugin and the CLI.
+ * Precedence: explicit `version` > `FLARE_SOURCEMAP_VERSION` env > package.json
+ * `version` (with a warning). Never a random value — a random default would
+ * silently desync the inlined runtime value from the uploaded `version_id`.
+ */
+export function resolveVersion({ version, cwd = process.cwd() }: ResolveVersionOptions = {}): string {
+    if (version) {
+        return version;
+    }
+
+    const envVersion = process.env.FLARE_SOURCEMAP_VERSION;
+    if (envVersion) {
+        return envVersion;
+    }
+
+    const pkgVersion = readPackageVersion(cwd);
+    if (pkgVersion) {
+        console.warn(
+            `${LOG_PREFIX}: No version provided (--version or FLARE_SOURCEMAP_VERSION). ` +
+                `Falling back to package.json version "${pkgVersion}". Use the same version when ` +
+                `building the bundle and uploading the map, or symbolication will silently fail.`,
+        );
+        return pkgVersion;
+    }
+
+    throw new Error(
+        `${LOG_PREFIX}: Could not resolve a sourcemap version. ` +
+            'Pass --version, set FLARE_SOURCEMAP_VERSION, or ensure package.json has a "version".',
+    );
+}
+
+function readPackageVersion(cwd: string): string | null {
+    try {
+        const pkg = JSON.parse(readFileSync(resolve(cwd, 'package.json'), 'utf8')) as { version?: string };
+        return pkg.version ?? null;
+    } catch {
+        return null;
+    }
+}

--- a/packages/react-native-sourcemaps/src/version.ts
+++ b/packages/react-native-sourcemaps/src/version.ts
@@ -1,14 +1,14 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 
+import { LOG_PREFIX } from './constants';
+
 export type ResolveVersionOptions = {
     /** Explicit version (e.g. CLI `--version`). Highest precedence. */
     version?: string;
     /** Directory whose package.json is read as the last-resort fallback. */
     cwd?: string;
 };
-
-const LOG_PREFIX = '@flareapp/react-native-sourcemaps';
 
 /**
  * Resolve the sourcemap version shared by the Babel plugin and the CLI.

--- a/packages/react-native-sourcemaps/src/version.ts
+++ b/packages/react-native-sourcemaps/src/version.ts
@@ -42,6 +42,24 @@ export function resolveVersion({ version, cwd = process.cwd() }: ResolveVersionO
     );
 }
 
+/**
+ * Version resolution for the AUTOMATIC native upload path. Unlike resolveVersion it
+ * NEVER falls back to package.json: the hook runs in android/ or ios/, a different
+ * cwd than Metro, so a package.json fallback would read a different (or missing)
+ * file and silently desync from the version the Babel plugin inlined. The only
+ * input guaranteed identical to both halves is FLARE_SOURCEMAP_VERSION. Returns
+ * null when unresolved so the caller can skip-with-banner rather than upload a
+ * guaranteed-mismatched map.
+ */
+export function resolveAutoVersion(version?: string): string | null {
+    if (version) {
+        return version;
+    }
+
+    const envVersion = process.env.FLARE_SOURCEMAP_VERSION;
+    return envVersion ? envVersion : null;
+}
+
 function readPackageVersion(cwd: string): string | null {
     try {
         const pkg = JSON.parse(readFileSync(resolve(cwd, 'package.json'), 'utf8')) as { version?: string };

--- a/packages/react-native-sourcemaps/tests/babel.test.ts
+++ b/packages/react-native-sourcemaps/tests/babel.test.ts
@@ -46,4 +46,11 @@ describe('flareSourcemapsBabelPlugin', () => {
         const out = transform('const v = process.env["FLARE_SOURCEMAP_VERSION"];', 'xyz');
         expect(out).toContain('"xyz"');
     });
+
+    test('resolves the version independently for each transform (pre() reset)', () => {
+        const first = transform('const v = process.env.FLARE_SOURCEMAP_VERSION;', 'v1');
+        const second = transform('const v = process.env.FLARE_SOURCEMAP_VERSION;', 'v2');
+        expect(first).toContain('"v1"');
+        expect(second).toContain('"v2"');
+    });
 });

--- a/packages/react-native-sourcemaps/tests/babel.test.ts
+++ b/packages/react-native-sourcemaps/tests/babel.test.ts
@@ -3,6 +3,8 @@ import { afterEach, describe, expect, test, vi } from 'vitest';
 
 import flareSourcemapsBabelPlugin from '../src/babel';
 
+const RUNTIME = '@flareapp/react-native-sourcemaps/runtime';
+
 function transform(code: string, version: string | undefined): string {
     const previous = process.env.FLARE_SOURCEMAP_VERSION;
     if (version === undefined) {
@@ -31,25 +33,37 @@ afterEach(() => {
 });
 
 describe('flareSourcemapsBabelPlugin', () => {
-    test('replaces process.env.FLARE_SOURCEMAP_VERSION with the resolved version literal', () => {
-        const out = transform('const v = process.env.FLARE_SOURCEMAP_VERSION;', 'abc123');
+    test('inlines the imported flareSourcemapVersion and drops the import', () => {
+        const out = transform(
+            `import { flareSourcemapVersion } from '${RUNTIME}';\nconst v = flareSourcemapVersion;`,
+            'abc123',
+        );
         expect(out).toContain('"abc123"');
-        expect(out).not.toContain('process.env.FLARE_SOURCEMAP_VERSION');
+        expect(out).not.toContain('flareSourcemapVersion');
+        expect(out).not.toContain(RUNTIME);
     });
 
-    test('leaves other process.env reads untouched', () => {
-        const out = transform('const a = process.env.OTHER_VAR;', 'abc123');
-        expect(out).toContain('process.env.OTHER_VAR');
-    });
-
-    test('handles computed access process.env["FLARE_SOURCEMAP_VERSION"]', () => {
-        const out = transform('const v = process.env["FLARE_SOURCEMAP_VERSION"];', 'xyz');
+    test('handles an aliased import', () => {
+        const out = transform(`import { flareSourcemapVersion as ver } from '${RUNTIME}';\nconst v = ver;`, 'xyz');
         expect(out).toContain('"xyz"');
+        expect(out).not.toContain(RUNTIME);
+    });
+
+    test('leaves unrelated imports and identifiers untouched', () => {
+        const out = transform(
+            `import { foo } from 'somewhere';\nconst flareSourcemapVersion = 1;\nconst a = foo + flareSourcemapVersion;`,
+            'abc123',
+        );
+        expect(out).toContain("from 'somewhere'");
+        expect(out).toContain('foo');
+        // The local const (not imported from our runtime) must NOT be inlined.
+        expect(out).not.toContain('"abc123"');
     });
 
     test('resolves the version independently for each transform (pre() reset)', () => {
-        const first = transform('const v = process.env.FLARE_SOURCEMAP_VERSION;', 'v1');
-        const second = transform('const v = process.env.FLARE_SOURCEMAP_VERSION;', 'v2');
+        const code = `import { flareSourcemapVersion } from '${RUNTIME}';\nexport const v = flareSourcemapVersion;`;
+        const first = transform(code, 'v1');
+        const second = transform(code, 'v2');
         expect(first).toContain('"v1"');
         expect(second).toContain('"v2"');
     });

--- a/packages/react-native-sourcemaps/tests/babel.test.ts
+++ b/packages/react-native-sourcemaps/tests/babel.test.ts
@@ -1,0 +1,49 @@
+import { transformSync } from '@babel/core';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import flareSourcemapsBabelPlugin from '../src/babel';
+
+function transform(code: string, version: string | undefined): string {
+    const previous = process.env.FLARE_SOURCEMAP_VERSION;
+    if (version === undefined) {
+        delete process.env.FLARE_SOURCEMAP_VERSION;
+    } else {
+        process.env.FLARE_SOURCEMAP_VERSION = version;
+    }
+    try {
+        const result = transformSync(code, {
+            plugins: [flareSourcemapsBabelPlugin],
+            babelrc: false,
+            configFile: false,
+        });
+        return result?.code ?? '';
+    } finally {
+        if (previous === undefined) {
+            delete process.env.FLARE_SOURCEMAP_VERSION;
+        } else {
+            process.env.FLARE_SOURCEMAP_VERSION = previous;
+        }
+    }
+}
+
+afterEach(() => {
+    vi.restoreAllMocks();
+});
+
+describe('flareSourcemapsBabelPlugin', () => {
+    test('replaces process.env.FLARE_SOURCEMAP_VERSION with the resolved version literal', () => {
+        const out = transform('const v = process.env.FLARE_SOURCEMAP_VERSION;', 'abc123');
+        expect(out).toContain('"abc123"');
+        expect(out).not.toContain('process.env.FLARE_SOURCEMAP_VERSION');
+    });
+
+    test('leaves other process.env reads untouched', () => {
+        const out = transform('const a = process.env.OTHER_VAR;', 'abc123');
+        expect(out).toContain('process.env.OTHER_VAR');
+    });
+
+    test('handles computed access process.env["FLARE_SOURCEMAP_VERSION"]', () => {
+        const out = transform('const v = process.env["FLARE_SOURCEMAP_VERSION"];', 'xyz');
+        expect(out).toContain('"xyz"');
+    });
+});

--- a/packages/react-native-sourcemaps/tests/banner.test.ts
+++ b/packages/react-native-sourcemaps/tests/banner.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'vitest';
+
+import { formatFailureBanner } from '../src/banner';
+
+describe('formatFailureBanner', () => {
+    test('renders a bordered banner with the reason', () => {
+        const banner = formatFailureBanner({ reason: 'boom' });
+        expect(banner).toContain('FLARE SOURCEMAP UPLOAD FAILED');
+        expect(banner).toContain('Reason: boom');
+        expect(banner).toContain('='.repeat(60));
+    });
+
+    test('starts and ends with a blank line so it stands out in CI', () => {
+        const lines = formatFailureBanner({ reason: 'x' }).split('\n');
+        expect(lines[0]).toBe('');
+        expect(lines[lines.length - 1]).toBe('');
+    });
+
+    test('interpolates the real resolved values into the recovery command', () => {
+        const banner = formatFailureBanner({
+            reason: 'x',
+            sourcemap: '/build/main.jsbundle.map',
+            bundleFilename: 'main.jsbundle',
+            version: 'sha123',
+            apiKey: 'real-key',
+        });
+        expect(banner).toContain('--sourcemap /build/main.jsbundle.map');
+        expect(banner).toContain('--bundle-filename main.jsbundle');
+        expect(banner).toContain('--version sha123');
+        expect(banner).toContain('--api-key real-key');
+    });
+
+    test('falls back to labelled placeholders when values are unknown', () => {
+        const banner = formatFailureBanner({ reason: 'no key' });
+        expect(banner).toContain('<path-to-map>');
+        expect(banner).toContain('<bundle-filename>');
+        expect(banner).toContain('<flare-sourcemap-version>');
+        expect(banner).toContain('<your-flare-api-key>');
+    });
+
+    test('treats empty-string version and apiKey as unknown (placeholders)', () => {
+        const banner = formatFailureBanner({ reason: 'x', version: '', apiKey: '' });
+        expect(banner).toContain('<flare-sourcemap-version>');
+        expect(banner).toContain('<your-flare-api-key>');
+    });
+});

--- a/packages/react-native-sourcemaps/tests/banner.test.ts
+++ b/packages/react-native-sourcemaps/tests/banner.test.ts
@@ -43,4 +43,14 @@ describe('formatFailureBanner', () => {
         expect(banner).toContain('<flare-sourcemap-version>');
         expect(banner).toContain('<your-flare-api-key>');
     });
+
+    test('includes --api-endpoint in the recovery command when a custom endpoint is set', () => {
+        const banner = formatFailureBanner({ reason: 'x', apiEndpoint: 'https://flare.internal/api/sourcemaps' });
+        expect(banner).toContain('--api-endpoint https://flare.internal/api/sourcemaps');
+    });
+
+    test('omits --api-endpoint when no endpoint is set', () => {
+        const banner = formatFailureBanner({ reason: 'x' });
+        expect(banner).not.toContain('--api-endpoint');
+    });
 });

--- a/packages/react-native-sourcemaps/tests/cli.test.ts
+++ b/packages/react-native-sourcemaps/tests/cli.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import { parseArgs, runCli } from '../src/cli';
+import { uploadSourcemaps } from '../src/uploadSourcemaps';
+
+vi.mock('../src/uploadSourcemaps', () => ({ uploadSourcemaps: vi.fn().mockResolvedValue(undefined) }));
+
+afterEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+    process.exitCode = undefined;
+    delete process.env.FLARE_API_KEY;
+});
+
+describe('parseArgs', () => {
+    test('parses the command and its flags', () => {
+        const { command, flags } = parseArgs([
+            'upload',
+            '--api-key',
+            'k',
+            '--sourcemap',
+            '/a.map',
+            '--bundle-filename',
+            'index.android.bundle',
+        ]);
+        expect(command).toBe('upload');
+        expect(flags).toEqual({
+            'api-key': 'k',
+            'sourcemap': '/a.map',
+            'bundle-filename': 'index.android.bundle',
+        });
+    });
+
+    test('treats a flag with no value as a boolean "true"', () => {
+        const { flags } = parseArgs(['upload', '--verbose']);
+        expect(flags.verbose).toBe('true');
+    });
+
+    test('parses the --flag=value form', () => {
+        const { flags } = parseArgs(['upload', '--api-key=k', '--sourcemap=/a.map']);
+        expect(flags['api-key']).toBe('k');
+        expect(flags.sourcemap).toBe('/a.map');
+    });
+});
+
+describe('runCli', () => {
+    test('upload forwards parsed flags to uploadSourcemaps', async () => {
+        await runCli([
+            'upload',
+            '--api-key',
+            'k',
+            '--sourcemap',
+            '/a.map',
+            '--bundle-filename',
+            'main.jsbundle',
+            '--version',
+            'v1',
+            '--api-endpoint',
+            'https://example.test/api/sourcemaps',
+        ]);
+        expect(uploadSourcemaps).toHaveBeenCalledWith({
+            apiKey: 'k',
+            sourcemap: '/a.map',
+            bundleFilename: 'main.jsbundle',
+            version: 'v1',
+            apiEndpoint: 'https://example.test/api/sourcemaps',
+        });
+    });
+
+    test('falls back to FLARE_API_KEY when --api-key is absent', async () => {
+        process.env.FLARE_API_KEY = 'env-key';
+        await runCli(['upload', '--sourcemap', '/a.map']);
+        expect(uploadSourcemaps).toHaveBeenCalledWith(
+            expect.objectContaining({ apiKey: 'env-key', sourcemap: '/a.map' }),
+        );
+    });
+
+    test('errors and sets exit code when --sourcemap is missing', async () => {
+        const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+        await runCli(['upload', '--api-key', 'k']);
+        expect(uploadSourcemaps).not.toHaveBeenCalled();
+        expect(process.exitCode).toBe(1);
+        expect(err).toHaveBeenCalled();
+    });
+
+    test('errors and sets exit code on an unknown command', async () => {
+        const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+        await runCli(['frobnicate']);
+        expect(process.exitCode).toBe(1);
+        expect(err).toHaveBeenCalled();
+    });
+});

--- a/packages/react-native-sourcemaps/tests/cli.test.ts
+++ b/packages/react-native-sourcemaps/tests/cli.test.ts
@@ -1,15 +1,21 @@
 import { afterEach, describe, expect, test, vi } from 'vitest';
 
 import { parseArgs, runCli } from '../src/cli';
+import { readFlareConfig } from '../src/config';
 import { uploadSourcemaps } from '../src/uploadSourcemaps';
 
 vi.mock('../src/uploadSourcemaps', () => ({ uploadSourcemaps: vi.fn().mockResolvedValue(undefined) }));
+// flare.json reading is covered in config.test.ts; here we stub it so the CLI's
+// key/endpoint resolution falls through to flags/env deterministically.
+vi.mock('../src/config', () => ({ readFlareConfig: vi.fn().mockReturnValue({}) }));
 
 afterEach(() => {
     vi.clearAllMocks();
     vi.restoreAllMocks();
     process.exitCode = undefined;
     delete process.env.FLARE_API_KEY;
+    delete process.env.FLARE_API_ENDPOINT;
+    delete process.env.FLARE_SOURCEMAP_VERSION;
 });
 
 describe('parseArgs', () => {
@@ -88,5 +94,70 @@ describe('runCli', () => {
         await runCli(['frobnicate']);
         expect(process.exitCode).toBe(1);
         expect(err).toHaveBeenCalled();
+    });
+});
+
+describe('runCli --auto', () => {
+    test('skips with a banner when no api key is resolvable, and exits 0', async () => {
+        const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+        await runCli(['upload', '--sourcemap', '/a.map', '--auto']);
+        expect(uploadSourcemaps).not.toHaveBeenCalled();
+        expect(process.exitCode).toBeUndefined();
+        expect(err.mock.calls.flat().join('\n')).toContain('FLARE SOURCEMAP UPLOAD FAILED');
+    });
+
+    test('skips with a banner when FLARE_SOURCEMAP_VERSION is unset, and exits 0', async () => {
+        const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+        await runCli(['upload', '--sourcemap', '/a.map', '--api-key', 'k', '--auto']);
+        expect(uploadSourcemaps).not.toHaveBeenCalled();
+        expect(process.exitCode).toBeUndefined();
+        expect(err.mock.calls.flat().join('\n')).toContain('FLARE_SOURCEMAP_VERSION');
+    });
+
+    test('does not fall back to package.json for the version', async () => {
+        // No env version set; even with a package.json present, auto mode must skip.
+        const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+        await runCli(['upload', '--sourcemap', '/a.map', '--api-key', 'k', '--auto']);
+        expect(uploadSourcemaps).not.toHaveBeenCalled();
+        expect(err).toHaveBeenCalled();
+    });
+
+    test('uploads under the env version and exits 0', async () => {
+        process.env.FLARE_SOURCEMAP_VERSION = 'sha123';
+        await runCli(['upload', '--sourcemap', '/a.map', '--api-key', 'k', '--auto']);
+        expect(uploadSourcemaps).toHaveBeenCalledWith(
+            expect.objectContaining({ apiKey: 'k', sourcemap: '/a.map', version: 'sha123' }),
+        );
+        expect(process.exitCode).toBeUndefined();
+    });
+
+    test('banners and exits 0 when the upload itself throws', async () => {
+        process.env.FLARE_SOURCEMAP_VERSION = 'sha123';
+        const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+        vi.mocked(uploadSourcemaps).mockRejectedValueOnce(new Error('Flare API returned 500'));
+        await runCli(['upload', '--sourcemap', '/a.map', '--api-key', 'k', '--auto']);
+        expect(process.exitCode).toBeUndefined();
+        const printed = err.mock.calls.flat().join('\n');
+        expect(printed).toContain('FLARE SOURCEMAP UPLOAD FAILED');
+        expect(printed).toContain('Flare API returned 500');
+    });
+
+    test('resolves the api key from flare.json when no flag or env is set', async () => {
+        process.env.FLARE_SOURCEMAP_VERSION = 'sha123';
+        vi.mocked(readFlareConfig).mockReturnValueOnce({ apiKey: 'from-config' });
+        await runCli(['upload', '--sourcemap', '/a.map', '--config', '/p/flare.json', '--auto']);
+        expect(uploadSourcemaps).toHaveBeenCalledWith(
+            expect.objectContaining({ apiKey: 'from-config', version: 'sha123' }),
+        );
+        expect(process.exitCode).toBeUndefined();
+    });
+
+    test('defaults --bundle-filename to the map basename when not given', async () => {
+        process.env.FLARE_SOURCEMAP_VERSION = 'sha123';
+        await runCli(['upload', '--sourcemap', '/build/index.android.bundle.map', '--api-key', 'k', '--auto']);
+        // No bundleFilename passed -> uploadSourcemaps applies its own basename default.
+        expect(uploadSourcemaps).toHaveBeenCalledWith(
+            expect.objectContaining({ bundleFilename: undefined, sourcemap: '/build/index.android.bundle.map' }),
+        );
     });
 });

--- a/packages/react-native-sourcemaps/tests/config.test.ts
+++ b/packages/react-native-sourcemaps/tests/config.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from 'node:fs';
+
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import { readFlareConfig } from '../src/config';
+
+vi.mock('node:fs', () => ({ readFileSync: vi.fn() }));
+
+afterEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+});
+
+describe('readFlareConfig', () => {
+    test('returns an empty config when no path is given (never reads cwd)', () => {
+        expect(readFlareConfig()).toEqual({});
+        expect(readFileSync).not.toHaveBeenCalled();
+    });
+
+    test('reads the exact path it is given', () => {
+        vi.mocked(readFileSync).mockReturnValue(
+            JSON.stringify({ apiKey: 'k', apiEndpoint: 'https://e.test/api/sourcemaps' }),
+        );
+        const config = readFlareConfig('/proj/flare.json');
+        expect(readFileSync).toHaveBeenCalledWith('/proj/flare.json', 'utf8');
+        expect(config).toEqual({ apiKey: 'k', apiEndpoint: 'https://e.test/api/sourcemaps' });
+    });
+
+    test('ignores a version key if present', () => {
+        vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ apiKey: 'k', version: '9.9.9' }));
+        expect(readFlareConfig('/p/flare.json')).toEqual({ apiKey: 'k' });
+    });
+
+    test('returns an empty config on a missing file', () => {
+        vi.mocked(readFileSync).mockImplementation(() => {
+            throw new Error('ENOENT');
+        });
+        expect(readFlareConfig('/nope/flare.json')).toEqual({});
+    });
+
+    test('returns an empty config on malformed JSON', () => {
+        vi.mocked(readFileSync).mockReturnValue('{ not json');
+        expect(readFlareConfig('/p/flare.json')).toEqual({});
+    });
+
+    test('treats empty-string values as absent', () => {
+        vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ apiKey: '', apiEndpoint: '' }));
+        expect(readFlareConfig('/p/flare.json')).toEqual({});
+    });
+});

--- a/packages/react-native-sourcemaps/tests/env.test.ts
+++ b/packages/react-native-sourcemaps/tests/env.test.ts
@@ -1,0 +1,83 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+
+import { loadEnvFiles } from '../src/env';
+
+let dir: string;
+
+beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'flare-env-'));
+});
+
+afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+    delete process.env.FLARE_API_KEY;
+    delete process.env.FLARE_API_ENDPOINT;
+    delete process.env.FLARE_SOURCEMAP_VERSION;
+    delete process.env.FLARE_QUOTED;
+    delete process.env.SOME_OTHER_SECRET;
+});
+
+function write(file: string, contents: string): void {
+    writeFileSync(join(dir, file), contents);
+}
+
+describe('loadEnvFiles', () => {
+    test('loads FLARE_* keys from .env.local', () => {
+        write('.env.local', 'FLARE_API_KEY=abc123\n');
+        loadEnvFiles(dir);
+        expect(process.env.FLARE_API_KEY).toBe('abc123');
+    });
+
+    test('only loads FLARE_-prefixed keys (never unrelated secrets)', () => {
+        write('.env.local', 'FLARE_API_KEY=abc123\nSOME_OTHER_SECRET=leak\n');
+        loadEnvFiles(dir);
+        expect(process.env.FLARE_API_KEY).toBe('abc123');
+        expect(process.env.SOME_OTHER_SECRET).toBeUndefined();
+    });
+
+    test('does not overwrite an already-set env value (explicit export wins)', () => {
+        process.env.FLARE_API_KEY = 'from-shell';
+        write('.env.local', 'FLARE_API_KEY=from-file\n');
+        loadEnvFiles(dir);
+        expect(process.env.FLARE_API_KEY).toBe('from-shell');
+    });
+
+    test('.env.local wins over .env for the same key', () => {
+        write('.env', 'FLARE_API_KEY=from-env\n');
+        write('.env.local', 'FLARE_API_KEY=from-local\n');
+        loadEnvFiles(dir);
+        expect(process.env.FLARE_API_KEY).toBe('from-local');
+    });
+
+    test('falls back to .env when .env.local is absent', () => {
+        write('.env', 'FLARE_API_KEY=from-env\n');
+        loadEnvFiles(dir);
+        expect(process.env.FLARE_API_KEY).toBe('from-env');
+    });
+
+    test('ignores comments and blank lines, supports `export ` and quotes', () => {
+        write(
+            '.env.local',
+            [
+                '# a comment',
+                '',
+                'export FLARE_API_KEY=k1',
+                'FLARE_QUOTED="q v"',
+                "FLARE_API_ENDPOINT='https://e.test'",
+            ].join('\n'),
+        );
+        loadEnvFiles(dir);
+        expect(process.env.FLARE_API_KEY).toBe('k1');
+        expect(process.env.FLARE_QUOTED).toBe('q v');
+        expect(process.env.FLARE_API_ENDPOINT).toBe('https://e.test');
+    });
+
+    test('is a no-op when neither file exists', () => {
+        expect(() => loadEnvFiles(dir)).not.toThrow();
+        expect(process.env.FLARE_API_KEY).toBeUndefined();
+    });
+});

--- a/packages/react-native-sourcemaps/tests/expo.test.ts
+++ b/packages/react-native-sourcemaps/tests/expo.test.ts
@@ -1,0 +1,28 @@
+import type { ConfigPlugin } from '@expo/config-plugins';
+import { describe, expect, test } from 'vitest';
+
+import plugin from '../src/expo';
+
+describe('expo config plugin', () => {
+    test('default export is a config-plugin function', () => {
+        expect(typeof plugin).toBe('function');
+    });
+
+    test('registers mods for both ios and android', () => {
+        const config = { name: 'x', slug: 'x' };
+        const out = (plugin as ConfigPlugin)(config) as unknown as {
+            mods?: {
+                ios?: { dangerous?: unknown; xcodeproj?: unknown };
+                android?: { dangerous?: unknown; appBuildGradle?: unknown };
+            };
+        };
+
+        // The flare.json write must land whichever platform EAS prebuilds, so a
+        // dangerous mod is registered for BOTH platforms.
+        expect(typeof out.mods?.ios?.dangerous).toBe('function');
+        expect(typeof out.mods?.android?.dangerous).toBe('function');
+        // Platform-specific native mods: iOS build phase + Android gradle apply.
+        expect(typeof out.mods?.ios?.xcodeproj).toBe('function');
+        expect(typeof out.mods?.android?.appBuildGradle).toBe('function');
+    });
+});

--- a/packages/react-native-sourcemaps/tests/expoTransforms.test.ts
+++ b/packages/react-native-sourcemaps/tests/expoTransforms.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+    addFlareGradleApply,
+    addSourcemapFileEnv,
+    ensureGitignored,
+    flareJsonContents,
+    flareXcodeShellScript,
+    toPosixRelative,
+} from '../src/expoTransforms';
+
+describe('flareJsonContents', () => {
+    test('serialises the provided props', () => {
+        expect(JSON.parse(flareJsonContents({ apiKey: 'k', apiEndpoint: 'https://e.test' }))).toEqual({
+            apiKey: 'k',
+            apiEndpoint: 'https://e.test',
+        });
+    });
+
+    test('omits absent keys', () => {
+        expect(JSON.parse(flareJsonContents({ apiKey: 'k' }))).toEqual({ apiKey: 'k' });
+        expect(JSON.parse(flareJsonContents({}))).toEqual({});
+    });
+
+    test('ends with a trailing newline', () => {
+        expect(flareJsonContents({})).toMatch(/\n$/);
+    });
+});
+
+describe('addFlareGradleApply', () => {
+    test('appends the apply line', () => {
+        const out = addFlareGradleApply('apply plugin: "com.android.application"\n', '../../x/flare.gradle');
+        expect(out).toContain('apply from: "../../x/flare.gradle"');
+        expect(out.startsWith('apply plugin:')).toBe(true);
+    });
+
+    test('is idempotent', () => {
+        const once = addFlareGradleApply('content\n', '../../x/flare.gradle');
+        const twice = addFlareGradleApply(once, '../../x/flare.gradle');
+        expect(twice).toBe(once);
+    });
+});
+
+describe('addSourcemapFileEnv', () => {
+    test('appends the SOURCEMAP_FILE export to empty/missing input', () => {
+        expect(addSourcemapFileEnv('')).toContain('export SOURCEMAP_FILE="$CONFIGURATION_BUILD_DIR/main.jsbundle.map"');
+    });
+
+    test('is idempotent and respects a pre-existing SOURCEMAP_FILE', () => {
+        const once = addSourcemapFileEnv('export NODE_BINARY=node\n');
+        expect(addSourcemapFileEnv(once)).toBe(once);
+        expect(addSourcemapFileEnv('export SOURCEMAP_FILE=/custom\n')).toBe('export SOURCEMAP_FILE=/custom\n');
+        expect(addSourcemapFileEnv('SOURCEMAP_FILE=/custom\n')).toBe('SOURCEMAP_FILE=/custom\n');
+    });
+
+    test('injects past a commented-out SOURCEMAP_FILE line', () => {
+        const out = addSourcemapFileEnv('# export SOURCEMAP_FILE=/old\n');
+        expect(out).toContain('export SOURCEMAP_FILE="$CONFIGURATION_BUILD_DIR/main.jsbundle.map"');
+    });
+});
+
+describe('ensureGitignored', () => {
+    test('appends flare.json once', () => {
+        const once = ensureGitignored('node_modules/\n');
+        expect(once).toContain('flare.json');
+        expect(ensureGitignored(once)).toBe(once);
+    });
+
+    test('does not duplicate an existing entry', () => {
+        expect(ensureGitignored('flare.json\n')).toBe('flare.json\n');
+    });
+});
+
+describe('flareXcodeShellScript', () => {
+    test('emits the with-environment wrapped invocation', () => {
+        const script = flareXcodeShellScript(
+            '../node_modules/react-native/scripts/xcode/with-environment.sh',
+            '../node_modules/@flareapp/x/scripts/flare-xcode.sh',
+        );
+        expect(script).toContain('WITH_ENVIRONMENT="../node_modules/react-native/scripts/xcode/with-environment.sh"');
+        expect(script).toContain('FLARE_XCODE="../node_modules/@flareapp/x/scripts/flare-xcode.sh"');
+        expect(script).toContain('/bin/sh -c "$WITH_ENVIRONMENT $FLARE_XCODE"');
+        expect(script).toContain('set -e');
+    });
+});
+
+describe('toPosixRelative', () => {
+    test('returns a forward-slash relative path', () => {
+        expect(toPosixRelative('/a/b/ios', '/a/b/node_modules/x/y.sh')).toBe('../node_modules/x/y.sh');
+    });
+});

--- a/packages/react-native-sourcemaps/tests/expoTransforms.test.ts
+++ b/packages/react-native-sourcemaps/tests/expoTransforms.test.ts
@@ -43,7 +43,7 @@ describe('addFlareGradleApply', () => {
 
 describe('addSourcemapFileEnv', () => {
     test('appends the SOURCEMAP_FILE export to empty/missing input', () => {
-        expect(addSourcemapFileEnv('')).toContain('export SOURCEMAP_FILE="$CONFIGURATION_BUILD_DIR/main.jsbundle.map"');
+        expect(addSourcemapFileEnv('')).toContain('export SOURCEMAP_FILE="$TARGET_TEMP_DIR/main.jsbundle.map"');
     });
 
     test('is idempotent and respects a pre-existing SOURCEMAP_FILE', () => {
@@ -55,7 +55,7 @@ describe('addSourcemapFileEnv', () => {
 
     test('injects past a commented-out SOURCEMAP_FILE line', () => {
         const out = addSourcemapFileEnv('# export SOURCEMAP_FILE=/old\n');
-        expect(out).toContain('export SOURCEMAP_FILE="$CONFIGURATION_BUILD_DIR/main.jsbundle.map"');
+        expect(out).toContain('export SOURCEMAP_FILE="$TARGET_TEMP_DIR/main.jsbundle.map"');
     });
 });
 

--- a/packages/react-native-sourcemaps/tests/expoXcode.test.ts
+++ b/packages/react-native-sourcemaps/tests/expoXcode.test.ts
@@ -59,4 +59,12 @@ describe('addUploadBuildPhase', () => {
         expect(pbxproj).toContain('Upload Flare sourcemaps');
         expect(pbxproj).toContain('flare-marker');
     });
+
+    // "Based on dependency analysis" unchecked → no "ambiguous dependencies / runs on
+    // every build" warning from Xcode. Serialized as `alwaysOutOfDate = 1`.
+    test('marks the phase always-out-of-date so Xcode does not warn', () => {
+        const project = parseFixture();
+        addUploadBuildPhase(project, 'echo flare');
+        expect(project.writeSync()).toContain('alwaysOutOfDate = 1');
+    });
 });

--- a/packages/react-native-sourcemaps/tests/expoXcode.test.ts
+++ b/packages/react-native-sourcemaps/tests/expoXcode.test.ts
@@ -1,0 +1,62 @@
+import { resolve } from 'node:path';
+
+import { describe, expect, test } from 'vitest';
+import xcode from 'xcode';
+
+import { addUploadBuildPhase, FLARE_PHASE_NAME } from '../src/expoXcode';
+
+const FIXTURE = resolve(__dirname, 'fixtures/project.pbxproj');
+
+function parseFixture() {
+    const project = xcode.project(FIXTURE);
+    project.parseSync();
+    return project;
+}
+
+function flarePhaseCount(project: ReturnType<typeof parseFixture>): number {
+    const phases = project.hash.project.objects.PBXShellScriptBuildPhase ?? {};
+    return Object.values(phases).filter(
+        (phase: unknown) =>
+            typeof phase === 'object' &&
+            phase !== null &&
+            typeof (phase as { name?: unknown }).name === 'string' &&
+            (phase as { name: string }).name.replace(/^"|"$/g, '') === FLARE_PHASE_NAME,
+    ).length;
+}
+
+describe('addUploadBuildPhase', () => {
+    test('adds exactly one Flare upload phase', () => {
+        const project = parseFixture();
+        expect(flarePhaseCount(project)).toBe(0);
+        addUploadBuildPhase(project, 'echo flare');
+        expect(flarePhaseCount(project)).toBe(1);
+    });
+
+    test('is idempotent — a second call adds nothing', () => {
+        const project = parseFixture();
+        addUploadBuildPhase(project, 'echo flare');
+        addUploadBuildPhase(project, 'echo flare');
+        expect(flarePhaseCount(project)).toBe(1);
+    });
+
+    test('stores the shell script on the phase', () => {
+        const project = parseFixture();
+        addUploadBuildPhase(project, 'echo flare-marker');
+        const phases = project.hash.project.objects.PBXShellScriptBuildPhase ?? {};
+        const serialised = JSON.stringify(phases);
+        expect(serialised).toContain('flare-marker');
+    });
+
+    // The in-memory checks above say nothing about whether the phase survives being
+    // written back to the pbxproj text format — the xcode lib quote-escapes shellScript
+    // (`'"' + script.replace(/"/g,'\\"') + '"'`), and our real script is multi-line with
+    // embedded quotes, which is exactly where that lib is fragile. writeSync() exercises
+    // the serializer end to end.
+    test('survives pbxproj serialization (writeSync)', () => {
+        const project = parseFixture();
+        addUploadBuildPhase(project, 'set -e\necho "flare-marker"\n');
+        const pbxproj = project.writeSync();
+        expect(pbxproj).toContain('Upload Flare sourcemaps');
+        expect(pbxproj).toContain('flare-marker');
+    });
+});

--- a/packages/react-native-sourcemaps/tests/fixtures/project.pbxproj
+++ b/packages/react-native-sourcemaps/tests/fixtures/project.pbxproj
@@ -1,0 +1,572 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 54;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
+		2B21EC9CB31D61A1F8A3BA2E /* libPods-reactnativeexpo.a in Frameworks */ = {isa = PBXBuildFile; fileRef = EF9CC47D39C965FB09BE755F /* libPods-reactnativeexpo.a */; };
+		3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */; };
+		862611819EF37DC0AA5B21C1 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 8E0DA4FD8D94BD5E5EBC90AC /* PrivacyInfo.xcprivacy */; };
+		BB2F792D24A3F905000567C9 /* Expo.plist in Resources */ = {isa = PBXBuildFile; fileRef = BB2F792C24A3F905000567C9 /* Expo.plist */; };
+		D6E25DCAEA15F1E0C4474149 /* ExpoModulesProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B952B0C53904AA6C0B7DB6A /* ExpoModulesProvider.swift */; };
+		F11748422D0307B40044C1D9 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11748412D0307B40044C1D9 /* AppDelegate.swift */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		13B07F961A680F5B00A75B9A /* reactnativeexpo.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = reactnativeexpo.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		13B07FB51A68108700A75B9A /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = Images.xcassets; path = reactnativeexpo/Images.xcassets; sourceTree = "<group>"; };
+		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = reactnativeexpo/Info.plist; sourceTree = "<group>"; };
+		1B952B0C53904AA6C0B7DB6A /* ExpoModulesProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpoModulesProvider.swift; path = "Pods/Target Support Files/Pods-reactnativeexpo/ExpoModulesProvider.swift"; sourceTree = "<group>"; };
+		8E0DA4FD8D94BD5E5EBC90AC /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; includeInIndex = 1; name = PrivacyInfo.xcprivacy; path = reactnativeexpo/PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; name = SplashScreen.storyboard; path = reactnativeexpo/SplashScreen.storyboard; sourceTree = "<group>"; };
+		BB2F792C24A3F905000567C9 /* Expo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Expo.plist; sourceTree = "<group>"; };
+		DC01E954BF96DE887D9CFEA0 /* Pods-reactnativeexpo.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-reactnativeexpo.debug.xcconfig"; path = "Target Support Files/Pods-reactnativeexpo/Pods-reactnativeexpo.debug.xcconfig"; sourceTree = "<group>"; };
+		E29D8CEC4E4C540EC9F516B5 /* Pods-reactnativeexpo.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-reactnativeexpo.release.xcconfig"; path = "Target Support Files/Pods-reactnativeexpo/Pods-reactnativeexpo.release.xcconfig"; sourceTree = "<group>"; };
+		ED297162215061F000B7C4FE /* JavaScriptCore.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = JavaScriptCore.framework; path = System/Library/Frameworks/JavaScriptCore.framework; sourceTree = SDKROOT; };
+		EF9CC47D39C965FB09BE755F /* libPods-reactnativeexpo.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-reactnativeexpo.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		F11748412D0307B40044C1D9 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppDelegate.swift; path = reactnativeexpo/AppDelegate.swift; sourceTree = "<group>"; };
+		F11748442D0722820044C1D9 /* reactnativeexpo-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "reactnativeexpo-Bridging-Header.h"; path = "reactnativeexpo/reactnativeexpo-Bridging-Header.h"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		13B07F8C1A680F5B00A75B9A /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2B21EC9CB31D61A1F8A3BA2E /* libPods-reactnativeexpo.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		13B07FAE1A68108700A75B9A /* reactnativeexpo */ = {
+			isa = PBXGroup;
+			children = (
+				F11748412D0307B40044C1D9 /* AppDelegate.swift */,
+				F11748442D0722820044C1D9 /* reactnativeexpo-Bridging-Header.h */,
+				BB2F792B24A3F905000567C9 /* Supporting */,
+				13B07FB51A68108700A75B9A /* Images.xcassets */,
+				13B07FB61A68108700A75B9A /* Info.plist */,
+				AA286B85B6C04FC6940260E9 /* SplashScreen.storyboard */,
+				8E0DA4FD8D94BD5E5EBC90AC /* PrivacyInfo.xcprivacy */,
+			);
+			name = reactnativeexpo;
+			sourceTree = "<group>";
+		};
+		2ACB99BE4183B992DBE87201 /* ExpoModulesProviders */ = {
+			isa = PBXGroup;
+			children = (
+				B1B6E069976157ADBB70C2A9 /* reactnativeexpo */,
+			);
+			name = ExpoModulesProviders;
+			sourceTree = "<group>";
+		};
+		2D16E6871FA4F8E400B85C8A /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				ED297162215061F000B7C4FE /* JavaScriptCore.framework */,
+				EF9CC47D39C965FB09BE755F /* libPods-reactnativeexpo.a */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		7E1771CF441B434277EBB253 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				DC01E954BF96DE887D9CFEA0 /* Pods-reactnativeexpo.debug.xcconfig */,
+				E29D8CEC4E4C540EC9F516B5 /* Pods-reactnativeexpo.release.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
+		832341AE1AAA6A7D00B99B32 /* Libraries */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Libraries;
+			sourceTree = "<group>";
+		};
+		83CBB9F61A601CBA00E9B192 = {
+			isa = PBXGroup;
+			children = (
+				13B07FAE1A68108700A75B9A /* reactnativeexpo */,
+				832341AE1AAA6A7D00B99B32 /* Libraries */,
+				83CBBA001A601CBA00E9B192 /* Products */,
+				2D16E6871FA4F8E400B85C8A /* Frameworks */,
+				7E1771CF441B434277EBB253 /* Pods */,
+				2ACB99BE4183B992DBE87201 /* ExpoModulesProviders */,
+			);
+			indentWidth = 2;
+			sourceTree = "<group>";
+			tabWidth = 2;
+			usesTabs = 0;
+		};
+		83CBBA001A601CBA00E9B192 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				13B07F961A680F5B00A75B9A /* reactnativeexpo.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		B1B6E069976157ADBB70C2A9 /* reactnativeexpo */ = {
+			isa = PBXGroup;
+			children = (
+				1B952B0C53904AA6C0B7DB6A /* ExpoModulesProvider.swift */,
+			);
+			name = reactnativeexpo;
+			sourceTree = "<group>";
+		};
+		BB2F792B24A3F905000567C9 /* Supporting */ = {
+			isa = PBXGroup;
+			children = (
+				BB2F792C24A3F905000567C9 /* Expo.plist */,
+			);
+			name = Supporting;
+			path = reactnativeexpo/Supporting;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		13B07F861A680F5B00A75B9A /* reactnativeexpo */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "reactnativeexpo" */;
+			buildPhases = (
+				08A4A3CD28434E44B6B9DE2E /* [CP] Check Pods Manifest.lock */,
+				6B1A097875E7C606058ADD2E /* [Expo] Configure project */,
+				13B07F871A680F5B00A75B9A /* Sources */,
+				13B07F8C1A680F5B00A75B9A /* Frameworks */,
+				13B07F8E1A680F5B00A75B9A /* Resources */,
+				00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */,
+				800E24972A6A228C8D4807E9 /* [CP] Copy Pods Resources */,
+				0D1BB7C7A0BD4DBFB1D09419 /* [CP] Embed Pods Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = reactnativeexpo;
+			productName = reactnativeexpo;
+			productReference = 13B07F961A680F5B00A75B9A /* reactnativeexpo.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		83CBB9F71A601CBA00E9B192 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 1130;
+				TargetAttributes = {
+					13B07F861A680F5B00A75B9A = {
+						LastSwiftMigration = 1250;
+					};
+				};
+			};
+			buildConfigurationList = 83CBB9FA1A601CBA00E9B192 /* Build configuration list for PBXProject "reactnativeexpo" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 83CBB9F61A601CBA00E9B192;
+			productRefGroup = 83CBBA001A601CBA00E9B192 /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				13B07F861A680F5B00A75B9A /* reactnativeexpo */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		13B07F8E1A680F5B00A75B9A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				BB2F792D24A3F905000567C9 /* Expo.plist in Resources */,
+				13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */,
+				3E461D99554A48A4959DE609 /* SplashScreen.storyboard in Resources */,
+				862611819EF37DC0AA5B21C1 /* PrivacyInfo.xcprivacy in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		00DD1BFF1BD5951E006B06BC /* Bundle React Native code and images */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/.xcode.env",
+				"$(SRCROOT)/.xcode.env.local",
+			);
+			name = "Bundle React Native code and images";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ -f \"$PODS_ROOT/../.xcode.env\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env\"\nfi\nif [[ -f \"$PODS_ROOT/../.xcode.env.local\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.local\"\nfi\n\n# The project root by default is one level up from the ios directory\nexport PROJECT_ROOT=\"$PROJECT_DIR\"/..\n\nif [[ \"$CONFIGURATION\" = *Debug* ]]; then\n  export SKIP_BUNDLING=1\nfi\nif [[ -z \"$ENTRY_FILE\" ]]; then\n  # Set the entry JS file using the bundler's entry resolution.\n  export ENTRY_FILE=\"$(\"$NODE_BINARY\" -e \"require('expo/scripts/resolveAppEntry')\" \"$PROJECT_ROOT\" ios absolute | tail -n 1)\"\nfi\n\nif [[ -z \"$CLI_PATH\" ]]; then\n  # Use Expo CLI\n  export CLI_PATH=\"$(\"$NODE_BINARY\" --print \"require.resolve('@expo/cli', { paths: [require.resolve('expo/package.json')] })\")\"\nfi\nif [[ -z \"$BUNDLE_COMMAND\" ]]; then\n  # Default Expo CLI command for bundling\n  export BUNDLE_COMMAND=\"export:embed\"\nfi\n\n# Source .xcode.env.updates if it exists to allow\n# SKIP_BUNDLING to be unset if needed\nif [[ -f \"$PODS_ROOT/../.xcode.env.updates\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.updates\"\nfi\n# Source local changes to allow overrides\n# if needed\nif [[ -f \"$PODS_ROOT/../.xcode.env.local\" ]]; then\n  source \"$PODS_ROOT/../.xcode.env.local\"\nfi\n\n`\"$NODE_BINARY\" --print \"require('path').dirname(require.resolve('react-native/package.json')) + '/scripts/react-native-xcode.sh'\"`\n\n";
+		};
+		08A4A3CD28434E44B6B9DE2E /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-reactnativeexpo-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
+		0D1BB7C7A0BD4DBFB1D09419 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-reactnativeexpo/Pods-reactnativeexpo-frameworks.sh",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/ExpoFileSystem/ExpoFileSystem.framework/ExpoFileSystem",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/ExpoFont/ExpoFont.framework/ExpoFont",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/ExpoModulesCore/ExpoModulesCore.framework/ExpoModulesCore",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/ExpoModulesJSI/ExpoModulesJSI.framework/ExpoModulesJSI",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/ExpoModulesWorklets/ExpoModulesWorklets.framework/ExpoModulesWorklets",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/React-Core-prebuilt/React.framework/React",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/ReactNativeDependencies/ReactNativeDependencies.framework/ReactNativeDependencies",
+				"${PODS_XCFRAMEWORKS_BUILD_DIR}/hermes-engine/Pre-built/hermesvm.framework/hermesvm",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ExpoFileSystem.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ExpoFont.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ExpoModulesCore.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ExpoModulesJSI.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ExpoModulesWorklets.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/React.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/ReactNativeDependencies.framework",
+				"${TARGET_BUILD_DIR}/${FRAMEWORKS_FOLDER_PATH}/hermesvm.framework",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-reactnativeexpo/Pods-reactnativeexpo-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		6B1A097875E7C606058ADD2E /* [Expo] Configure project */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/.xcode.env",
+				"$(SRCROOT)/.xcode.env.local",
+				"$(SRCROOT)/reactnativeexpo/reactnativeexpo.entitlements",
+				"$(SRCROOT)/Pods/Target Support Files/Pods-reactnativeexpo/expo-configure-project.sh",
+			);
+			name = "[Expo] Configure project";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(SRCROOT)/Pods/Target Support Files/Pods-reactnativeexpo/ExpoModulesProvider.swift",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# This script configures Expo modules and generates the modules provider file.\nbash -l -c \"./Pods/Target\\ Support\\ Files/Pods-reactnativeexpo/expo-configure-project.sh\"\n";
+		};
+		800E24972A6A228C8D4807E9 /* [CP] Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-reactnativeexpo/Pods-reactnativeexpo-resources.sh",
+				"${PODS_CONFIGURATION_BUILD_DIR}/EXApplication/ExpoApplication_privacy.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/EXConstants.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/EXConstants/ExpoConstants_privacy.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/ExpoDevice/ExpoDevice_privacy.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/ExpoFileSystem/ExpoFileSystem_privacy.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/React-Core/React-Core_privacy.bundle",
+				"${PODS_CONFIGURATION_BUILD_DIR}/React-cxxreact/React-cxxreact_privacy.bundle",
+			);
+			name = "[CP] Copy Pods Resources";
+			outputPaths = (
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ExpoApplication_privacy.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/EXConstants.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ExpoConstants_privacy.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ExpoDevice_privacy.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/ExpoFileSystem_privacy.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/React-Core_privacy.bundle",
+				"${TARGET_BUILD_DIR}/${UNLOCALIZED_RESOURCES_FOLDER_PATH}/React-cxxreact_privacy.bundle",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-reactnativeexpo/Pods-reactnativeexpo-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		13B07F871A680F5B00A75B9A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F11748422D0307B40044C1D9 /* AppDelegate.swift in Sources */,
+				D6E25DCAEA15F1E0C4474149 /* ExpoModulesProvider.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		13B07F941A680F5B00A75B9A /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = DC01E954BF96DE887D9CFEA0 /* Pods-reactnativeexpo.debug.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = reactnativeexpo/reactnativeexpo.entitlements;
+				CURRENT_PROJECT_VERSION = 1;
+				ENABLE_BITCODE = NO;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"$(inherited)",
+					"FB_SONARKIT_ENABLED=1",
+				);
+				INFOPLIST_FILE = reactnativeexpo/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_DEBUG";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.anonymous.react-native-expo";
+				PRODUCT_NAME = reactnativeexpo;
+				SWIFT_OBJC_BRIDGING_HEADER = "reactnativeexpo/reactnativeexpo-Bridging-Header.h";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Debug;
+		};
+		13B07F951A680F5B00A75B9A /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = E29D8CEC4E4C540EC9F516B5 /* Pods-reactnativeexpo.release.xcconfig */;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = reactnativeexpo/reactnativeexpo.entitlements;
+				CURRENT_PROJECT_VERSION = 1;
+				INFOPLIST_FILE = reactnativeexpo/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MACOSX_DEPLOYMENT_TARGET = 13.4;
+				MARKETING_VERSION = 1.0;
+				OTHER_LDFLAGS = (
+					"$(inherited)",
+					"-ObjC",
+					"-lc++",
+				);
+				OTHER_SWIFT_FLAGS = "$(inherited) -D EXPO_CONFIGURATION_RELEASE";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.anonymous.react-native-expo";
+				PRODUCT_NAME = reactnativeexpo;
+				SWIFT_OBJC_BRIDGING_HEADER = "reactnativeexpo/reactnativeexpo-Bridging-Header.h";
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+			};
+			name = Release;
+		};
+		83CBBA201A601CBA00E9B192 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "$(SDKROOT)/usr/lib/swift\"$(inherited)\"";
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-DRCT_REMOVE_LEGACY_ARCH=1",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"$(inherited)",
+					"-DRCT_REMOVE_LEGACY_ARCH=1",
+				);
+				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) DEBUG";
+				SWIFT_ENABLE_EXPLICIT_MODULES = NO;
+				USE_HERMES = true;
+			};
+			name = Debug;
+		};
+		83CBBA211A601CBA00E9B192 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
+				CLANG_CXX_LANGUAGE_STANDARD = "c++20";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.4;
+				LD_RUNPATH_SEARCH_PATHS = (
+					/usr/lib/swift,
+					"$(inherited)",
+				);
+				LIBRARY_SEARCH_PATHS = "$(SDKROOT)/usr/lib/swift\"$(inherited)\"";
+				MTL_ENABLE_DEBUG_INFO = NO;
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-DRCT_REMOVE_LEGACY_ARCH=1",
+				);
+				OTHER_CPLUSPLUSFLAGS = (
+					"$(inherited)",
+					"-DRCT_REMOVE_LEGACY_ARCH=1",
+				);
+				REACT_NATIVE_PATH = "${PODS_ROOT}/../../node_modules/react-native";
+				SDKROOT = iphoneos;
+				SWIFT_ENABLE_EXPLICIT_MODULES = NO;
+				USE_HERMES = true;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		13B07F931A680F5B00A75B9A /* Build configuration list for PBXNativeTarget "reactnativeexpo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				13B07F941A680F5B00A75B9A /* Debug */,
+				13B07F951A680F5B00A75B9A /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		83CBB9FA1A601CBA00E9B192 /* Build configuration list for PBXProject "reactnativeexpo" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				83CBBA201A601CBA00E9B192 /* Debug */,
+				83CBBA211A601CBA00E9B192 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 83CBB9F71A601CBA00E9B192 /* Project object */;
+}

--- a/packages/react-native-sourcemaps/tests/runtime.test.ts
+++ b/packages/react-native-sourcemaps/tests/runtime.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, test } from 'vitest';
+
+import { flareSourcemapVersion } from '../src/runtime';
+
+describe('flareSourcemapVersion', () => {
+    test('defaults to an empty string when the Babel plugin has not inlined it', () => {
+        // Without the Babel transform the source value is the empty-string default,
+        // which is harmless: sourcemaps are only uploaded for release builds.
+        expect(flareSourcemapVersion).toBe('');
+    });
+});

--- a/packages/react-native-sourcemaps/tests/uploadSourcemaps.test.ts
+++ b/packages/react-native-sourcemaps/tests/uploadSourcemaps.test.ts
@@ -1,0 +1,64 @@
+import { readFileSync } from 'node:fs';
+
+import { FlareApi } from '@flareapp/flare-api';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import { uploadSourcemaps } from '../src/uploadSourcemaps';
+
+vi.mock('@flareapp/flare-api');
+vi.mock('node:fs', () => ({ readFileSync: vi.fn() }));
+
+afterEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+});
+
+describe('uploadSourcemaps', () => {
+    test('uploads the map under the resolved version and default bundle filename', async () => {
+        vi.spyOn(console, 'log').mockImplementation(() => {});
+        vi.mocked(readFileSync).mockReturnValue('MAP_CONTENT');
+        const uploadSourcemap = vi.fn().mockResolvedValue(undefined);
+        vi.mocked(FlareApi).mockImplementation(function () {
+            return { uploadSourcemap } as unknown as FlareApi;
+        });
+
+        await uploadSourcemaps({
+            apiKey: 'key',
+            sourcemap: '/build/index.android.bundle.map',
+            version: 'v1',
+        });
+
+        expect(FlareApi).toHaveBeenCalledWith('https://flareapp.io/api/sourcemaps', 'key', 'v1');
+        expect(uploadSourcemap).toHaveBeenCalledWith({
+            originalFile: 'index.android.bundle',
+            content: 'MAP_CONTENT',
+        });
+    });
+
+    test('honours an explicit bundle filename and api endpoint', async () => {
+        vi.spyOn(console, 'log').mockImplementation(() => {});
+        vi.mocked(readFileSync).mockReturnValue('MAP');
+        const uploadSourcemap = vi.fn().mockResolvedValue(undefined);
+        vi.mocked(FlareApi).mockImplementation(function () {
+            return { uploadSourcemap } as unknown as FlareApi;
+        });
+
+        await uploadSourcemaps({
+            apiKey: 'key',
+            sourcemap: '/build/x.map',
+            bundleFilename: 'main.jsbundle',
+            apiEndpoint: 'https://example.test/api/sourcemaps',
+            version: 'v2',
+        });
+
+        expect(FlareApi).toHaveBeenCalledWith('https://example.test/api/sourcemaps', 'key', 'v2');
+        expect(uploadSourcemap).toHaveBeenCalledWith({ originalFile: 'main.jsbundle', content: 'MAP' });
+    });
+
+    test('warns and no-ops without an api key', async () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        await uploadSourcemaps({ apiKey: '', sourcemap: '/build/x.map' });
+        expect(FlareApi).not.toHaveBeenCalled();
+        expect(warn).toHaveBeenCalledTimes(1);
+    });
+});

--- a/packages/react-native-sourcemaps/tests/version.test.ts
+++ b/packages/react-native-sourcemaps/tests/version.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from 'node:fs';
+
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import { resolveVersion } from '../src/version';
+
+vi.mock('node:fs', () => ({ readFileSync: vi.fn() }));
+
+afterEach(() => {
+    vi.clearAllMocks();
+    vi.restoreAllMocks();
+    delete process.env.FLARE_SOURCEMAP_VERSION;
+});
+
+describe('resolveVersion', () => {
+    test('prefers an explicit version over the env var', () => {
+        process.env.FLARE_SOURCEMAP_VERSION = 'from-env';
+        expect(resolveVersion({ version: 'from-flag' })).toBe('from-flag');
+    });
+
+    test('uses FLARE_SOURCEMAP_VERSION when no explicit version is given', () => {
+        process.env.FLARE_SOURCEMAP_VERSION = 'from-env';
+        expect(resolveVersion()).toBe('from-env');
+    });
+
+    test('falls back to package.json version with a warning', () => {
+        const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+        vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ version: '9.9.9' }));
+        expect(resolveVersion({ cwd: '/proj' })).toBe('9.9.9');
+        expect(warn).toHaveBeenCalledTimes(1);
+    });
+
+    test('throws when no version can be resolved', () => {
+        vi.mocked(readFileSync).mockImplementation(() => {
+            throw new Error('ENOENT');
+        });
+        expect(() => resolveVersion({ cwd: '/proj' })).toThrow(/Could not resolve a sourcemap version/);
+    });
+});

--- a/packages/react-native-sourcemaps/tests/version.test.ts
+++ b/packages/react-native-sourcemaps/tests/version.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'node:fs';
 
 import { afterEach, describe, expect, test, vi } from 'vitest';
 
-import { resolveVersion } from '../src/version';
+import { resolveAutoVersion, resolveVersion } from '../src/version';
 
 vi.mock('node:fs', () => ({ readFileSync: vi.fn() }));
 
@@ -35,5 +35,29 @@ describe('resolveVersion', () => {
             throw new Error('ENOENT');
         });
         expect(() => resolveVersion({ cwd: '/proj' })).toThrow(/Could not resolve a sourcemap version/);
+    });
+});
+
+describe('resolveAutoVersion', () => {
+    test('prefers an explicit version', () => {
+        process.env.FLARE_SOURCEMAP_VERSION = 'from-env';
+        expect(resolveAutoVersion('from-flag')).toBe('from-flag');
+    });
+
+    test('uses FLARE_SOURCEMAP_VERSION when no explicit version is given', () => {
+        process.env.FLARE_SOURCEMAP_VERSION = 'from-env';
+        expect(resolveAutoVersion()).toBe('from-env');
+    });
+
+    test('returns null when nothing is set — never falls back to package.json', () => {
+        delete process.env.FLARE_SOURCEMAP_VERSION;
+        vi.mocked(readFileSync).mockReturnValue(JSON.stringify({ version: '9.9.9' }));
+        expect(resolveAutoVersion()).toBeNull();
+        expect(readFileSync).not.toHaveBeenCalled();
+    });
+
+    test('treats an empty env var as unresolved', () => {
+        process.env.FLARE_SOURCEMAP_VERSION = '';
+        expect(resolveAutoVersion()).toBeNull();
     });
 });

--- a/packages/react-native-sourcemaps/tsconfig.json
+++ b/packages/react-native-sourcemaps/tsconfig.json
@@ -1,0 +1,4 @@
+{
+    "extends": "../../tsconfig.json",
+    "include": ["src"]
+}

--- a/packages/react-native-sourcemaps/tsdown.config.ts
+++ b/packages/react-native-sourcemaps/tsdown.config.ts
@@ -1,0 +1,16 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+    entry: ['src/index.ts', 'src/babel.ts', 'src/bin.ts', 'src/runtime.ts'],
+    format: ['cjs', 'esm'],
+    dts: true,
+    clean: true,
+    // `@flareapp/flare-api` is private and unpublished, so bundle it into the
+    // output instead of leaving it as an external runtime import.
+    noExternal: ['@flareapp/flare-api'],
+    // tsdown warns when it bundles dependencies (here: `@flareapp/flare-api` into
+    // the output, and `@babel/types` declarations into `babel.d.ts`) and, with the
+    // default `failOnWarn: "ci-only"`, that warning is fatal under CI. Both are
+    // intentional, so disable the check.
+    inlineOnly: false,
+});

--- a/packages/react-native-sourcemaps/tsdown.config.ts
+++ b/packages/react-native-sourcemaps/tsdown.config.ts
@@ -1,16 +1,29 @@
 import { defineConfig } from 'tsdown';
 
-export default defineConfig({
-    entry: ['src/index.ts', 'src/babel.ts', 'src/bin.ts', 'src/runtime.ts'],
-    format: ['cjs', 'esm'],
-    dts: true,
-    clean: true,
-    // `@flareapp/flare-api` is private and unpublished, so bundle it into the
-    // output instead of leaving it as an external runtime import.
-    noExternal: ['@flareapp/flare-api'],
-    // tsdown warns when it bundles dependencies (here: `@flareapp/flare-api` into
-    // the output, and `@babel/types` declarations into `babel.d.ts`) and, with the
-    // default `failOnWarn: "ci-only"`, that warning is fatal under CI. Both are
-    // intentional, so disable the check.
-    inlineOnly: false,
-});
+export default defineConfig([
+    {
+        entry: ['src/index.ts', 'src/babel.ts', 'src/bin.ts', 'src/runtime.ts'],
+        format: ['cjs', 'esm'],
+        dts: true,
+        clean: true,
+        // `@flareapp/flare-api` is private and unpublished, so bundle it into the
+        // output instead of leaving it as an external runtime import.
+        noExternal: ['@flareapp/flare-api'],
+        // tsdown warns when it bundles dependencies (here: `@flareapp/flare-api` into
+        // the output, and `@babel/types` declarations into `babel.d.ts`) and, with the
+        // default `failOnWarn: "ci-only"`, that warning is fatal under CI. Both are
+        // intentional, so disable the check.
+        inlineOnly: false,
+    },
+    {
+        // The Expo config plugin is loaded by the Expo CLI via require() at prebuild;
+        // Metro never bundles it. Emit CJS only — an ESM build would carry bare
+        // `require`/`require.resolve` (undefined in ESM) and throw.
+        entry: ['src/expo.ts'],
+        format: ['cjs'],
+        dts: true,
+        clean: false,
+        noExternal: ['@flareapp/flare-api'],
+        inlineOnly: false,
+    },
+]);

--- a/packages/react-native-sourcemaps/vitest.config.ts
+++ b/packages/react-native-sourcemaps/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    test: {
+        globals: false,
+    },
+});

--- a/playgrounds/react-native-bare/.gitignore
+++ b/playgrounds/react-native-bare/.gitignore
@@ -76,3 +76,6 @@ yarn-error.log
 
 # Flare smoke-test config (contains your project key)
 flare.config.ts
+
+# Flare sourcemap verification artifact
+*.jsbundle.map

--- a/playgrounds/react-native-bare/App.tsx
+++ b/playgrounds/react-native-bare/App.tsx
@@ -1,4 +1,5 @@
 import { flare, FlareErrorBoundary } from '@flareapp/react-native';
+import { flareSourcemapVersion } from '@flareapp/react-native-sourcemaps/runtime';
 import React, { useState } from 'react';
 import { Pressable, SafeAreaView, ScrollView, StyleSheet, Text, View } from 'react-native';
 
@@ -6,7 +7,14 @@ import { config, isConfigured } from './flare.config';
 
 // Boot once at module load. Skipped until a real key is set.
 if (isConfigured) {
-    flare.configure({ ingestUrl: config.ingestUrl, stage: 'smoke' });
+    flare.configure({
+        ingestUrl: config.ingestUrl,
+        stage: 'smoke',
+        // The babel plugin (@flareapp/react-native-sourcemaps/babel) replaces
+        // flareSourcemapVersion with the build's FLARE_SOURCEMAP_VERSION literal, so
+        // reports carry a sourcemapVersionId the backend matches against the upload.
+        sourcemapVersionId: flareSourcemapVersion,
+    });
     flare.light(config.key);
 }
 

--- a/playgrounds/react-native-bare/babel.config.js
+++ b/playgrounds/react-native-bare/babel.config.js
@@ -1,3 +1,8 @@
 module.exports = {
     presets: ['module:@react-native/babel-preset'],
+    // Inlines `process.env.FLARE_SOURCEMAP_VERSION` at bundle time so the running
+    // app reports a `sourcemapVersionId` that matches the uploaded sourcemap's
+    // version. The version comes from the FLARE_SOURCEMAP_VERSION env var set on
+    // the build (falls back to package.json version with a warning).
+    plugins: ['@flareapp/react-native-sourcemaps/babel'],
 };

--- a/playgrounds/react-native-bare/ios/Podfile.lock
+++ b/playgrounds/react-native-bare/ios/Podfile.lock
@@ -2130,7 +2130,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   FBLazyVector: b3e7ad108f0d882e30445c5527d774e3fd432f3d
-  hermes-engine: ddab712edf425acb247bac2853e1a2df9a8b73d4
+  hermes-engine: 4f33c0a501693c306268a9402a8d67ba27b32d34
   RCTDeprecation: 2a74a2c57675e64419bd89078efde81f7c1de90b
   RCTRequired: 30451112e6fef4e6f31b4e7eee0845156e35e4b0
   RCTSwiftUI: 5aaf0b07e747ba749dc6acc94d8bd41eea4b570f

--- a/playgrounds/react-native-bare/metro.config.js
+++ b/playgrounds/react-native-bare/metro.config.js
@@ -1,19 +1,50 @@
+const path = require('path');
 const { getDefaultConfig, mergeConfig } = require('@react-native/metro-config');
 
-/**
- * Metro configuration
- * https://reactnative.dev/docs/metro
- *
- * @type {import('@react-native/metro-config').MetroConfig}
- */
+// This bare app lives inside the flare-client-js monorepo and is NOT an npm
+// workspace member. It consumes the workspace packages (@flareapp/react-native
+// and its @flareapp/core / @flareapp/react deps) through the ROOT node_modules
+// symlinks, which point OUTSIDE this project directory. Node and Babel resolve
+// those already, but Metro only bundles files inside a watched folder and only
+// searches the resolver paths it is given. So we watch the monorepo root and add
+// the root node_modules to the resolver, otherwise Metro fails with
+// "Unable to resolve module @flareapp/react-native".
+const projectRoot = __dirname;
+const monorepoRoot = path.resolve(projectRoot, '../..');
+const appNodeModules = path.resolve(projectRoot, 'node_modules');
+
+// The monorepo root has its OWN react-native (0.79, a dev/peer dep of
+// packages/react-native) and react. Without pinning, Metro resolves the
+// react-native/react imports INSIDE the symlinked @flareapp/* packages to those
+// root copies, so the bundle ends up with two react-native versions and the
+// native binary crashes with "TurboModuleRegistry... 'DeviceInfo' could not be
+// found". Force these singleton, native-coupled packages to the app's one copy.
+const forceAppCopy = ['react', 'react-native'];
+
 const config = {
+    watchFolders: [monorepoRoot],
     resolver: {
         // Required: @flareapp/react-native imports @flareapp/react/inject, a
-        // subpath that resolves ONLY through @flareapp/react's exports map. The
-        // bare RN template defaults this off, so without it Metro cannot resolve
-        // the subpath. Expo enables it by default; this is the bare-only opt-in.
+        // subpath that resolves ONLY through @flareapp/react's exports map, and the
+        // package itself resolves via a "react-native" export condition. The bare RN
+        // template defaults this off, so without it Metro cannot resolve the subpath.
+        // Expo enables it by default; this is the bare-only opt-in.
         unstable_enablePackageExports: true,
+        nodeModulesPaths: [appNodeModules, path.resolve(monorepoRoot, 'node_modules')],
+        resolveRequest: (context, moduleName, platform) => {
+            const pinned = forceAppCopy.some((name) => moduleName === name || moduleName.startsWith(`${name}/`));
+            if (pinned) {
+                // Re-root resolution at the app so node_modules walking finds the
+                // app's single copy, regardless of which package did the import.
+                return context.resolveRequest(
+                    { ...context, originModulePath: path.join(projectRoot, 'index.js') },
+                    moduleName,
+                    platform,
+                );
+            }
+            return context.resolveRequest(context, moduleName, platform);
+        },
     },
 };
 
-module.exports = mergeConfig(getDefaultConfig(__dirname), config);
+module.exports = mergeConfig(getDefaultConfig(projectRoot), config);

--- a/playgrounds/react-native-bare/package-lock.json
+++ b/playgrounds/react-native-bare/package-lock.json
@@ -8,6 +8,7 @@
             "name": "RnBareSmoke",
             "version": "0.0.1",
             "dependencies": {
+                "@flareapp/react-native-sourcemaps": "file:../../packages/react-native-sourcemaps",
                 "@react-native/new-app-screen": "0.86.0",
                 "react": "19.2.3",
                 "react-native": "0.86.0",
@@ -35,6 +36,33 @@
             },
             "engines": {
                 "node": ">= 22.11.0"
+            }
+        },
+        "../../packages/react-native-sourcemaps": {
+            "name": "@flareapp/react-native-sourcemaps",
+            "version": "0.1.0",
+            "license": "MIT",
+            "bin": {
+                "flare-rn-sourcemaps": "dist/bin.cjs"
+            },
+            "devDependencies": {
+                "@babel/core": "^7.0.0",
+                "@flareapp/flare-api": "*",
+                "@types/babel__core": "^7.0.0",
+                "tsdown": "^0.20.3",
+                "typescript": "^5.7.0",
+                "vitest": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@babel/core": ">=7.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@babel/core": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@babel/code-frame": {
@@ -2128,6 +2156,10 @@
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
+        },
+        "node_modules/@flareapp/react-native-sourcemaps": {
+            "resolved": "../../packages/react-native-sourcemaps",
+            "link": true
         },
         "node_modules/@hapi/hoek": {
             "version": "9.3.0",

--- a/playgrounds/react-native-bare/package.json
+++ b/playgrounds/react-native-bare/package.json
@@ -13,7 +13,8 @@
         "react": "19.2.3",
         "react-native": "0.86.0",
         "@react-native/new-app-screen": "0.86.0",
-        "react-native-safe-area-context": "^5.5.2"
+        "react-native-safe-area-context": "^5.5.2",
+        "@flareapp/react-native-sourcemaps": "file:../../packages/react-native-sourcemaps"
     },
     "devDependencies": {
         "@babel/core": "^7.25.2",

--- a/playgrounds/react-native-expo/.gitignore
+++ b/playgrounds/react-native-expo/.gitignore
@@ -42,3 +42,6 @@ yarn-error.*
 
 # Flare smoke-test config (contains your project key)
 flare.config.ts
+
+# Flare sourcemap verification artifact
+*.jsbundle.map

--- a/playgrounds/react-native-expo/.gitignore
+++ b/playgrounds/react-native-expo/.gitignore
@@ -45,3 +45,4 @@ flare.config.ts
 
 # Flare sourcemap verification artifact
 *.jsbundle.map
+flare.json

--- a/playgrounds/react-native-expo/App.tsx
+++ b/playgrounds/react-native-expo/App.tsx
@@ -1,4 +1,5 @@
 import { flare, FlareErrorBoundary } from '@flareapp/react-native';
+import { flareSourcemapVersion } from '@flareapp/react-native-sourcemaps/runtime';
 import React, { useState } from 'react';
 import { Pressable, SafeAreaView, ScrollView, StyleSheet, Text, View } from 'react-native';
 
@@ -6,7 +7,13 @@ import { config, isConfigured } from './flare.config';
 
 // Boot once at module load. Skipped until a real key is set.
 if (isConfigured) {
-    flare.configure({ ingestUrl: config.ingestUrl, stage: 'smoke' });
+    flare.configure({
+        ingestUrl: config.ingestUrl,
+        stage: 'smoke',
+        // Babel replaces flareSourcemapVersion with the build's version literal so
+        // reports carry a sourcemapVersionId the backend matches against the upload.
+        sourcemapVersionId: flareSourcemapVersion,
+    });
     flare.light(config.key);
 }
 

--- a/playgrounds/react-native-expo/app.json
+++ b/playgrounds/react-native-expo/app.json
@@ -6,6 +6,7 @@
         "orientation": "portrait",
         "icon": "./assets/icon.png",
         "userInterfaceStyle": "light",
+        "plugins": ["@flareapp/react-native-sourcemaps/expo"],
         "ios": {
             "supportsTablet": true,
             "bundleIdentifier": "com.anonymous.react-native-expo"
@@ -17,7 +18,8 @@
                 "backgroundImage": "./assets/android-icon-background.png",
                 "monochromeImage": "./assets/android-icon-monochrome.png"
             },
-            "predictiveBackGestureEnabled": false
+            "predictiveBackGestureEnabled": false,
+            "package": "com.anonymous.reactnativeexpo"
         },
         "web": {
             "favicon": "./assets/favicon.png"

--- a/playgrounds/react-native-expo/app.json
+++ b/playgrounds/react-native-expo/app.json
@@ -7,7 +7,8 @@
         "icon": "./assets/icon.png",
         "userInterfaceStyle": "light",
         "ios": {
-            "supportsTablet": true
+            "supportsTablet": true,
+            "bundleIdentifier": "com.anonymous.react-native-expo"
         },
         "android": {
             "adaptiveIcon": {

--- a/playgrounds/react-native-expo/babel.config.js
+++ b/playgrounds/react-native-expo/babel.config.js
@@ -1,0 +1,10 @@
+module.exports = function (api) {
+    api.cache(true);
+    return {
+        presets: ['babel-preset-expo'],
+        // Inlines `flareSourcemapVersion` (imported from
+        // @flareapp/react-native-sourcemaps/runtime) at bundle time so production
+        // reports carry a sourcemapVersionId matching the uploaded sourcemap.
+        plugins: ['@flareapp/react-native-sourcemaps/babel'],
+    };
+};

--- a/playgrounds/react-native-expo/metro.config.js
+++ b/playgrounds/react-native-expo/metro.config.js
@@ -1,0 +1,31 @@
+const path = require('path');
+const { getDefaultConfig } = require('expo/metro-config');
+
+// Managed Expo app inside the flare-client-js monorepo. The @flareapp/* packages are
+// file: deps symlinked into this app's node_modules and point at ../../packages/*,
+// so watch the monorepo root (Metro must be allowed to read those files) and pin
+// react/react-native to the app's single copy (root has RN 0.79 vs this app's 0.85;
+// without pinning the bundle carries two versions and crashes with
+// "TurboModuleRegistry... 'DeviceInfo' could not be found").
+const projectRoot = __dirname;
+const monorepoRoot = path.resolve(projectRoot, '../..');
+const forceAppCopy = ['react', 'react-native'];
+
+const config = getDefaultConfig(projectRoot);
+
+config.watchFolders = [monorepoRoot];
+config.resolver.unstable_enablePackageExports = true;
+config.resolver.nodeModulesPaths = [path.join(projectRoot, 'node_modules'), path.join(monorepoRoot, 'node_modules')];
+
+config.resolver.resolveRequest = (context, moduleName, platform) => {
+    if (forceAppCopy.some((name) => moduleName === name || moduleName.startsWith(`${name}/`))) {
+        return context.resolveRequest(
+            { ...context, originModulePath: path.join(projectRoot, 'index.ts') },
+            moduleName,
+            platform,
+        );
+    }
+    return context.resolveRequest(context, moduleName, platform);
+};
+
+module.exports = config;

--- a/playgrounds/react-native-expo/package-lock.json
+++ b/playgrounds/react-native-expo/package-lock.json
@@ -8,6 +8,9 @@
             "name": "react-native-expo",
             "version": "1.0.0",
             "dependencies": {
+                "@flareapp/core": "file:../../packages/core",
+                "@flareapp/react": "file:../../packages/react",
+                "@flareapp/react-native": "file:../../packages/react-native",
                 "expo": "~56.0.12",
                 "expo-application": "~56.0.3",
                 "expo-device": "~56.0.4",
@@ -16,8 +19,101 @@
                 "react-native": "0.85.3"
             },
             "devDependencies": {
+                "@flareapp/react-native-sourcemaps": "file:../../packages/react-native-sourcemaps",
                 "@types/react": "~19.2.2",
+                "babel-preset-expo": "~56.0.15",
                 "typescript": "~6.0.3"
+            }
+        },
+        "../../packages/core": {
+            "name": "@flareapp/core",
+            "version": "2.5.0",
+            "license": "MIT",
+            "dependencies": {
+                "error-stack-parser": "^2.0.2"
+            },
+            "devDependencies": {
+                "jsdom": "^26.1.0",
+                "tsdown": "^0.20.3",
+                "typescript": "^5.7.0",
+                "vitest": "^4.0.18"
+            }
+        },
+        "../../packages/react": {
+            "name": "@flareapp/react",
+            "version": "2.5.0",
+            "license": "MIT",
+            "dependencies": {
+                "@flareapp/core": "2.5.0"
+            },
+            "devDependencies": {
+                "@flareapp/electron": "file:../electron",
+                "@flareapp/js": "file:../js",
+                "@testing-library/jest-dom": "^6.9.1",
+                "@testing-library/react": "^16.0.0",
+                "@types/react": "^19.0.0",
+                "@types/react-dom": "^19.0.0",
+                "jsdom": "^26.1.0",
+                "react": "^19.0.0",
+                "react-dom": "^19.0.0",
+                "tsdown": "^0.20.3",
+                "typescript": "^5.7.0",
+                "vitest": "^4.0.0"
+            },
+            "peerDependencies": {
+                "@flareapp/js": "^2.5.0",
+                "react": "^16.0.0||^17.0.0||^18.0.0||^19.0.0"
+            }
+        },
+        "../../packages/react-native": {
+            "name": "@flareapp/react-native",
+            "version": "0.1.0",
+            "license": "MIT",
+            "dependencies": {
+                "@flareapp/core": "2.5.0"
+            },
+            "devDependencies": {
+                "@flareapp/js": "file:../js",
+                "@flareapp/react": "file:../react",
+                "@types/react": "^19.0.0",
+                "react": "^19.0.0",
+                "react-native": "^0.79.0",
+                "tsdown": "^0.20.3",
+                "typescript": "^5.7.0",
+                "vitest": "^4.0.18"
+            },
+            "peerDependencies": {
+                "@flareapp/react": "^2.5.0",
+                "react": "^18.0.0||^19.0.0",
+                "react-native": ">=0.79.0"
+            }
+        },
+        "../../packages/react-native-sourcemaps": {
+            "name": "@flareapp/react-native-sourcemaps",
+            "version": "0.1.0",
+            "dev": true,
+            "license": "MIT",
+            "bin": {
+                "flare-rn-sourcemaps": "dist/bin.cjs"
+            },
+            "devDependencies": {
+                "@babel/core": "^7.0.0",
+                "@flareapp/flare-api": "*",
+                "@types/babel__core": "^7.0.0",
+                "tsdown": "^0.20.3",
+                "typescript": "^5.7.0",
+                "vitest": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "peerDependencies": {
+                "@babel/core": ">=7.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@babel/core": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@babel/code-frame": {
@@ -1399,6 +1495,22 @@
                 "excpretty": "build/cli.js"
             }
         },
+        "node_modules/@flareapp/core": {
+            "resolved": "../../packages/core",
+            "link": true
+        },
+        "node_modules/@flareapp/react": {
+            "resolved": "../../packages/react",
+            "link": true
+        },
+        "node_modules/@flareapp/react-native": {
+            "resolved": "../../packages/react-native",
+            "link": true
+        },
+        "node_modules/@flareapp/react-native-sourcemaps": {
+            "resolved": "../../packages/react-native-sourcemaps",
+            "link": true
+        },
         "node_modules/@isaacs/ttlcache": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/@isaacs/ttlcache/-/ttlcache-1.4.1.tgz",
@@ -1967,6 +2079,73 @@
             "license": "MIT",
             "dependencies": {
                 "@babel/plugin-syntax-flow": "^7.12.1"
+            }
+        },
+        "node_modules/babel-preset-expo": {
+            "version": "56.0.15",
+            "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-56.0.15.tgz",
+            "integrity": "sha512-0MqbQoM6nBUbKvgu2xJ4VixZnUTGTq3HB2WwvOikdO4CiPxbQ+wGA25fOoHHSni5iEFW39wy6y1ookTWlq3wVw==",
+            "license": "MIT",
+            "dependencies": {
+                "@babel/generator": "^7.20.5",
+                "@babel/helper-module-imports": "^7.25.9",
+                "@babel/plugin-proposal-decorators": "^7.12.9",
+                "@babel/plugin-proposal-export-default-from": "^7.24.7",
+                "@babel/plugin-syntax-dynamic-import": "^7.8.3",
+                "@babel/plugin-syntax-export-default-from": "^7.24.7",
+                "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
+                "@babel/plugin-syntax-optional-chaining": "^7.8.3",
+                "@babel/plugin-transform-async-generator-functions": "^7.25.4",
+                "@babel/plugin-transform-async-to-generator": "^7.24.7",
+                "@babel/plugin-transform-block-scoping": "^7.25.0",
+                "@babel/plugin-transform-class-properties": "^7.25.4",
+                "@babel/plugin-transform-class-static-block": "^7.27.1",
+                "@babel/plugin-transform-classes": "^7.25.4",
+                "@babel/plugin-transform-destructuring": "^7.24.8",
+                "@babel/plugin-transform-export-namespace-from": "^7.25.9",
+                "@babel/plugin-transform-flow-strip-types": "^7.25.2",
+                "@babel/plugin-transform-for-of": "^7.24.7",
+                "@babel/plugin-transform-logical-assignment-operators": "^7.24.7",
+                "@babel/plugin-transform-modules-commonjs": "^7.24.8",
+                "@babel/plugin-transform-named-capturing-groups-regex": "^7.24.7",
+                "@babel/plugin-transform-nullish-coalescing-operator": "^7.24.7",
+                "@babel/plugin-transform-object-rest-spread": "^7.24.7",
+                "@babel/plugin-transform-optional-catch-binding": "^7.24.7",
+                "@babel/plugin-transform-optional-chaining": "^7.24.8",
+                "@babel/plugin-transform-parameters": "^7.24.7",
+                "@babel/plugin-transform-private-methods": "^7.24.7",
+                "@babel/plugin-transform-private-property-in-object": "^7.24.7",
+                "@babel/plugin-transform-react-display-name": "^7.24.7",
+                "@babel/plugin-transform-react-jsx": "^7.28.6",
+                "@babel/plugin-transform-react-jsx-development": "^7.27.1",
+                "@babel/plugin-transform-react-pure-annotations": "^7.27.1",
+                "@babel/plugin-transform-runtime": "^7.24.7",
+                "@babel/plugin-transform-typescript": "^7.25.2",
+                "@babel/plugin-transform-unicode-regex": "^7.24.7",
+                "@babel/preset-typescript": "^7.23.0",
+                "@react-native/babel-plugin-codegen": "0.85.3",
+                "babel-plugin-react-compiler": "^1.0.0",
+                "babel-plugin-react-native-web": "~0.21.0",
+                "babel-plugin-syntax-hermes-parser": "^0.33.3",
+                "babel-plugin-transform-flow-enums": "^0.0.2",
+                "debug": "^4.3.4"
+            },
+            "peerDependencies": {
+                "@babel/runtime": "^7.20.0",
+                "expo": "*",
+                "expo-widgets": "^56.0.18",
+                "react-refresh": ">=0.14.0 <1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@babel/runtime": {
+                    "optional": true
+                },
+                "expo": {
+                    "optional": true
+                },
+                "expo-widgets": {
+                    "optional": true
+                }
             }
         },
         "node_modules/balanced-match": {
@@ -2916,73 +3095,6 @@
             },
             "engines": {
                 "node": ">= 0.6"
-            }
-        },
-        "node_modules/expo/node_modules/babel-preset-expo": {
-            "version": "56.0.15",
-            "resolved": "https://registry.npmjs.org/babel-preset-expo/-/babel-preset-expo-56.0.15.tgz",
-            "integrity": "sha512-0MqbQoM6nBUbKvgu2xJ4VixZnUTGTq3HB2WwvOikdO4CiPxbQ+wGA25fOoHHSni5iEFW39wy6y1ookTWlq3wVw==",
-            "license": "MIT",
-            "dependencies": {
-                "@babel/generator": "^7.20.5",
-                "@babel/helper-module-imports": "^7.25.9",
-                "@babel/plugin-proposal-decorators": "^7.12.9",
-                "@babel/plugin-proposal-export-default-from": "^7.24.7",
-                "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-                "@babel/plugin-syntax-export-default-from": "^7.24.7",
-                "@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
-                "@babel/plugin-syntax-optional-chaining": "^7.8.3",
-                "@babel/plugin-transform-async-generator-functions": "^7.25.4",
-                "@babel/plugin-transform-async-to-generator": "^7.24.7",
-                "@babel/plugin-transform-block-scoping": "^7.25.0",
-                "@babel/plugin-transform-class-properties": "^7.25.4",
-                "@babel/plugin-transform-class-static-block": "^7.27.1",
-                "@babel/plugin-transform-classes": "^7.25.4",
-                "@babel/plugin-transform-destructuring": "^7.24.8",
-                "@babel/plugin-transform-export-namespace-from": "^7.25.9",
-                "@babel/plugin-transform-flow-strip-types": "^7.25.2",
-                "@babel/plugin-transform-for-of": "^7.24.7",
-                "@babel/plugin-transform-logical-assignment-operators": "^7.24.7",
-                "@babel/plugin-transform-modules-commonjs": "^7.24.8",
-                "@babel/plugin-transform-named-capturing-groups-regex": "^7.24.7",
-                "@babel/plugin-transform-nullish-coalescing-operator": "^7.24.7",
-                "@babel/plugin-transform-object-rest-spread": "^7.24.7",
-                "@babel/plugin-transform-optional-catch-binding": "^7.24.7",
-                "@babel/plugin-transform-optional-chaining": "^7.24.8",
-                "@babel/plugin-transform-parameters": "^7.24.7",
-                "@babel/plugin-transform-private-methods": "^7.24.7",
-                "@babel/plugin-transform-private-property-in-object": "^7.24.7",
-                "@babel/plugin-transform-react-display-name": "^7.24.7",
-                "@babel/plugin-transform-react-jsx": "^7.28.6",
-                "@babel/plugin-transform-react-jsx-development": "^7.27.1",
-                "@babel/plugin-transform-react-pure-annotations": "^7.27.1",
-                "@babel/plugin-transform-runtime": "^7.24.7",
-                "@babel/plugin-transform-typescript": "^7.25.2",
-                "@babel/plugin-transform-unicode-regex": "^7.24.7",
-                "@babel/preset-typescript": "^7.23.0",
-                "@react-native/babel-plugin-codegen": "0.85.3",
-                "babel-plugin-react-compiler": "^1.0.0",
-                "babel-plugin-react-native-web": "~0.21.0",
-                "babel-plugin-syntax-hermes-parser": "^0.33.3",
-                "babel-plugin-transform-flow-enums": "^0.0.2",
-                "debug": "^4.3.4"
-            },
-            "peerDependencies": {
-                "@babel/runtime": "^7.20.0",
-                "expo": "*",
-                "expo-widgets": "^56.0.18",
-                "react-refresh": ">=0.14.0 <1.0.0"
-            },
-            "peerDependenciesMeta": {
-                "@babel/runtime": {
-                    "optional": true
-                },
-                "expo": {
-                    "optional": true
-                },
-                "expo-widgets": {
-                    "optional": true
-                }
             }
         },
         "node_modules/expo/node_modules/ci-info": {

--- a/playgrounds/react-native-expo/package-lock.json
+++ b/playgrounds/react-native-expo/package-lock.json
@@ -98,20 +98,26 @@
             },
             "devDependencies": {
                 "@babel/core": "^7.0.0",
+                "@expo/config-plugins": "^56.0.9",
                 "@flareapp/flare-api": "*",
                 "@types/babel__core": "^7.0.0",
                 "tsdown": "^0.20.3",
                 "typescript": "^5.7.0",
-                "vitest": "^4.0.0"
+                "vitest": "^4.0.0",
+                "xcode": "^3.0.1"
             },
             "engines": {
                 "node": ">=18"
             },
             "peerDependencies": {
-                "@babel/core": ">=7.0.0"
+                "@babel/core": ">=7.0.0",
+                "@expo/config-plugins": ">=7.0.0"
             },
             "peerDependenciesMeta": {
                 "@babel/core": {
+                    "optional": true
+                },
+                "@expo/config-plugins": {
                     "optional": true
                 }
             }

--- a/playgrounds/react-native-expo/package.json
+++ b/playgrounds/react-native-expo/package.json
@@ -3,6 +3,9 @@
     "version": "1.0.0",
     "main": "index.ts",
     "dependencies": {
+        "@flareapp/core": "file:../../packages/core",
+        "@flareapp/react": "file:../../packages/react",
+        "@flareapp/react-native": "file:../../packages/react-native",
         "expo": "~56.0.12",
         "expo-application": "~56.0.3",
         "expo-device": "~56.0.4",
@@ -11,13 +14,15 @@
         "react-native": "0.85.3"
     },
     "devDependencies": {
+        "@flareapp/react-native-sourcemaps": "file:../../packages/react-native-sourcemaps",
         "@types/react": "~19.2.2",
+        "babel-preset-expo": "~56.0.15",
         "typescript": "~6.0.3"
     },
     "scripts": {
         "start": "expo start",
-        "android": "expo start --android",
-        "ios": "expo start --ios",
+        "android": "expo run:android",
+        "ios": "expo run:ios",
         "web": "expo start --web"
     },
     "private": true


### PR DESCRIPTION
## @flareapp/react-native-sourcemaps — complete

Upload React Native (Metro) sourcemaps to Flare so production stack traces symbolicate. Version-based matching (`version_id` + `relative_filename`), not Debug IDs.

This branch now contains the **whole feature**, verified end-to-end on **both platforms**. The original description (below) scoped this PR to the JS core and deferred native wiring to "Plan 2" — that follow-up is now included here:

- **JS core** — Babel plugin inlining a typed `flareSourcemapVersion`, and the `flare-rn-sourcemaps upload` CLI over `@flareapp/flare-api`.
- **Bare RN native hooks** — Android `flare.gradle` (hooks the release JS-bundle task) and iOS `flare-xcode.sh` (Xcode run-script phase). Auto-upload on every release build; the build never fails because of a sourcemap problem (loud banner instead).
- **Expo config plugin** — `@flareapp/react-native-sourcemaps/expo` injects the same wiring on every CNG prebuild (CJS-only subpath; Expo `require()`s plugins).
- **`.env.local` auto-load** — in auto mode the hooks read `FLARE_API_KEY` from a gitignored `.env.local`/`.env` next to `flare.json`, so the key isn't required in the build environment.

### Verified end-to-end (Android + iOS, Expo playground, production Flare)

A real minified frame resolves to `App.tsx` source under the build's `FLARE_SOURCEMAP_VERSION` — on **Android** (Hermes, Gradle hook) and **iOS** (Hermes, Xcode phase).

### Notable bugs found and fixed during device verification

- **Android never uploaded.** A bare `exec {}` inside the bundle task's `doLast` resolves against the task, not the project ("Could not find method exec()"), so every Android build silently skipped. Now uses `ProcessBuilder`, and prefers the composed Hermes map over the pre-Hermes packager map (`task.sourcemapOutput`) so frames actually resolve.
- **iOS deleted its own map.** `SOURCEMAP_FILE` pointed at `$CONFIGURATION_BUILD_DIR`, where RN's Hermes step writes an intermediate map and `rm`s it after composing. Now `$TARGET_TEMP_DIR`, outside that dir.

### Carries one cross-package fix

`fix(core)`: strip the Hermes `address at ` prefix from stack-frame file names (in `@flareapp/core`). This was the actual blocker for backend matching; it benefits the RN client broadly, not just sourcemap upload, and could be split out if preferred.

### Docs

Public RN sourcemap docs live in flareapp.io (`docs/react-native`), tracked and pushed separately. They document two real gotchas: `expo run:*` may skip the upload (eager bundle + up-to-date native task — release/verify via `eas build` or a direct Gradle/Xcode build), and the Gradle daemon freezes its env (use `--no-daemon`/`--stop` or clean CI).

## Test plan

- [x] `@flareapp/react-native-sourcemaps` unit tests (69) + monorepo typecheck/build green
- [x] Android Hermes release build → frame resolves to source in Flare
- [x] iOS Hermes release build → frame resolves to source in Flare
- [x] Negative path: build stays green with a loud banner when key/version is missing

---

<details>
<summary>Original PR description (JS-core scope + first verification update)</summary>

## Summary

Adds `@flareapp/react-native-sourcemaps`, a new build-time package for uploading React Native (Metro) sourcemaps to Flare. This is the **JS core only**; native auto-wiring is a planned follow-up (see Scope).

Two halves that share one version string so reports symbolicate:

- **Babel plugin** (`@flareapp/react-native-sourcemaps/babel`) inlines `process.env.FLARE_SOURCEMAP_VERSION` into the app bundle at build time (Metro does not inline arbitrary `process.env`, so this is required on bare RN).
- **CLI** (`flare-rn-sourcemaps upload`) uploads a `.map` under that same version via the shared `@flareapp/flare-api` client.

A single `resolveVersion()` (flag > `FLARE_SOURCEMAP_VERSION` env > `package.json` version > throw) is used by both halves so they cannot disagree on the version.

### Why version-based, not Debug IDs

Flare's backend matches sourcemaps by `version_id` + `relative_filename`, not by Sentry-style Debug IDs (which would need backend work). The design follows Flare's existing model; full rationale in `docs/superpowers/specs/2026-06-24-react-native-sourcemaps-design.md`.

## Package contents

- `src/version.ts` — `resolveVersion()`
- `src/babel.ts` — version-inlining Babel plugin (zero runtime `@babel/*` imports; type-only)
- `src/uploadSourcemaps.ts` — upload logic over `@flareapp/flare-api`
- `src/cli.ts` / `src/bin.ts` — `flare-rn-sourcemaps upload`
- `README.md` — manual + `expo export` flows

Follows the `@flareapp/webpack`/`@flareapp/vite` conventions (tsdown CJS+ESM+d.ts, `@flareapp/flare-api` bundled via `--noExternal`).

## Scope (intentional)

- **In:** Babel plugin, upload CLI, `resolveVersion`. Covers the manual and `expo export` flows end to end.
- **Out (Plan 2):** native auto-wiring — Android `flare.gradle`, iOS `flare-xcode.sh`, Expo config plugin. To be built after the first real-build symbolication checkpoint.
- **Out:** Debug IDs (backend); `--strip-prefix` (deferred until matching is verified).

## Open risk to verify before native wiring

`--bundle-filename` (the `relative_filename` matched against runtime frames) defaults to the map basename minus `.map`. What an RN production frame's filename actually is has **not** been verified against a live Flare report; this is the required checkpoint before Plan 2.

## Test plan

- [x] 18 unit tests (version precedence, Babel transform incl. `pre()` per-file isolation, upload, CLI parse/dispatch)
- [x] `npm run build` / `npm run typescript` / `npm run test` green across the monorepo
- [x] Built `dist/babel.{cjs,mjs}` confirmed to have no runtime `@babel/*` imports
- [x] CLI smoke-run (shebang preserved, usage on no-args, exit 1)
- [ ] End-to-end symbolication of a real RN release build (the open-risk checkpoint above)

---

## Update: end-to-end verification on a real RN release build

The open-risk checkpoint above is now **done** — verified on Android Hermes (emulator) against a local Flare backend: typed version inlined → report carries `sourcemapVersionId` → CLI upload under the same version → backend matches `relative_filename: index.android.bundle` → composed map resolves the frame to `App.tsx` source. The default `--bundle-filename index.android.bundle` is correct for Android.

The verification surfaced changes beyond the original package, included in this PR:

- **`refactor(rn-sourcemaps)!`: typed `flareSourcemapVersion` import instead of `process.env`.** Bare RN does not type `process` (it needs `@types/node`, which wrongly drags Node globals into an RN app), and `process.env.X` misleadingly looks like a runtime read when it is build-time-substituted. The Babel plugin now inlines a typed `flareSourcemapVersion` imported from a new RN-safe `./runtime` entry (and drops the dead import). App code: `import { flareSourcemapVersion } from '@flareapp/react-native-sourcemaps/runtime'; flare.configure({ sourcemapVersionId: flareSourcemapVersion })`. This supersedes the `process.env` form described earlier in this PR.

- **`fix(core)`: strip the Hermes `address at ` prefix from stack-frame file names.** Hermes emits frames like `onPress@address at index.android.bundle:1:NN`; `error-stack-parser` kept `address at ` in the fileName, so the backend's `relative_filename` match could never succeed. This was the actual blocker. It lives in `@flareapp/core` and benefits the RN client (PR #62) broadly, not just sourcemap upload — flagging it here since it is slightly outside this package's scope and could be reviewed/split independently.

- **Playground harness (`playgrounds/react-native-bare`):** monorepo Metro config (`watchFolders` + `nodeModulesPaths`) plus a `resolveRequest` that pins `react`/`react-native` to the app's single copy (the root has RN 0.79 vs the app's 0.86, which otherwise caused a `DeviceInfo` TurboModule crash). This is test-harness wiring, not part of the shipped package.

### Still open before the Plan 2 native-wiring follow-up

- [ ] iOS Hermes (expected basename `main.jsbundle`, map under DerivedData)
- [ ] Physical Android device (Hermes may emit a full APK path; should still match via the backend basename fallback after the prefix strip — confirm)


</details>
