### PR TITLE
Tighten source comments and convert to JSDoc

### DIFF
--- a/packages/core/src/Flare.ts
+++ b/packages/core/src/Flare.ts
@@ -69,16 +69,11 @@ export class Flare {
     private framework: Framework | null = null;
 
     /**
-     * @param api              sends the report over HTTP.
-     * @param contextCollector returns per-report attributes (browser DOM info, Node
-     *                         process info, etc). Default is a no-op.
-     * @param fileReader       reads source files for stack-trace snippets. Default
-     *                         returns null (no snippets); `@flareapp/js` injects a
-     *                         fetch-based reader, `@flareapp/node` injects a disk reader.
-     * @param scopeProvider    returns the current `Scope` (per-call mutable state:
-     *                         glows, pendingAttributes, entryPoint). Browser uses a
-     *                         single global scope; Node uses an AsyncLocalStorage-
-     *                         backed provider so each request gets its own.
+     * @param contextCollector returns per-report attributes (browser DOM, Node process, etc). No-op by default.
+     * @param fileReader       reads source files for stack-trace snippets. Default returns null (no snippets);
+     *                         `@flareapp/js` injects a fetch reader, `@flareapp/node` a disk reader.
+     * @param scopeProvider    returns the current `Scope` (glows, pendingAttributes, entryPoint). Browser uses one
+     *                         global scope; Node uses an AsyncLocalStorage-backed provider so each request gets its own.
      */
     constructor(
         public api: Api = new Api(),
@@ -112,55 +107,14 @@ export class Flare {
     }
 
     /**
-     * Register an in-flight report so `flush()` can wait for it. Called by
-     * every public report entry point (`report`, `reportSilently`,
-     * `reportMessage`, `reportUnhandledRejection`, `test`); each wraps its
-     * full async pipeline (beforeEvaluate -> stack trace + source snippets ->
-     * beforeSubmit -> `api.report()`) so the entire roundtrip is what's
-     * tracked, not just the HTTP send at the end.
+     * Register an in-flight report so `flush()` can wait for it. Called by every public report entry point, each
+     * wrapping its full async pipeline (beforeEvaluate -> stack trace -> beforeSubmit -> api.report) so the whole
+     * roundtrip is tracked, not just the HTTP send.
      *
-     * Two problems this method solves at once.
-     *
-     * Problem 1: hold a reference to the work without leaking rejections.
-     *
-     *   `p` is the real report pipeline; it can reject (network failure,
-     *   `beforeSubmit` throws, etc). If we stored `p` directly in `inflight`
-     *   and no caller attached a `.catch` (the global error listeners use
-     *   `reportSilently` which DOES catch, but the path is still subtle), an
-     *   eventual rejection would surface as an unhandled-rejection warning
-     *   on Node and a console error in the browser. Bad citizen.
-     *
-     *   So we build a SHADOW promise that mirrors `p`'s timing but cannot
-     *   reject:
-     *
-     *     p.then(
-     *         () => undefined,   // on fulfilment, value is undefined
-     *         () => undefined,   // on rejection, ALSO resolve with undefined
-     *     )
-     *
-     *   Providing the second argument means we have "handled" any rejection
-     *   from `p`. The shadow always resolves with `undefined`, and `p`'s
-     *   rejection is consumed at the boundary. From the runtime's point of
-     *   view, the shadow is well-behaved.
-     *
-     * Problem 2: self-cleaning entry.
-     *
-     *   `tracked.finally(() => this.inflight.delete(tracked))`. `finally`
-     *   fires whether the shadow resolves or rejects, but the shadow can no
-     *   longer reject (problem 1 normalized it), so this is effectively
-     *   "when the underlying report has settled, remove me from the Set."
-     *   No GC magic, no external cleanup, no race window.
-     *
-     *   Note that `.finally` itself returns a new promise that we drop on
-     *   the floor. If the cleanup callback ever throws, that would surface
-     *   as an unhandled rejection on the dropped promise; `delete` does not
-     *   throw so we are safe today, but anything more elaborate added here
-     *   should be wrapped in try/catch.
-     *
-     * The return value is the ORIGINAL `p`. The caller awaits real success
-     * or failure; the tracking is completely invisible to them. This is why
-     * `await flare.report(err)` inside a fatal handler observes network
-     * errors the same as before tracking was added.
+     * Stores a shadow promise that mirrors `p`'s timing but cannot reject (the `() => undefined` rejection handler
+     * consumes any failure), so an unhandled report rejection never surfaces as a Node warning / console error. The
+     * shadow self-removes from the Set via `.finally`; `delete` never throws, so wrap any richer cleanup in try/catch.
+     * Returns the original `p` so the caller still observes real success/failure; tracking is invisible to them.
      */
     private track<T>(p: Promise<T>): Promise<T> {
         const tracked = p.then(
@@ -173,83 +127,14 @@ export class Flare {
     }
 
     /**
-     * Wait until every in-flight report settles, or until `timeoutMs`
-     * elapses, whichever comes first. Always resolves; never rejects.
+     * Wait until every in-flight report settles or `timeoutMs` elapses, whichever comes first. Always resolves, never
+     * rejects; no retry. Main consumer is `@flareapp/node`'s fatal handler, which awaits the fatal report explicitly
+     * then calls flush to drain any OTHER concurrent reports before `process.exit`.
      *
-     * The main consumer is `@flareapp/node`'s fatal handler:
-     *
-     *     process.on('uncaughtException', async (err) => {
-     *         process.exitCode = 1;
-     *         try { await flare.report(err); } catch {}
-     *         await flare.flush(shutdownTimeoutMs);
-     *         process.exit(1);
-     *     });
-     *
-     * The fatal `report` is awaited explicitly; `flush` then drains any
-     * OTHER reports that were already in flight (a request handler that
-     * fired `flare.report(...)` concurrently with the crash). The timeout
-     * caps the wait so a hung HTTP request cannot indefinitely block
-     * shutdown.
-     *
-     * Walking the implementation:
-     *
-     *   const pending = [...this.inflight];
-     *
-     *     Spread takes a SNAPSHOT of the Set at this instant. Reports that
-     *     start AFTER this line are not included in `pending`, so they are
-     *     not awaited by THIS flush call. This is intentional: it bounds
-     *     the wait. Without the snapshot, a handler that kept emitting
-     *     reports during shutdown could keep flush alive forever and block
-     *     the process from exiting.
-     *
-     *   if (pending.length === 0) return Promise.resolve();
-     *
-     *     Fast path. No timer scheduled, no promise constructor needed.
-     *     Resolves on the microtask queue. Cheap.
-     *
-     *   return new Promise<void>((resolve) => {
-     *       const timer = setTimeout(resolve, timeoutMs);
-     *       Promise.allSettled(pending).then(() => {
-     *           clearTimeout(timer);
-     *           resolve();
-     *       });
-     *   });
-     *
-     *     The race between two outcomes, both calling the same `resolve`:
-     *
-     *     1. `setTimeout(resolve, timeoutMs)` schedules a "give up" call.
-     *        After `timeoutMs` it fires, calling `resolve()` from the
-     *        timer-queue side. The outer promise resolves immediately,
-     *        even if reports are still pending. Those reports are abandoned
-     *        (they continue running but the process is about to die).
-     *
-     *     2. `Promise.allSettled(pending)` returns a promise that resolves
-     *        when every promise in `pending` has either fulfilled or
-     *        rejected. It NEVER rejects on its own. We use `allSettled`
-     *        rather than `Promise.all` because `all` short-circuits on the
-     *        first rejection -- we want to wait for everyone regardless of
-     *        whether their HTTP calls succeed or fail. (Our shadows cannot
-     *        reject anyway because `track` normalized them, but using
-     *        `allSettled` documents the intent and survives future changes
-     *        to shadow construction.) When it resolves, we call
-     *        `clearTimeout(timer)` to cancel the pending timer (so it does
-     *        not fire later and call `resolve` a second time -- a no-op,
-     *        but wasted work) and then `resolve()` ourselves.
-     *
-     *   Resolve can only meaningfully fire once. Subsequent calls to the
-     *   same `resolve` are silently ignored by the Promise spec, so the
-     *   race is safe even if for some reason both branches fired together.
-     *
-     * Things flush() deliberately does NOT do:
-     *
-     *   - It does not reject. Even if every report failed, allSettled
-     *     resolves. Callers do not need a `.catch`.
-     *   - It does not retry. One pipeline attempt per report, then move on.
-     *   - It does not stop new reports from starting. The Flare instance
-     *     is still usable after flush resolves. flush is "wait for what is
-     *     in flight," not "freeze the SDK."
-     *   - It does not drain reports started after the snapshot. Call flush
-     *     again if you need to wait for those too.
+     * `[...this.inflight]` snapshots the Set: reports started after this line are NOT awaited, which bounds the wait so
+     * a handler emitting reports during shutdown cannot block the process forever. Call flush again to drain those.
+     * `allSettled` (not `all`) waits for every report regardless of HTTP success/failure; `all` would short-circuit on
+     * the first rejection. Flush does not stop new reports; the instance stays usable afterward.
      */
     flush(timeoutMs = 2000): Promise<void> {
         this._logger.flush();
@@ -433,8 +318,8 @@ export class Flare {
 
         const seenAtUnixNano = Date.now() * 1_000_000;
 
-        // Coerce non-Error values (strings, rejected promises, etc) so we always have a real Error
-        // to walk a stack from. Typed as Error for ergonomics, but consumers may pass anything.
+        // Coerce non-Error values so we always have a real Error to walk a stack from. Typed as Error
+        // for ergonomics, but consumers may pass anything.
         const coerced = error instanceof Error ? error : new Error(typeof error === 'string' ? error : String(error));
 
         const errorToReport = await this._config.beforeEvaluate(coerced);
@@ -562,8 +447,7 @@ export class Flare {
         if (entryPoint?.type !== undefined) entryPointOverrides['flare.entry_point.handler.type'] = entryPoint.type;
         if (entryPoint?.name !== undefined) entryPointOverrides['flare.entry_point.handler.name'] = entryPoint.name;
 
-        // entryPointOverrides come after the collector so explicitly-set entry-point values
-        // win over any defaults the collector provided.
+        // entryPointOverrides come after the collector so explicit entry-point values win over collector defaults.
         const attributes: Attributes = {
             ...baseAttributes,
             ...collectorAttributes,
@@ -572,9 +456,7 @@ export class Flare {
             ...extraAttributes,
         };
 
-        // Deep-merge context.custom: combine the scope's pendingAttributes['context.custom']
-        // with the user-supplied extra context.custom per-key (user wins) so scope-set context
-        // is not clobbered by the spread above.
+        // Deep-merge context.custom per-key (user wins) so the spread above does not clobber scope-set context.
         const pendingCustom = activeScope.pendingAttributes['context.custom'];
         const extraCustom = extraAttributes['context.custom'];
         if (
@@ -591,8 +473,7 @@ export class Flare {
             };
         }
 
-        // Inject the framework name into context.custom so it is emitted even inside a fresh
-        // request scope that carries no other custom context.
+        // Inject framework name into context.custom so it is emitted even in a fresh request scope with no other custom context.
         if (this.framework?.name) {
             const existing = (attributes['context.custom'] as Record<string, AttributeValue> | undefined) ?? {};
             attributes['context.custom'] = { ...existing, framework: this.framework.name.toLowerCase() };
@@ -610,19 +491,15 @@ export class Flare {
     }
 
     private getScopeAttributes(): Attributes {
-        // The scope-derived record a LOCAL ROOT span carries: user context (addContext /
-        // addContextGroup), entry-point overrides, framework-in-context.custom. The Tracer
-        // snapshots this at span START, so a long-lived root does not pick up scope
-        // mutations from the next page (drift). Spans never auto-run the DOM context
-        // collector; children get no scope at all. Mirrors the PHP client, where the
-        // request root carries the request/user context and child recorders stay lean.
+        // Scope-derived record a LOCAL ROOT span carries: user context, entry-point overrides,
+        // framework-in-context.custom. Tracer snapshots this at span START so a long-lived root does not drift into the
+        // next page's scope. Spans never run the DOM collector; children get no scope. Mirrors the PHP client.
         return this.assembleAttributes({}, {}, false);
     }
 
     private spanResourceAttributes(): Attributes {
-        // Resource is stable per page (host.name). Reuse the existing collector but keep only
-        // its resource partition, discarding record-level context (cookies/url) so nothing
-        // heavy or drifting reaches spans. Evaluated once per flush, not per span.
+        // Resource is stable per page (host.name). Keep only the collector's resource partition, dropping record-level
+        // context (cookies/url) so nothing heavy or drifting reaches spans. Evaluated once per flush, not per span.
         return partitionAttributes(this.contextCollector(this._config)).resource;
     }
 
@@ -639,10 +516,9 @@ export class Flare {
         const activeScope = this.scopeProvider.active();
         const attributes = this.assembleAttributes(this.contextCollector(this._config), input.extraAttributes, true);
 
-        // seenAtUnixNano: real nanoseconds. Date.now() * 1_000_000 exceeds Number.MAX_SAFE_INTEGER
-        // by ~3 bits (~256 ns of drift), but browser clocks are millisecond-precision so the lost
-        // bits are below source resolution. PHP's json_decode reads the resulting 19-digit literal
-        // as a 64-bit int (PHP_INT_MAX ~ 9.22e18 vs our value ~ 1.78e18).
+        // seenAtUnixNano in real nanoseconds. Date.now() * 1_000_000 exceeds MAX_SAFE_INTEGER by ~3 bits (~256 ns), but
+        // browser clocks are millisecond-precision so the lost bits are below source resolution. PHP's json_decode
+        // reads the 19-digit literal as a 64-bit int (PHP_INT_MAX ~9.22e18 vs our ~1.78e18).
         const report: Report = {
             exceptionClass: input.exceptionClass,
             message: input.message,

--- a/packages/core/src/Scope.ts
+++ b/packages/core/src/Scope.ts
@@ -1,10 +1,8 @@
 import type { Attributes, AttributeValue, EntryPointHandler, Glow } from './types';
 
 /**
- * Maps each `User` identity field to the flat report attribute key it projects to.
- * `Flare.setUser`'s set pass writes through these so the literal key strings live in
- * exactly one place; `USER_IDENTITY_KEYS` (the clear pass) derives from them, so adding
- * a field here can never silently leave the clear pass out of date.
+ * Maps each `User` identity field to the flat report attribute key it projects to. `Flare.setUser` writes through
+ * these; `USER_IDENTITY_KEYS` (the clear pass) derives from them, so a new field can never leave the clear pass stale.
  */
 export const USER_FIELD_KEYS = {
     id: 'user.id',
@@ -14,18 +12,15 @@ export const USER_FIELD_KEYS = {
 } as const;
 
 /**
- * The report attribute keys that `Flare.setUser` owns: the four projected identity
- * fields plus the `user.attributes` bag for extras. Single source of truth so the
- * clear pass and the set pass in `setUser` cannot drift, and so consumers that must
- * stamp identity outside core's report pipeline (Electron's forwarded-renderer path)
- * pick up the exact same set instead of re-hardcoding it.
+ * Attribute keys `Flare.setUser` owns: the four projected identity fields plus the `user.attributes` bag. Single
+ * source of truth so the set/clear passes cannot drift, and so consumers stamping identity outside core's report
+ * pipeline (Electron's forwarded-renderer path) reuse the exact same set.
  */
 export const USER_IDENTITY_KEYS = [...Object.values(USER_FIELD_KEYS), 'user.attributes'] as const;
 
 /**
- * Pick the user-identity attributes currently set on a scope. Used where identity must
- * be copied onto a report that does not flow through `Flare.report()` (which would
- * otherwise spread `pendingAttributes` automatically).
+ * Pick the user-identity attributes currently set on a scope. Used where identity must be copied onto a report that
+ * does not flow through `Flare.report()` (which would otherwise spread `pendingAttributes` automatically).
  */
 export function userIdentityAttributes(scope: Scope): Attributes {
     const attrs: Attributes = {};
@@ -37,25 +32,13 @@ export function userIdentityAttributes(scope: Scope): Attributes {
 }
 
 /**
- * Holds the per-call mutable state that used to live on the `Flare` instance:
- * breadcrumbs (`glows`), custom attributes (`pendingAttributes`), and the
- * current entry-point handler.
+ * Per-call mutable state: breadcrumbs (`glows`), custom attributes (`pendingAttributes`), and the current entry-point
+ * handler. Split out of `Flare` so the consumer can choose a single global `Scope` (browser, one user at a time) or one
+ * `Scope` per request via AsyncLocalStorage (Node, concurrent requests must not leak into each other). `Flare` reaches
+ * it through `scopeProvider.active()`, so per-request behavior lives in the provider.
  *
- * Why this exists as its own class: in the browser there is one `Flare` per
- * page and one user at a time, so a single shared bag of state is fine. In
- * Node, a single `Flare` instance serves many concurrent requests, and each
- * request wants its own breadcrumbs and its own custom context that do NOT
- * leak into other requests. Splitting this state out of `Flare` lets the
- * consumer choose: one global `Scope` (browser) or one `Scope` per request
- * via AsyncLocalStorage (Node).
- *
- * `Flare` reads and writes this through `scopeProvider.active()` instead of
- * holding the state directly, so the per-request behavior comes from the
- * provider, not from the class itself.
- *
- * `NodeScope` (in `@flareapp/node`) extends this with a `request` bucket
- * (HTTP method, path, headers). User identity is written to `pendingAttributes`
- * by `Flare.setUser`, so it needs no dedicated field. Browser does not need `request`.
+ * `NodeScope` (in `@flareapp/node`) extends this with a `request` bucket (method, path, headers). User identity goes to
+ * `pendingAttributes` via `Flare.setUser`, so it needs no dedicated field.
  */
 export class Scope {
     glows: Glow[] = [];
@@ -63,13 +46,8 @@ export class Scope {
     entryPoint: EntryPointHandler | null = null;
 
     /**
-     * Append a breadcrumb. Caps the list at `maxGlowsPerReport` by dropping the
-     * OLDEST entries when the limit is exceeded; this keeps reports below a
-     * payload-size threshold while preserving the most recent events leading
-     * up to an error.
-     *
-     * `slice(length - max)` returns the trailing `max` items, which is the
-     * shortest way to drop from the front and keep insertion order.
+     * Append a breadcrumb, capping the list at `maxGlowsPerReport` by dropping the oldest entries. Keeps the payload
+     * bounded while preserving the most recent events leading up to an error.
      */
     addGlow(glow: Glow, maxGlowsPerReport: number): void {
         this.glows.push(glow);
@@ -82,19 +60,14 @@ export class Scope {
         this.glows = [];
     }
 
-    /**
-     * Set a single attribute on this scope. Called from `Flare.addContext` and
-     * `Flare.addContextGroup`. Last write wins.
-     */
+    /** Set a single attribute (`Flare.addContext` / `addContextGroup`). Last write wins. */
     setAttribute(key: string, value: AttributeValue): void {
         this.pendingAttributes[key] = value;
     }
 
     /**
-     * Shallow-merge a bag of attributes into this scope. Used by Node's
-     * AsyncLocalStorage provider when patching the live request context via
-     * `flare.mergeContext({ ... })`. Last write wins per key; nested objects
-     * are NOT deep-merged.
+     * Shallow-merge attributes into this scope. Used by Node's provider when patching live request context via
+     * `flare.mergeContext({ ... })`. Last write wins per key; nested objects are not deep-merged.
      */
     mergeAttributes(partial: Attributes): void {
         Object.assign(this.pendingAttributes, partial);
@@ -102,27 +75,18 @@ export class Scope {
 }
 
 /**
- * The seam through which `Flare` reaches its current `Scope`. Implementations
- * decide what "current" means.
- *
- * - `GlobalScopeProvider` always returns the same `Scope` instance (browser).
- * - `AsyncLocalStorageScopeProvider` in `@flareapp/node` returns the per-request
- *   `NodeScope` stored in `node:async_hooks` for the in-flight async chain,
- *   falling back to a single shared scope when called outside any
- *   `runWithContext(...)` callback.
- *
- * Any consumer of `@flareapp/core` can supply its own provider to plug in
- * different "current scope" semantics.
+ * The seam through which `Flare` reaches its current `Scope`; implementations decide what "current" means.
+ * `GlobalScopeProvider` always returns the same instance (browser); `@flareapp/node`'s provider returns the
+ * per-request `NodeScope` from `node:async_hooks`, falling back to a shared scope outside any `runWithContext(...)`.
+ * Consumers may supply their own.
  */
 export interface ScopeProvider {
     active(): Scope;
 }
 
 /**
- * The simplest provider: one `Scope` for the lifetime of the provider, shared
- * by every caller. This is the right default for environments with a single
- * logical context (browser tab, CLI script, etc.) and is the default that
- * `Flare`'s constructor falls back to when no provider is supplied.
+ * One `Scope` for the provider's lifetime, shared by every caller. Right default for single-context environments
+ * (browser tab, CLI script) and the fallback `Flare`'s constructor uses when no provider is supplied.
  */
 export class GlobalScopeProvider implements ScopeProvider {
     private scope = new Scope();

--- a/packages/core/src/api/Api.ts
+++ b/packages/core/src/api/Api.ts
@@ -1,21 +1,17 @@
 import { LogsEnvelope, Report, TracesEnvelope } from '../types';
 import { flatJsonStringify } from '../util';
 
-// A browser rejects a keepalive fetch with a network error when the sum of its
-// body and every other in-flight keepalive body exceeds ~64 KiB (Fetch spec).
-// logs and traces share one Api, so on pagehide two ~60 KB envelopes would breach
-// that limit and one would be dropped. We track the in-flight total and downgrade
-// a request to a normal fetch when it would breach the budget, keeping a margin
-// under 64 KiB. A downgraded request still ships on soft backgrounding, and on a
-// real unload it is no worse off than the rejection it replaces.
+// A browser rejects a keepalive fetch when the sum of its body and every other in-flight keepalive body exceeds ~64 KiB
+// (Fetch spec). logs and traces share one Api, so on pagehide two ~60 KB envelopes would breach that and one would be
+// dropped. Track the in-flight total and downgrade a request to a normal fetch when it would breach the budget. A
+// downgraded request still ships on soft backgrounding, and on a real unload is no worse off than the rejection.
 const MAX_PENDING_KEEPALIVE_BYTES = 60_000;
 const MAX_PENDING_KEEPALIVE_REQUESTS = 15;
 
 const textEncoder = new TextEncoder();
 
 export class Api {
-    // Per-Api budget: correct for the single-instance model. Two Flare instances on
-    // one page do not share this counter (see the documented one-instance assumption).
+    // Per-Api budget: correct for the single-instance model. Two Flare instances on one page do not share this counter.
     private pendingKeepaliveBytes = 0;
     private pendingKeepaliveRequests = 0;
 

--- a/packages/core/src/logging/Logger.ts
+++ b/packages/core/src/logging/Logger.ts
@@ -11,10 +11,9 @@ export type LoggerDeps = {
     getConfig: () => Config;
     getSdkInfo: () => SdkInfo;
     getFramework: () => Framework | null;
-    // Returns attributes ALREADY split into resource-level (only the collector's
-    // resource keys) and record-level (collector record keys + scope + entry point
-    // + user attrs). The Logger does NOT partition — only the collector output is
-    // partitionable; scope/user/entry-point attributes always stay record-level.
+    // Returns attributes already split into resource-level (only the collector's resource keys) and record-level
+    // (collector record keys + scope + entry point + user attrs). The Logger does not partition; only the collector
+    // output is partitionable, scope/user/entry-point attributes always stay record-level.
     buildLogAttributes: (userAttributes: Attributes) => { record: Attributes; resource: Attributes };
     track: <T>(p: Promise<T>) => Promise<T>;
     scheduler: FlushScheduler;
@@ -60,10 +59,8 @@ export class Logger {
         return this.buffer.length;
     }
 
-    // Mirrors the PHP client's Logger::record(message, level, context, attributes):
-    // the everyday `context` is nested under `log.context` (rendered as the "Context"
-    // section in Flare), while `attributes` is an advanced raw passthrough spread flat
-    // onto the record (subject to the same resource/record partitioning).
+    // Mirrors PHP's Logger::record: everyday `context` nests under `log.context` (Flare's "Context" section), while
+    // `attributes` is a raw passthrough spread flat onto the record (same resource/record partitioning).
     private record(level: MessageLevel, message: string, context: Attributes, attributes: Attributes): void {
         const config = this.deps.getConfig();
         if (!config.enableLogs) return;
@@ -81,26 +78,22 @@ export class Logger {
             resourceAttributes: resource,
         };
 
-        // Oversized-record guard: a single record bigger than the byte cap can
-        // never ship (and would make the trim unsatisfiable). Drop at capture.
+        // Oversized-record guard: a single record over the byte cap can never ship (and makes the trim
+        // unsatisfiable). Drop at capture.
         if (this.estimateBytes(buffered) > config.logFlushMaxBytes) {
             if (config.debug) console.error('Flare: dropping oversized log record');
             return;
         }
 
         this.buffer.push(buffered);
-        // Last-write-wins: the envelope stamps ALL batched records with this single
-        // most-recent resource map. That is correct ONLY because every
-        // resource-prefixed key in the partition allowlist is instance-static for the
-        // process lifetime (the one varying process.* key, process.uptime, is held
-        // back to record-level via the partition's exception set). A future collector
-        // emitting a request-varying resource-prefixed key would silently mis-stamp
-        // batched records.
+        // Last-write-wins: the envelope stamps ALL batched records with this single most-recent resource map. Correct
+        // ONLY because every resource-prefixed key in the partition allowlist is instance-static for the process
+        // lifetime (the one varying key, process.uptime, is held to record-level via the partition's exception set). A
+        // future collector emitting a request-varying resource key would silently mis-stamp batched records.
         this.resourceAttributes = resource;
 
-        // Triggers run BEFORE the trim: a keyed over-cap push flushes-and-clears
-        // here (data shipped); the trim is only the safety net when the flush
-        // no-ops (no key).
+        // Triggers run BEFORE the trim: a keyed over-cap push flushes-and-clears here (data shipped); the trim is only
+        // the safety net when the flush no-ops (no key).
         this.evaluateTriggers(config);
         this.trim(config);
     }
@@ -139,10 +132,8 @@ export class Logger {
         if (!config.enableLogs) return;
         if (this.buffer.length === 0) return;
 
-        // Key gate: never send unauthenticated. Use assertKey (not a bare
-        // truthiness check) so debug mode logs the same missing-key diagnostic
-        // reports get. Reset the timer (one-shot fired) but keep the buffer so
-        // records survive until a key is set.
+        // Key gate: never send unauthenticated. assertKey (not bare truthiness) so debug mode logs the same missing-key
+        // diagnostic reports get. Reset the timer but keep the buffer so records survive until a key is set.
         if (!assertKey(config.key, config.debug)) {
             this.clearTimer();
             return;
@@ -150,17 +141,14 @@ export class Logger {
 
         this.clearTimer();
 
-        // keepalive fires on visibilitychange:hidden, which also fires when a tab is
-        // merely backgrounded (not just on unload). packForKeepalive ships only what
-        // fits the browser's ~64KB keepalive budget, so retain the over-budget tail in
-        // the buffer instead of clearing it — a resumed tab can still send those records
-        // normally. A real unload discards the buffer with the page either way.
+        // keepalive fires on visibilitychange:hidden, which also fires on mere backgrounding (not just unload).
+        // packForKeepalive ships only what fits the browser's ~64KB keepalive budget, so the over-budget tail is
+        // retained (a resumed tab can still send it normally). A real unload discards the buffer with the page anyway.
         let records: BufferedLog[];
         if (opts?.keepalive) {
             records = this.packForKeepalive(config);
             this.buffer = this.buffer.filter((log) => !records.includes(log));
-            // Re-arm the interval so retained records flush on resume without waiting
-            // for the next captured log.
+            // Re-arm the interval so retained records flush on resume without waiting for the next captured log.
             if (this.buffer.length > 0) this.armTimer(config);
         } else {
             records = this.buffer;
@@ -230,26 +218,17 @@ export class Logger {
     }
 
     private estimateBytes(log: BufferedLog): number {
-        // Intentionally approximate heuristic used ONLY for the soft batching caps
-        // (logFlushMaxBytes weight-flush, oversized-record drop guard, trim loop).
-        // Two known approximations:
-        //   1. .length counts UTF-16 code units, not UTF-8 bytes — multi-byte
-        //      characters may be under- or over-counted vs the real wire size.
-        //   2. BufferedLog includes resourceAttributes, which are hoisted to the
-        //      envelope resource object and sent once per request, not per record —
-        //      so repeated resource attributes are counted once per record here.
-        // Both are acceptable: these caps are soft batching heuristics and /v1/logs
-        // has no hard per-request byte limit.  The HARD keepalive cap is measured
-        // separately with exact UTF-8 bytes in packForKeepalive(), because that one
-        // is a real browser-enforced limit (~64 KB on keepalive request bodies).
-        //
-        // flatJsonStringify (not JSON.stringify) because record attributes are raw
-        // user data that can contain cycles.
+        // Approximate heuristic used ONLY for the soft batching caps (weight-flush, oversized-record drop, trim loop).
+        // Two known approximations: (1) .length counts UTF-16 code units, not UTF-8 bytes; (2) resourceAttributes are
+        // hoisted to the envelope and sent once per request, but counted once per record here. Both acceptable: these
+        // caps are soft and /v1/logs has no hard per-request byte limit. The HARD keepalive cap is measured separately
+        // with exact UTF-8 bytes in packForKeepalive (~64 KB, real browser-enforced). flatJsonStringify (not
+        // JSON.stringify) because record attributes are raw user data that can contain cycles.
         return flatJsonStringify(log).length;
     }
 
     private bufferBytes(): number {
-        // Uses estimateBytes() — see its comment for the deliberate approximations.
+        // Uses estimateBytes(); see its comment for the deliberate approximations.
         return this.buffer.reduce((sum, log) => sum + this.estimateBytes(log), 0);
     }
 }

--- a/packages/core/src/logging/otel.ts
+++ b/packages/core/src/logging/otel.ts
@@ -1,8 +1,9 @@
 import type { AnyValue, AttributeValue, Attributes, KeyValue } from '../types';
 
-// `inPath` tracks ancestors on the current branch only (added on enter, removed on
-// exit), mirroring flatJsonStringify's decycle. A global "seen" set would mis-flag
-// the same object referenced twice in sibling branches as circular.
+/**
+ * `inPath` tracks ancestors on the current branch only (added on enter, removed on exit), mirroring
+ * flatJsonStringify's decycle. A global "seen" set would mis-flag an object referenced twice in sibling branches.
+ */
 export function valueToOpenTelemetry(value: AttributeValue, inPath: WeakSet<object> = new WeakSet()): AnyValue | null {
     if (typeof value === 'string') return { stringValue: value };
     if (typeof value === 'boolean') return { boolValue: value };

--- a/packages/core/src/logging/partition.ts
+++ b/packages/core/src/logging/partition.ts
@@ -1,14 +1,12 @@
 import type { Attributes } from '../types';
 
-// Allowlist of resource-level key prefixes. Every other key — known or unknown —
-// is record-level. Mis-placing a static key on a record costs a little duplication;
-// mis-placing a request-varying key on the shared resource corrupts batched
-// envelopes, so record-level is the safe default.
+// Allowlist of resource-level key prefixes. Every other key is record-level. Mis-placing a static key on a record
+// costs a little duplication; mis-placing a request-varying key on the shared resource corrupts batched envelopes, so
+// record-level is the safe default.
 const RESOURCE_PREFIXES = ['service.', 'telemetry.', 'host.', 'os.', 'process.', 'flare.framework.', 'flare.language.'];
 
-// Keys that match a resource prefix but are NOT instance-static, so they must stay
-// record-level. `process.uptime` changes every read; promoting it to the shared
-// envelope resource would tag batched records with the flush-time value.
+// Keys matching a resource prefix but NOT instance-static, so they stay record-level. process.uptime changes every
+// read; promoting it to the shared resource would tag batched records with the flush-time value.
 const RECORD_LEVEL_EXCEPTIONS = new Set(['process.uptime']);
 
 export function partitionAttributes(attributes: Attributes): {

--- a/packages/core/src/stacktrace/NullFileReader.ts
+++ b/packages/core/src/stacktrace/NullFileReader.ts
@@ -1,25 +1,11 @@
 import type { FileReader } from './fileReader';
 
 /**
- * No-op `FileReader` that returns `null` for every URL it is asked to read.
- *
- * Used as the default for `Flare`'s `fileReader` constructor parameter so the
- * class is usable without picking a side: instantiated bare (`new Flare()`),
- * reports still build, but stack frames omit source-code snippets — which is
- * the correct, safe behavior in an environment we know nothing about.
- *
- * The two real implementations live in the consumer packages and take their
- * place once the right environment is established:
- *
- * - `@flareapp/js` injects `FetchFileReader`, which `fetch()`s source maps
- *   and original files over HTTP for browser stack frames.
- * - `@flareapp/node` injects `DiskFileReader`, which reads files from disk
- *   via `node:fs/promises` for server stack frames.
- *
- * The interface (`read(url) -> Promise<string | null>`) lets the stack-trace
- * builder treat all three the same way: ask for a URL, render the snippet
- * when text comes back, gracefully skip it when `null` does. No environment
- * checks anywhere in core.
+ * No-op `FileReader` returning `null` for every URL. Default for `Flare`'s `fileReader` param so `new Flare()` builds
+ * reports without picking an environment; stack frames just omit source snippets. Consumer packages inject the real
+ * ones: `@flareapp/js` a fetch-based reader, `@flareapp/node` a disk reader. The `read(url) -> Promise<string | null>`
+ * interface lets the stack-trace builder treat all three the same (render on text, skip on null), so core needs no
+ * environment checks.
  */
 export class NullFileReader implements FileReader {
     read(_url: string): Promise<string | null> {

--- a/packages/core/src/stacktrace/createStackTrace.ts
+++ b/packages/core/src/stacktrace/createStackTrace.ts
@@ -40,12 +40,9 @@ export function createStackTrace(error: Error, debug: boolean, fileReader: FileR
     });
 }
 
-// Hermes (React Native's default engine) emits stack frames like
-// `onPress@address at index.android.bundle:1:1234`. error-stack-parser keeps the
-// `address at ` literal as part of the fileName, which breaks both sourcemap matching
-// (the backend matches the bundle path against the uploaded relative_filename) and
-// source display. Strip the prefix so `file` is the real bundle path. No real file
-// path begins with `address at `, so this is a no-op on other engines.
+// Hermes (RN's default engine) emits frames like `onPress@address at index.android.bundle:1:1234`. error-stack-parser
+// keeps the `address at ` literal in the fileName, breaking sourcemap matching and source display. Strip it so `file`
+// is the real bundle path. No real path begins with `address at `, so this is a no-op on other engines.
 const HERMES_ADDRESS_PREFIX = 'address at ';
 
 function normalizeFileName(fileName: string | undefined): string | undefined {

--- a/packages/core/src/tracing/Tracer.ts
+++ b/packages/core/src/tracing/Tracer.ts
@@ -20,8 +20,8 @@ import { parseTraceparent } from './traceparent';
 
 export const defaultNowNano = (): number => {
     const perf = (globalThis as { performance?: Performance }).performance;
-    // timeOrigin is missing in some environments (older Safari, some Hermes builds
-    // and polyfills); undefined + now() would yield NaN timestamps on every span.
+    // timeOrigin is missing in some environments (older Safari, some Hermes builds/polyfills); undefined + now() would
+    // yield NaN timestamps on every span. Fall back to Date.now().
     const ms =
         perf && typeof perf.now === 'function' && typeof perf.timeOrigin === 'number'
             ? perf.timeOrigin + perf.now()
@@ -88,8 +88,7 @@ export class Tracer {
     }
 
     setActiveRoot(span?: Span): void {
-        // setActiveRoot is optional on the holder interface (non-breaking); a holder
-        // that does not support active roots simply ignores it.
+        // setActiveRoot is optional on the holder interface; a holder without active-root support ignores it.
         this.holder.setActiveRoot?.(span);
     }
 
@@ -161,11 +160,9 @@ export class Tracer {
         const config = this.deps.getConfig();
         const spanId = makeSpanId();
 
-        // The pending continuation (continueFromTraceparent) is a strict one-shot for
-        // the NEXT startSpan, whatever that span turns out to be: consumed by a
-        // parentless root, dropped when the span has a parent, dropped when tracing is
-        // disabled. It must never linger and attach a stale remote trace to an
-        // unrelated root later.
+        // Pending continuation (continueFromTraceparent) is a strict one-shot for the NEXT startSpan: consumed by a
+        // parentless root, dropped when the span has a parent or tracing is disabled. Never lingers, so it can't attach
+        // a stale remote trace to an unrelated later root.
         const continuation = this.pendingContinuation;
         this.pendingContinuation = null;
 
@@ -190,8 +187,7 @@ export class Tracer {
         }
         state.openSpanCount++;
 
-        // The Tracer's real "local root" test: this span seeded (or is) the local root of its
-        // TraceState. True for new roots, continued roots (non-null remote parentSpanId), and
+        // "Local root" test: this span seeded (or is) its TraceState's local root. True for new, continued, and
         // foreign-parent roots; false for a child of an already-seen trace.
         const isLocalRoot = state.localRootSpanId === spanId;
         const span = this.makeSpan({ traceId, spanId, parentSpanId, name, recording, isLocalRoot }, opts, config);
@@ -206,23 +202,21 @@ export class Tracer {
         config: Config,
         continuation: { traceId: string; parentSpanId: string; sampled: boolean } | null,
     ): { traceId: string; parentSpanId: string | null; state: TraceState } {
-        // forceRoot: never inherit the ambient active span. A navigation root started
-        // while the app is inside withSpan(...) must not become a mid-trace child.
+        // forceRoot: never inherit the ambient active span. A navigation root started inside withSpan(...) must not
+        // become a mid-trace child.
         let parent = opts.forceRoot ? opts.parent : (opts.parent ?? this.holder.getActive());
 
-        // A Span created before a clear() is stale: it must not parent or re-seed live
-        // state. Plain {traceId, spanId} objects have no epoch and are never stale.
+        // A Span created before a clear() is stale: must not parent or re-seed live state. Plain {traceId, spanId}
+        // objects have no epoch and are never stale.
         if (parent && 'epoch' in parent && (parent as { epoch: number }).epoch !== this.epoch) {
             parent = undefined;
         }
 
         if (parent && 'spanId' in parent && 'traceId' in parent) {
             const traceId = parent.traceId;
-            // A real Span carries its trace's recording decision; a manually stitched
-            // {traceId, spanId} parent does not. Run the sampler instead of assuming
-            // recording, so tracesSampleRate 0 does not still buffer and ship. Lazy so
-            // the sampler (side effects, rng consumption) only runs when new state is
-            // actually seeded.
+            // A real Span carries its trace's recording decision; a manually stitched {traceId, spanId} parent does
+            // not. Run the sampler instead of assuming recording, so tracesSampleRate 0 does not still buffer and ship.
+            // Lazy so the sampler (side effects, rng consumption) only runs when new state is actually seeded.
             const fallbackRecording = (): boolean =>
                 'isRecording' in parent
                     ? (parent as Span).isRecording
@@ -235,8 +229,7 @@ export class Tracer {
             return { traceId, parentSpanId: parent.spanId, state };
         }
 
-        // Continued trace: the continuation was captured and cleared by startSpan
-        // (strict one-shot); a parentless span here adopts it.
+        // Continued trace: continuation captured and cleared by startSpan (one-shot); a parentless span adopts it.
         if (continuation) {
             const ctx: SamplingContext = {
                 name,
@@ -260,8 +253,7 @@ export class Tracer {
     private getOrSeedState(traceId: string, localRootSpanId: string, fallbackRecording: () => boolean): TraceState {
         const existing = this.traceStates.get(traceId);
         if (existing) {
-            // Refresh recency: delete + re-insert so it moves to the most-recent end
-            // of the Map, making eviction true LRU rather than FIFO.
+            // Refresh recency: delete + re-insert moves it to the Map's most-recent end, making eviction true LRU.
             this.traceStates.delete(traceId);
             this.traceStates.set(traceId, existing);
             return existing;
@@ -270,9 +262,8 @@ export class Tracer {
     }
 
     private createState(traceId: string, localRootSpanId: string, recording: boolean): TraceState {
-        // Bounded backstop: an app that never ends spans must not grow the map forever.
-        // The Map is kept in recency order (getOrSeedState refreshes on access), so the
-        // first key is the least-recently-used; evict it when at the cap.
+        // Bounded backstop: an app that never ends spans must not grow the map forever. The Map is kept in recency
+        // order (getOrSeedState refreshes on access), so the first key is the LRU; evict it at the cap.
         if (this.traceStates.size >= this.maxLiveTraces) {
             const lru = this.traceStates.keys().next().value;
             if (lru !== undefined) this.traceStates.delete(lru);
@@ -338,9 +329,8 @@ export class Tracer {
         if (!span.isRecording) return;
         if (!this.deps.getConfig().enableTracing) return; // ended after disable/clear: no buffering
 
-        // Buffering runs inside the app's span.end() call (e.g. the fetch wrapper's
-        // success path). Serializing exotic attribute values must never throw out of
-        // end() and reject a host request; a failed buffer just drops the span.
+        // Buffering runs inside the app's span.end() call (e.g. the fetch wrapper's success path). Serializing exotic
+        // attribute values must never throw out of end() and reject a host request; a failed buffer just drops the span.
         try {
             const record: Attributes = { ...span.scopeAttributes, ...span.attributes };
             const buffered: BufferedSpan = {

--- a/packages/core/src/tracing/context.ts
+++ b/packages/core/src/tracing/context.ts
@@ -2,15 +2,16 @@ import type { Span } from '../types';
 
 export interface ActiveSpanHolder {
     getActive(): Span | undefined;
-    // Runs `fn` with `span` as the active span, restoring the prior active span
-    // afterward. Modeled as a callback (not a bare setter) so a Node holder can
-    // back it with AsyncLocalStorage.run(...) to preserve async-scoped context.
+    /**
+     * Run `fn` with `span` active, restoring the prior active span afterward. A callback (not a bare setter) so a Node
+     * holder can back it with AsyncLocalStorage.run(...) to preserve async-scoped context.
+     */
     withActive<T>(span: Span, fn: () => T): T;
-    // Sets a persistent "active root" that getActive() falls back to when no
-    // withActive scope is on the stack. Used by long-lived pageload/navigation
-    // roots so child spans (e.g. fetches) auto-parent to them. Optional so it is
-    // a non-breaking addition: a holder that does not implement it simply does
-    // not support active roots (callers invoke it as `holder.setActiveRoot?.(...)`).
+    /**
+     * Persistent "active root" that getActive() falls back to when no withActive scope is on the stack. Used by
+     * long-lived pageload/navigation roots so child spans (e.g. fetches) auto-parent to them. Optional; a holder that
+     * omits it simply has no active-root support.
+     */
     setActiveRoot?(span: Span | undefined): void;
 }
 

--- a/packages/core/src/tracing/sampler.ts
+++ b/packages/core/src/tracing/sampler.ts
@@ -15,8 +15,8 @@ export function resolveSampling(
         try {
             result = config.tracesSampler(ctx);
         } catch (error) {
-            // A throwing customer sampler must never propagate out of startSpan
-            // (it would break instrumented host calls like fetch). Fail closed.
+            // A throwing customer sampler must never propagate out of startSpan (it would break instrumented host calls
+            // like fetch). Fail closed.
             if (config.debug) console.error('Flare: tracesSampler threw, treating span as not sampled', error);
             return false;
         }

--- a/packages/core/src/tracing/traceparent.ts
+++ b/packages/core/src/tracing/traceparent.ts
@@ -16,7 +16,7 @@ export function parseTraceparent(header: string): { traceId: string; parentSpanI
     if (!HEX32.test(traceId) || traceId === ZERO32) return null;
     if (!HEX16.test(spanId) || spanId === ZERO16) return null;
     if (!HEX8.test(flags)) return null;
-    // trace-flags is a bit field (W3C). Only the low bit (sampled) is defined;
-    // current OTel SDKs also set the random-trace-id bit, emitting 03/09/etc.
+    // trace-flags is a W3C bit field. Only the low bit (sampled) is defined; current OTel SDKs also set the
+    // random-trace-id bit, emitting 03/09/etc, so mask instead of comparing.
     return { traceId, parentSpanId: spanId, sampled: (parseInt(flags, 16) & 0x01) === 1 };
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -5,14 +5,10 @@ export type AttributeValue = string | number | boolean | null | AttributeValue[]
 export type Attributes = Record<string, AttributeValue>;
 
 /**
- * An identified user passed to `Flare.setUser`. The four known fields project to the
- * report keys the Flare backend reads: `id`→`user.id`, `email`→`user.email`,
- * `fullName`→`user.full_name`, `ipAddress`→`client.address`. Any OTHER key is bundled
- * into `user.attributes`.
- *
- * Caveat: the open index signature means a misspelled known field (e.g. `fullname` or
- * `full_name` instead of `fullName`) does NOT raise a type error — it silently lands in
- * `user.attributes` rather than the identity key. Spell the four known fields exactly.
+ * An identified user passed to `Flare.setUser`. Known fields project to the backend keys: `id`->`user.id`,
+ * `email`->`user.email`, `fullName`->`user.full_name`, `ipAddress`->`client.address`. Any other key lands in
+ * `user.attributes`. Caveat: the open index signature means a misspelled known field (e.g. `full_name` for `fullName`)
+ * silently lands in `user.attributes` with no type error. Spell the four known fields exactly.
  */
 export type User = {
     id?: string | number;
@@ -47,11 +43,9 @@ export type Config = {
     tracesSampleRate: number;
     tracesSampler?: TracesSampler;
     /**
-     * URLs to which a W3C `traceparent` header may be attached on outgoing
-     * requests. Default (unset): same-origin + relative only. `[]` disables
-     * all injection. Each entry matches by String.includes (string) or
-     * RegExp.test. Note: attaching `traceparent` cross-origin forces a CORS
-     * preflight; the target server must allow the `traceparent` request header.
+     * URLs a W3C `traceparent` header may be attached to on outgoing requests. Default (unset): same-origin + relative
+     * only; `[]` disables all injection. Each entry matches by String.includes (string) or RegExp.test. Attaching
+     * cross-origin forces a CORS preflight; the target server must allow the `traceparent` request header.
      */
     tracePropagationTargets?: (string | RegExp)[];
     /** Idle-span: ms of no open child spans before a pageload/navigation root closes. Browser default 1000. */
@@ -131,7 +125,7 @@ export type SdkInfo = { name: string; version: string };
 
 export type Framework = { name: string; version?: string };
 
-// --- Logging ---
+// Logging
 
 export type AnyValue =
     | { stringValue: string }
@@ -180,7 +174,7 @@ export type BufferedLog = {
     resourceAttributes: Attributes;
 };
 
-// --- Tracing ---
+// Tracing
 
 export type SpanStatusCode = 0 | 1 | 2; // Unset | Ok | Error (OTel)
 
@@ -244,7 +238,7 @@ export type BufferedSpan = {
 export type OtelSpan = {
     traceId: string;
     spanId: string;
-    parentSpanId: string | null; // ALWAYS present; null for roots
+    parentSpanId: string | null; // always present; null for roots
     name: string;
     startTimeUnixNano: number;
     endTimeUnixNano: number;

--- a/packages/core/src/util/flatJsonStringify.ts
+++ b/packages/core/src/util/flatJsonStringify.ts
@@ -1,13 +1,13 @@
-// JSON.stringify throws on circular references. User-supplied glow data and addContext values can
-// realistically contain cycles (e.g. Vue/React component instances), so we walk the tree first and
-// replace any back-edges with the sentinel "[Circular]" before serialising.
+/**
+ * JSON.stringify but cycle-safe. User glow data / addContext values can contain cycles (Vue/React component
+ * instances), so back-edges are replaced with "[Circular]" before serialising.
+ */
 export function flatJsonStringify(json: object): string {
     return JSON.stringify(decycle(json));
 }
 
-// Restricted to literal object/null prototypes on purpose: class instances may have getters with
-// side effects or non-enumerable internals that we shouldn't traverse. They're left to JSON.stringify
-// to handle (typically by calling toJSON or returning {}).
+// Literal object/null prototypes only: class instances may have side-effecting getters or non-enumerable internals we
+// should not traverse. Those are left to JSON.stringify (typically toJSON or {}).
 function isPlainObject(value: unknown): value is Record<string, unknown> {
     if (typeof value !== 'object' || value === null) return false;
     const proto = Object.getPrototypeOf(value);
@@ -15,9 +15,8 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 }
 
 function decycle(root: unknown): unknown {
-    // `inPath` tracks ancestors on the current branch only (added on enter, removed on exit). Using a
-    // global "seen" set would mis-flag the same object referenced twice in different branches as
-    // circular, even though no cycle exists.
+    // `inPath` tracks ancestors on the current branch only (added on enter, removed on exit). A global "seen" set would
+    // mis-flag an object referenced twice in different branches as circular.
     const inPath = new WeakSet<object>();
 
     function clone(node: unknown): unknown {

--- a/packages/core/src/util/redactUrl.ts
+++ b/packages/core/src/util/redactUrl.ts
@@ -1,6 +1,5 @@
-// Matched against query-string keys (and, in framework SDKs, against prop/route-param keys).
-// Values for matching keys are replaced with [redacted] before the data is sent to Flare so
-// credentials/PII don't leak in error reports.
+// Matched against query-string keys (and, in framework SDKs, prop/route-param keys). Values for matching keys are
+// replaced with [redacted] before sending so credentials/PII don't leak in error reports.
 export const DEFAULT_URL_DENYLIST =
     /password|passwd|pwd|token|secret|authorization|\bauth\b|bearer|oauth|credentials?|cookie|api[-_]?key|private[-_]?key|session|csrf|xsrf|\bpin\b|\bssn\b|card[-_]?number|\bcvv\b/i;
 

--- a/packages/core/src/util/rejection.ts
+++ b/packages/core/src/util/rejection.ts
@@ -1,18 +1,14 @@
 /**
- * Shared unhandled-rejection routing. A rejection "reason" can be anything a
- * promise was rejected with: an Error, an Error-like object carrying a `.stack`,
- * a string, or a plain object. The browser `unhandledrejection` listener
- * (`@flareapp/js`) and the React Native engine rejection tracker
- * (`@flareapp/react-native`) need the SAME routing so a report looks identical
- * across SDKs, so it lives here instead of being copy-pasted (and drifting) per
- * client.
+ * Shared unhandled-rejection routing. A rejection reason can be anything a promise rejected with: an Error, a
+ * stack-bearing object, a string, or a plain object. The browser `unhandledrejection` listener (`@flareapp/js`) and the
+ * React Native rejection tracker (`@flareapp/react-native`) share this routing so reports look identical across SDKs.
  */
 
 export type RejectionReporter = {
     // Error / stack-bearing reasons: preserve the stack.
     reportSilently: (error: Error) => void;
-    // Stackless reasons: empty-stack `UnhandledRejection` shaping. May return a
-    // promise (core's does); `routeRejection` swallows any rejection from it.
+    // Stackless reasons: empty-stack `UnhandledRejection` shaping. May return a promise (core's does);
+    // `routeRejection` swallows any rejection from it.
     reportUnhandledRejection: (message: string) => unknown;
 };
 
@@ -21,8 +17,7 @@ export function describeRejectionReason(reason: unknown): string {
     if (typeof reason === 'string') return reason;
     if (reason && typeof reason === 'object') {
         const message = (reason as { message?: unknown }).message;
-        // An empty `.message` carries no signal; fall through to JSON.stringify so
-        // the report shows the object's actual shape instead of a blank message.
+        // An empty `.message` carries no signal; fall through to JSON.stringify so the report shows the object's shape.
         if (typeof message === 'string' && message) return message;
         try {
             return JSON.stringify(reason);
@@ -38,14 +33,10 @@ function hasStack(reason: unknown): reason is { stack: string } {
 }
 
 /**
- * Route a rejection reason to the reporter: an Error (or any stack-bearing
- * object) goes to `reportSilently` so the STACK survives; only a stackless
- * reason falls back to `reportUnhandledRejection` (string message, empty-stack
- * `UnhandledRejection` class). Any rejection from `reportUnhandledRejection`'s
- * returned promise is swallowed so a transport failure cannot itself surface as
- * an unhandled rejection. `reportSilently` is assumed not to throw synchronously
- * (core's does its work asynchronously); it is intentionally not wrapped, so a
- * synchronous throw there would propagate.
+ * Route a rejection reason: an Error (or any stack-bearing object) goes to `reportSilently` so the stack survives; a
+ * stackless reason falls back to `reportUnhandledRejection` (string message, empty-stack `UnhandledRejection`). Any
+ * rejection from `reportUnhandledRejection`'s promise is swallowed so a transport failure cannot itself surface as an
+ * unhandled rejection. `reportSilently` is assumed async and not wrapped, so a synchronous throw there would propagate.
  */
 export function routeRejection(reporter: RejectionReporter, reason: unknown): void {
     if (reason instanceof Error) {

--- a/packages/core/tests/logger.test.ts
+++ b/packages/core/tests/logger.test.ts
@@ -62,9 +62,8 @@ describe('Logger record/buffer', () => {
     });
 
     it('drops a single record larger than logFlushMaxBytes at capture', () => {
-        // Cap sits above a minimal record's serialized size (~140B incl. timestamp,
-        // severity, empty attribute maps) but below the 500-char record (~640B), so
-        // only the big one is dropped at capture.
+        // Cap sits above a minimal record (~140B) but below the 500-char record (~640B), so only the big one is
+        // dropped at capture.
         const logger = makeLogger(makeConfig({ logFlushMaxBytes: 300, maxLogBufferSize: 100 }));
         logger.info('x'.repeat(500));
         expect(logger.bufferLength()).toBe(0);
@@ -73,9 +72,8 @@ describe('Logger record/buffer', () => {
     });
 
     it('trims oldest records past maxLogBufferSize (keyless, so the count-cap flush no-ops)', () => {
-        // With a key, hitting the count cap would flush-and-clear, so the buffer
-        // would never accumulate to the cap. key: null makes flush no-op, so the
-        // hard trim is what bounds the buffer — which is exactly what we assert.
+        // With a key, hitting the count cap would flush-and-clear so the buffer never reaches the cap. key: null makes
+        // flush a no-op, so the hard trim is what bounds the buffer, which is what we assert.
         const logger = makeLogger(makeConfig({ key: null, maxLogBufferSize: 3, logFlushIntervalMs: 999_999 }));
         for (let i = 0; i < 10; i++) logger.info(`m${i}`);
         expect(logger.bufferLength()).toBe(3);
@@ -169,7 +167,7 @@ describe('Logger triggers', () => {
         expect(bodies).toContainEqual({ stringValue: 'small-1' });
         expect(bodies).toContainEqual({ stringValue: 'small-2' });
         expect(bodies.some((b) => 'stringValue' in b && b.stringValue.length > 1000)).toBe(false);
-        // The over-budget record is not dropped — a backgrounded tab may resume.
+        // The over-budget record is not dropped; a backgrounded tab may resume.
         expect(logger.bufferLength()).toBe(1);
     });
 
@@ -181,8 +179,8 @@ describe('Logger triggers', () => {
         );
         logger.info('x'.repeat(5000)); // > keepaliveMaxBytes, < logFlushMaxBytes
 
-        // visibilitychange:hidden on a backgrounded (not unloading) tab. Nothing fits
-        // the keepalive budget, so no envelope ships and the record must survive.
+        // visibilitychange:hidden on a backgrounded (not unloading) tab. Nothing fits the keepalive budget, so no
+        // envelope ships and the record must survive.
         logger.flush({ keepalive: true });
         expect(api.logEnvelopes).toHaveLength(0);
         expect(logger.bufferLength()).toBe(1);
@@ -213,9 +211,8 @@ describe('Logger triggers', () => {
 
     it('weight cap flushes-and-clears with a key (ships, does not trim away)', () => {
         const api = new FakeApi();
-        // logFlushMaxBytes chosen so a SINGLE record stays under it (no oversized
-        // drop at capture), but TWO cross it — so the 2nd push fires the weight
-        // trigger. Each ~250-char message serializes to ~380B incl. envelope keys.
+        // logFlushMaxBytes chosen so a single record stays under it (no oversized drop), but two cross it, so the 2nd
+        // push fires the weight trigger. Each ~250-char message serializes to ~380B incl. envelope keys.
         const logger = makeLogger(
             makeConfig({ logFlushMaxBytes: 700, maxLogBufferSize: 100, logFlushIntervalMs: 999_999 }),
             api,

--- a/packages/core/tests/rejection.test.ts
+++ b/packages/core/tests/rejection.test.ts
@@ -12,9 +12,8 @@ describe('describeRejectionReason', () => {
     });
 
     test('falls through to JSON for an object with an empty .message', () => {
-        // An empty message is useless; the serialized object carries more signal.
-        // This locks the deliberate divergence from the pre-refactor browser path,
-        // which returned the empty string.
+        // An empty message is useless; the serialized object carries more signal. Locks the deliberate divergence from
+        // the pre-refactor browser path, which returned the empty string.
         expect(describeRejectionReason({ message: '', code: 42 })).toBe('{"message":"","code":42}');
     });
 

--- a/packages/core/tests/traceparent.test.ts
+++ b/packages/core/tests/traceparent.test.ts
@@ -22,8 +22,8 @@ describe('parseTraceparent', () => {
     });
 
     it('reads the sampled bit from the trace-flags bit field', () => {
-        // trace-flags is a bit field; only bit 0 (sampled) is defined. OTel SDKs also
-        // set bit 1 (random-trace-id), emitting 03/09 — those are still sampled.
+        // trace-flags is a bit field; only bit 0 (sampled) is defined. OTel SDKs also set bit 1 (random-trace-id),
+        // emitting 03/09, which are still sampled.
         expect(parseTraceparent(`00-${TID}-${SID}-00`)?.sampled).toBe(false);
         expect(parseTraceparent(`00-${TID}-${SID}-01`)?.sampled).toBe(true);
         expect(parseTraceparent(`00-${TID}-${SID}-02`)?.sampled).toBe(false); // random bit only

--- a/packages/core/tests/tracer.test.ts
+++ b/packages/core/tests/tracer.test.ts
@@ -199,8 +199,8 @@ describe('Tracer.startSpan', () => {
     });
 
     it('runs the sampler for a plain parent with unknown recording state (no default-to-recording)', () => {
-        // A manually stitched {traceId, spanId} parent carries no recording decision.
-        // With tracesSampleRate 0 the child must be sampled out, not assumed recording.
+        // A manually stitched {traceId, spanId} parent carries no recording decision, so at tracesSampleRate 0 the
+        // child must be sampled out, not assumed recording.
         const tracer = makeTracer(config({ tracesSampleRate: 0 }));
         const child = tracer.startSpan('child', {
             parent: { traceId: 'f'.repeat(32), spanId: 'e'.repeat(16) },
@@ -274,8 +274,8 @@ describe('defaultNowNano', () => {
     });
 
     it('falls back to Date.now() when performance.timeOrigin is missing (no NaN)', () => {
-        // Some environments (older Safari, some Hermes builds) expose performance.now
-        // without timeOrigin; timeOrigin + now() would be NaN there.
+        // Some environments (older Safari, some Hermes builds) expose performance.now without timeOrigin; timeOrigin +
+        // now() would be NaN there.
         vi.stubGlobal('performance', { now: () => 5 });
         const before = Date.now() * 1e6;
         const value = defaultNowNano();

--- a/packages/core/tests/tracerWithSpan.test.ts
+++ b/packages/core/tests/tracerWithSpan.test.ts
@@ -124,8 +124,8 @@ describe('Tracer.withSpan', () => {
     it('detects a thenable (not just instanceof Promise) and sets Error on rejection', async () => {
         const tracer = makeTracer();
         let captured: Span | undefined;
-        // A thenable that is NOT a Promise instance; instanceof Promise would miss it,
-        // take the sync path, and leave status Unset (code 0) — this test catches that.
+        // A thenable that is not a Promise instance; instanceof Promise would miss it, take the sync path, and leave
+        // status Unset (code 0). This test catches that.
         const rejecting = Promise.reject(new Error('thenable-boom'));
         // eslint-disable-next-line unicorn/no-thenable
         const thenable = { then: (res: unknown, rej: unknown) => rejecting.then(res as never, rej as never) }; // oxlint-disable-line unicorn/no-thenable

--- a/packages/electron/src/main/ElectronFlare.ts
+++ b/packages/electron/src/main/ElectronFlare.ts
@@ -1,12 +1,16 @@
-import { Api, Flare as CoreFlare, GlobalScopeProvider, USER_IDENTITY_KEYS, userIdentityAttributes, type Config, type Report } from '@flareapp/core';
+import {
+    Api,
+    Flare as CoreFlare,
+    GlobalScopeProvider,
+    USER_IDENTITY_KEYS,
+    userIdentityAttributes,
+    type Config,
+    type Report,
+} from '@flareapp/core';
 import type { App, IpcMain } from 'electron';
 
 import { CLIENT_VERSION } from '../env';
-import {
-    DEFAULT_ELECTRON_OPTIONS,
-    type ElectronOptions,
-    type ResolvedElectronOptions,
-} from '../types';
+import { DEFAULT_ELECTRON_OPTIONS, type ElectronOptions, type ResolvedElectronOptions } from '../types';
 import { collectElectronAppAttributes, makeElectronContextCollector } from './collectElectron';
 import { ElectronDiskFileReader } from './ElectronDiskFileReader';
 import { ElectronFlushScheduler } from './ElectronFlushScheduler';
@@ -37,9 +41,8 @@ export class ElectronFlare extends CoreFlare {
     private app: AppLike;
     private ipcMain: IpcMain;
     private options: ResolvedElectronOptions = { ...DEFAULT_ELECTRON_OPTIONS };
-    // Held separately because CoreFlare's scopeProvider is private; receiveRendererReport needs it
-    // to stamp main-side user identity onto forwarded renderer reports, which bypass core's report()
-    // pipeline (and so do not pick up pendingAttributes automatically).
+    // Held separately (CoreFlare's scopeProvider is private): receiveRendererReport stamps main-side
+    // user identity onto forwarded reports, which bypass core's report() pipeline and pendingAttributes.
     private mainScope: GlobalScopeProvider;
     private isLit = false;
     private handlerManager: ProcessHandlerManager;
@@ -78,9 +81,9 @@ export class ElectronFlare extends CoreFlare {
             onReport: (report) => this.receiveRendererReport(report),
         });
 
-        // Crash observers (like the IPC receiver) attach immediately: they only observe, and any
-        // report they produce drops harmlessly until light() sets a key. The fatal process handlers,
-        // by contrast, gate on light() because they alter the process's crash behavior.
+        // Crash observers attach immediately (like the IPC receiver): they only observe, and any
+        // report drops harmlessly until light() sets a key. Fatal process handlers gate on light()
+        // instead, since they alter the process's crash behavior.
         this.reconcileCrashListeners();
     }
 
@@ -140,7 +143,7 @@ export class ElectronFlare extends CoreFlare {
         this.flushScheduler.dispose();
     }
 
-    /** Attach or detach the process-gone listeners to match options.captureRenderProcessGone. Idempotent. */
+    /** Attach/detach the process-gone listeners to match options.captureRenderProcessGone. Idempotent. */
     private reconcileCrashListeners(): void {
         const want = this.options.captureRenderProcessGone;
         const attached = this.renderGoneHandler !== null;
@@ -221,9 +224,9 @@ export class ElectronFlare extends CoreFlare {
 
     /** Overlay main-authoritative config + Electron metadata + user identity (from the main scope) onto a forwarded report, then send. */
     private receiveRendererReport(report: Report): Promise<void> {
-        // User identity is main-authoritative, exactly like the config fields below: a renderer
-        // must never set identity the main process did not, and a partial main identity must not
-        // be mixed with leftover renderer keys. Clear every identity key first, then stamp main's.
+        // User identity is main-authoritative (like the config fields below): a renderer must never
+        // set identity main did not, and partial main identity must not mix with leftover renderer
+        // keys. Clear every identity key first, then stamp main's.
         for (const key of USER_IDENTITY_KEYS) delete report.attributes[key];
         Object.assign(
             report.attributes,
@@ -231,10 +234,9 @@ export class ElectronFlare extends CoreFlare {
             userIdentityAttributes(this.mainScope.active()),
         );
 
-        // Config-derived fields are main-authoritative. Always overlay them so a renderer can never
-        // supply its own value: write main's value when set, otherwise delete any renderer-supplied
-        // key. This makes the "configure once, in main" guarantee hold even when main left a field
-        // unset (an unconditional overlay; the renderer's value is never trusted for these).
+        // Config-derived fields are main-authoritative: always overlay (main's value when set,
+        // else delete the renderer-supplied key) so "configure once, in main" holds even when main
+        // left a field unset. The renderer's value is never trusted here.
         overlayOrDelete(report.attributes, 'service.stage', this.mainStage);
         overlayOrDelete(report.attributes, 'service.version', this.mainVersion);
         if (this.mainSourcemapVersionId) {

--- a/packages/electron/src/main/collectElectron.ts
+++ b/packages/electron/src/main/collectElectron.ts
@@ -6,11 +6,9 @@ import type { App } from 'electron';
 type AppLike = Pick<App, 'getName' | 'getVersion' | 'getLocale' | 'isReady'> & { isPackaged: boolean };
 
 /**
- * App + runtime attributes that are safe to overlay onto ANY report regardless of origin.
- * Reused by both the collector (main errors) and the IPC receiver (forwarded renderer reports).
- *
- * Intentionally does NOT include per-process fields like `flare.entry_point.type` or `process.type`
- * so that forwarded renderer reports keep their own `flare.entry_point.type: 'web'` intact.
+ * App + runtime attributes safe to overlay onto any report regardless of origin. Reused by both
+ * the collector (main errors) and the IPC receiver (forwarded renderer reports). Excludes per-process
+ * fields like `flare.entry_point.type` / `process.type` so forwarded renderer reports keep their own.
  */
 export function collectElectronAppAttributes(app: AppLike): Attributes {
     const versions = process.versions as Record<string, string | undefined>;
@@ -32,7 +30,7 @@ export function collectElectronAppAttributes(app: AppLike): Attributes {
         try {
             attrs['app.locale'] = app.getLocale();
         } catch {
-            // ignore; locale stays unset
+            // locale stays unset
         }
     }
 
@@ -42,8 +40,8 @@ export function collectElectronAppAttributes(app: AppLike): Attributes {
 /** Build the ContextCollector core calls on every main-process report. */
 export function makeElectronContextCollector(app: AppLike): ContextCollector {
     return (_config: Readonly<Config>): Attributes => ({
-        // Per-process fields: these reflect the MAIN process and are intentionally only applied to
-        // main-origin reports (not forwarded renderer reports, which carry their own entry_point.type).
+        // Per-process fields reflect the main process; applied only to main-origin reports, not
+        // forwarded renderer reports (which carry their own entry_point.type).
         'flare.entry_point.type': 'server',
         'process.type': (process as { type?: string }).type ?? 'browser',
         ...collectElectronAppAttributes(app),

--- a/packages/electron/src/main/ipcReceiver.ts
+++ b/packages/electron/src/main/ipcReceiver.ts
@@ -23,7 +23,7 @@ export function defaultTrustPolicy(frame: SenderFrame, opts: ResolvedElectronOpt
     }
     const scheme = parsed.protocol.replace(/:$/, '');
     if (scheme === 'file') {
-        // file: with a foreign host is unusual and untrusted; accept only host-less or localhost file URLs.
+        // A foreign host on file: is untrusted; accept only host-less or localhost file URLs.
         return parsed.hostname === '' || parsed.hostname === 'localhost';
     }
     const isLoopback =
@@ -48,10 +48,9 @@ function isTrusted(frame: SenderFrame | undefined, opts: ResolvedElectronOptions
 }
 
 /**
- * Minimal top-level structural guard for a parsed report. This is intentionally NOT an exhaustive
- * validator of every StackFrame / SpanEvent: the renderer builds the report with our own Flare code,
- * and a compromised renderer could forge any valid-looking shape anyway. The real security boundary
- * is the sender-trust check plus the byte-size cap; this guard only rejects obviously-wrong payloads.
+ * Minimal top-level structural guard for a parsed report, not an exhaustive StackFrame/SpanEvent
+ * validator: a compromised renderer could forge any valid-looking shape anyway. The security boundary
+ * is the sender-trust check plus the byte-size cap; this only rejects obviously-wrong payloads.
  */
 function isReportShape(value: unknown): value is Report {
     if (typeof value !== 'object' || value === null) {

--- a/packages/electron/src/main/processHandlers.ts
+++ b/packages/electron/src/main/processHandlers.ts
@@ -9,9 +9,9 @@ type FatalOptions = {
 };
 
 /**
- * Fatal callbacks for Electron main. Mirrors @flareapp/node's buildFatalCallbacks but exits via
- * the injected `exit` (defaulting to app.exit at the call site), which is immediate and skips
- * before-quit/will-quit, correct after an uncaught exception.
+ * Fatal callbacks for Electron main. Mirrors @flareapp/node's buildFatalCallbacks but exits via the
+ * injected `exit` (app.exit at the call site), which is immediate and skips before-quit/will-quit,
+ * correct after an uncaught exception.
  */
 export function buildFatalCallbacks(flare: Flare, getOpts: () => FatalOptions, exit: (code: number) => void) {
     return {
@@ -26,10 +26,8 @@ export function buildFatalCallbacks(flare: Flare, getOpts: () => FatalOptions, e
             } catch {
                 // swallow
             }
-            // Only drain other in-flight reports when we're about to exit. In
-            // 'report' mode the process keeps running, so those reports settle
-            // on their own and flushing here would just waste time. Mirrors
-            // onRejection.
+            // Only drain other in-flight reports when about to exit. In 'report' mode the process
+            // keeps running, so they settle on their own. Mirrors onRejection.
             if (opts.uncaughtExceptionMode === 'report-and-exit') {
                 await flare.flush(opts.shutdownTimeoutMs);
                 exit(1);
@@ -60,9 +58,8 @@ type Callbacks = {
 };
 
 /**
- * Owns the lifecycle of the two process-level error listeners for the Electron main process.
- * Mirrors node's ProcessHandlerManager. Attach/detach the two process listeners, reconciling
- * against the desired modes.
+ * Owns the lifecycle of the two process-level error listeners for the Electron main process,
+ * reconciling attach/detach against the desired modes. Mirrors node's ProcessHandlerManager.
  */
 export class ProcessHandlerManager {
     private uncaughtHandler: ((err: unknown, origin: string) => void) | null = null;

--- a/packages/electron/tests/electronFlare.test.ts
+++ b/packages/electron/tests/electronFlare.test.ts
@@ -11,7 +11,7 @@ function fakeApp() {
         isReady: () => true,
         isPackaged: false,
         on: vi.fn(),
-        // off is needed once Task 11 makes the constructor attach crash listeners and dispose() detach them.
+        // off is needed: the constructor attaches crash listeners and dispose() detaches them.
         off: vi.fn(),
     };
 }
@@ -253,8 +253,8 @@ describe('ElectronFlare', () => {
 
         const handler = ipcMain.handlers['flare:report'];
         const reportJson = JSON.stringify({ seenAtUnixNano: 2, stacktrace: [], events: [], attributes: {} });
-        // A report from a trusted file: sender should be accepted (trustedProtocols.includes must not throw,
-        // byte cap must still be active). If defaults were clobbered this line would throw.
+        // A trusted file: sender is accepted; if defaults were clobbered, trustedProtocols.includes
+        // would throw here.
         await handler({ senderFrame: { url: 'file:///a.html' } }, reportJson);
 
         expect(sent.length).toBe(1);

--- a/packages/electron/tests/reactInjection.test.ts
+++ b/packages/electron/tests/reactInjection.test.ts
@@ -44,8 +44,8 @@ describe('@flareapp/react/inject reports through an injected RendererFlare', () 
         const reactCtx = parsed.attributes['context.custom'].react;
         expect(Array.isArray(reactCtx.componentStack)).toBe(true);
         expect(reactCtx.componentStack.join(' ')).toContain('App');
-        // No-root is guarded authoritatively by react's dist-grep (verify:inject); importing
-        // the inject entry here additionally must not have installed any global flare singleton.
+        // react's dist-grep (verify:inject) guards no-root; here we also check the inject entry
+        // installed no global flare singleton.
         expect((globalThis as Record<string, unknown>).flare).toBeUndefined();
     });
 });

--- a/packages/js/src/browser/FetchFileReader.ts
+++ b/packages/js/src/browser/FetchFileReader.ts
@@ -1,28 +1,17 @@
 import type { FileReader } from '@flareapp/core';
 
 /**
- * Browser `FileReader` implementation that fetches source files over HTTP(S).
- *
- * Wired into `@flareapp/js`'s singleton so the stack-trace builder can pull
- * the original source for each frame and render a code snippet around the
- * offending line. The source URL comes from the frame (usually the URL of
- * the JS bundle that produced the error, post-sourcemap resolution).
+ * Browser `FileReader` that fetches source files over HTTP(S) so the stack-trace builder can
+ * render a code snippet around the offending line. Source URL comes from the frame (usually the
+ * JS bundle URL, post-sourcemap resolution). `read()` returns null on any failure, never throws.
  *
  * Three safety gates:
- *
- * 1. **Scheme allowlist.** Only `http:` and `https:` URLs are fetched. Other
- *    schemes (`chrome-extension://`, `file://`, `blob:`, `data:`) return
- *    `null` immediately. This avoids surprise privilege boundaries (e.g.,
- *    pages should not read extension-internal files) and dodges CORS/CSP
- *    walls that would error noisily.
- * 2. **Status check.** Only `200 OK` responses are used. 3xx redirects are
- *    handled transparently by `fetch`; 4xx/5xx fall back to `null` so the
- *    snippet is simply omitted from the report.
- * 3. **Catch-all.** Network failures, CORS errors, and aborted requests
- *    return `null`. We never let a source-fetch failure leak as an error
- *    that the consumer page would see.
- *
- * The `read()` contract returns `null` on any failure path, never throws.
+ * 1. Scheme allowlist: only http(s) is fetched. Other schemes (chrome-extension://, file://,
+ *    blob:, data:) return null, avoiding privilege boundaries and noisy CORS/CSP walls.
+ * 2. Status check: only 200 OK is used. fetch handles 3xx transparently; 4xx/5xx return null so
+ *    the snippet is omitted.
+ * 3. Catch-all: network/CORS/abort failures return null; a source-fetch failure never leaks to
+ *    the consumer page.
  */
 export class FetchFileReader implements FileReader {
     read(url: string): Promise<string | null> {

--- a/packages/js/src/browser/catchWindowErrors.ts
+++ b/packages/js/src/browser/catchWindowErrors.ts
@@ -1,9 +1,9 @@
-// Wires up global `error` and `unhandledrejection` listeners. Reports are routed through
-// `window.flare`, which the host app must assign (see Flare.light()/configure()). If the global
-// is not present (e.g. flare not initialised yet), events are silently dropped rather than queued.
-
 import { routeRejection, type RejectionReporter } from '@flareapp/core';
 
+/**
+ * Wire up global `error` and `unhandledrejection` listeners, routing reports through `window.flare`
+ * (assigned by Flare.light()/configure()). Events are dropped, not queued, when the global is absent.
+ */
 export function catchWindowErrors() {
     if (typeof window === 'undefined') {
         return;
@@ -22,8 +22,8 @@ export function catchWindowErrors() {
         const flare = (window as unknown as { flare?: RejectionReporter }).flare;
         if (!flare) return;
 
-        // Shared routing (Error/stack-bearing -> reportSilently, stackless ->
-        // reportUnhandledRejection); same path the RN engine tracker uses.
+        // Shared routing: Error/stack-bearing -> reportSilently, stackless ->
+        // reportUnhandledRejection. Same path the RN engine tracker uses.
         routeRejection(flare, event.reason);
     });
 }

--- a/packages/js/src/browser/context/collectBrowserSpanContext.ts
+++ b/packages/js/src/browser/context/collectBrowserSpanContext.ts
@@ -4,11 +4,10 @@ import { browserEntryPoint } from './collectBrowser';
 import request from './request';
 
 /**
- * The lean context a browser pageload/navigation ROOT span carries: entry-point
- * plus request identity (url.full, user_agent.original, referrer, ready_state),
- * redacted. Deliberately excludes cookies, structured query params (requestData),
- * and host.name (resource-level, sourced separately). Captured at span START so a
- * long-lived root reflects the page it represents, not the page current at close.
+ * Lean context a browser pageload/navigation root span carries: entry-point plus request identity
+ * (url.full, user_agent.original, referrer, ready_state), redacted. Excludes cookies, structured
+ * query params (requestData), and host.name (resource-level, sourced separately). Captured at span
+ * start so a long-lived root reflects the page it represents, not the page current at close.
  */
 export const collectBrowserSpanContext: ContextCollector = (config: Readonly<Config>): Attributes => {
     if (typeof window === 'undefined') {

--- a/packages/js/src/index.ts
+++ b/packages/js/src/index.ts
@@ -33,5 +33,5 @@ export type {
 } from '@flareapp/core';
 export { convertToError, DEFAULT_URL_DENYLIST, redactUrlQuery, resolveDenylist } from '@flareapp/core';
 
-/** @deprecated use redactUrlQuery instead — same behavior, more honest name */
+/** @deprecated use redactUrlQuery instead - same behavior, more honest name */
 export { redactUrlQuery as redactFullPath } from '@flareapp/core';

--- a/packages/js/src/tracing/IdleRootController.ts
+++ b/packages/js/src/tracing/IdleRootController.ts
@@ -19,11 +19,10 @@ export type IdleRootDeps = {
 type Timer = ReturnType<typeof setTimeout> | null;
 
 /**
- * Owns one root span's idle lifecycle. The root stays open while child spans in
- * its trace are active; it closes after `idleTimeout` of no open children
- * (trimmed to the last child's end), a `finalTimeout` hard cap, or a
- * `childSpanTimeout` stuck-child cap. Deps are injected so it is unit-testable
- * without real timers or a real tracer.
+ * Owns one root span's idle lifecycle. The root stays open while child spans in its trace are
+ * active; it closes after `idleTimeout` of no open children (trimmed to the last child's end), a
+ * `finalTimeout` hard cap, or a `childSpanTimeout` stuck-child cap. Deps are injected so it is
+ * unit-testable without real timers or a real tracer.
  */
 export class IdleRootController {
     private openChildren = 0;
@@ -64,15 +63,14 @@ export class IdleRootController {
         if (phase === 'start') {
             this.openChildren++;
             this.clearIdle();
-            // childSpanTimeout is anchored to the start of a non-empty period (the 0->1
-            // transition), not to each individual child; a continuously-busy root force-ends
-            // childSpanTimeout ms after the batch began.
+            // childSpanTimeout is anchored to the 0->1 transition, not each child; a continuously
+            // busy root force-ends childSpanTimeout ms after the batch began.
             if (this.openChildren === 1) this.armChildTimeout();
         } else {
             this.openChildren = Math.max(0, this.openChildren - 1);
-            // endTimeUnixNano is 0 (SpanImpl's unset sentinel) until end() runs; end() sets it
-            // before dispatching this event, so a real child always has a non-zero value here.
-            // `||` treats the 0 sentinel as "unset" and falls back to now(), matching SpanImpl.
+            // endTimeUnixNano is 0 (SpanImpl's unset sentinel) until end() runs, which sets it
+            // before dispatching this event, so a real child is non-zero here. `||` treats the 0
+            // sentinel as unset and falls back to now(), matching SpanImpl.
             this.lastChildEndTime = span.endTimeUnixNano || this.deps.now();
             if (this.openChildren === 0) {
                 this.clearChildTimeout();

--- a/packages/js/src/tracing/browserTracing.ts
+++ b/packages/js/src/tracing/browserTracing.ts
@@ -15,8 +15,8 @@ export type BrowserTracingFlare = {
 let controller: IdleRootController | null = null;
 let uninstall: (() => void) | null = null;
 let lastPath = '';
-// Page-global: a document's real pageload window can only be traced once. Guards
-// against re-enabling after a disable fabricating a second backdated pageload.
+// Page-global: a document's real pageload window can only be traced once. Guards against
+// re-enabling after a disable fabricating a second backdated pageload.
 let pageloadTraced = false;
 
 function resolveTimeouts(config: Config): IdleTimeouts {
@@ -50,9 +50,8 @@ function startRoot(flare: BrowserTracingFlare, spanType: string, startTimeUnixNa
             resolveTimeouts(flare.config),
         );
     } catch (error) {
-        // Instrumentation must never break the app. If root creation or the idle
-        // controller fails, undo any partial state (end the orphaned span, clear
-        // the active root) and leave tracing inert rather than throwing.
+        // Instrumentation must never break the app. On failure, undo partial state (end the
+        // orphaned span, clear the active root) and leave tracing inert rather than throwing.
         controller = null;
         try {
             root?.end();
@@ -83,10 +82,9 @@ function onUrlChanged(flare: BrowserTracingFlare): void {
 }
 
 /**
- * Start framework-agnostic browser tracing: a backdated `browser_pageload` root,
- * plus `browser_navigation` roots on SPA route changes detected by patching the
- * History API (`pushState`/`replaceState`) and listening for `popstate`.
- * No-op outside a browser. Idempotent (a second call while running is ignored).
+ * Start framework-agnostic browser tracing: a backdated `browser_pageload` root, plus
+ * `browser_navigation` roots on SPA route changes (History API `pushState`/`replaceState` patch
+ * plus `popstate`). No-op outside a browser. Idempotent.
  */
 export function startBrowserTracing(flare: BrowserTracingFlare): void {
     if (typeof window === 'undefined' || typeof history === 'undefined' || typeof location === 'undefined') return;
@@ -105,10 +103,9 @@ export function startBrowserTracing(flare: BrowserTracingFlare): void {
     startRoot(flare, 'browser_pageload', pageloadStart);
 
     const handle = (): void => {
-        // A third party may wrap history.pushState/replaceState on top of ours,
-        // in which case unfill cannot restore on stop and this closure leaks.
-        // `uninstall` doubles as the installed flag, so the leaked wrapper stays
-        // inert instead of starting roots and arming timers while tracing is off.
+        // A third party may wrap history.pushState/replaceState on top of ours, so unfill can't
+        // restore on stop and this closure leaks. `uninstall` doubles as the installed flag, so the
+        // leaked wrapper stays inert instead of starting roots and arming timers while tracing is off.
         if (!uninstall) return;
         try {
             onUrlChanged(flare);
@@ -126,10 +123,9 @@ export function startBrowserTracing(flare: BrowserTracingFlare): void {
     fill(history as unknown as Record<string, unknown>, 'replaceState', wrap);
     window.addEventListener('popstate', handle);
 
-    // On page teardown the open root must be force-ended (Sentry does the same on
-    // pagehide) and then keepalive-flushed from HERE: BrowserFlushScheduler's own
-    // visibilitychange listener registered earlier, so by the time it flushed the
-    // just-ended root was not buffered yet. Re-flushing an empty buffer is a no-op.
+    // On page teardown the open root must be force-ended and then keepalive-flushed from here:
+    // BrowserFlushScheduler's own visibilitychange listener registered earlier, so when it flushed
+    // the just-ended root was not buffered yet. Re-flushing an empty buffer is a no-op.
     const endRootAndFlush = (): void => {
         if (controller && !controller.isEnded) {
             try {
@@ -162,7 +158,7 @@ export function startBrowserTracing(flare: BrowserTracingFlare): void {
 
 /**
  * Stop browser tracing: end the active root and restore the History API. Idempotent.
- * Page-global singleton: stops whatever tracing session is active, not a per-Flare-instance session.
+ * Page-global singleton: stops whatever session is active, not a per-Flare-instance one.
  */
 export function stopBrowserTracing(): void {
     if (controller && !controller.isEnded) controller.endNow();

--- a/packages/js/src/tracing/createPatcher.ts
+++ b/packages/js/src/tracing/createPatcher.ts
@@ -6,17 +6,16 @@ type Wrapped<F> = F & { __flare_original__?: F };
 export type MethodPatch = { name: string; wrap: (original: unknown) => unknown };
 
 /**
- * Own ONE `installed` flag across a set of methods patched on the same target
- * object, so a multi-method patch (e.g. XHR's open/setRequestHeader/send) installs
- * and restores atomically. A per-method flag, or none at all relying only on
- * `fill`'s own idempotency tag, is unsafe once more than one method shares state:
- * if a third party wraps just ONE of the methods on top of ours (e.g. `send`), the
- * others would restore to native while the leaked one stays live, corrupting the
- * state the methods share (XHR's `open` populates state that `send` depends on).
+ * Own one `installed` flag across a set of methods patched on the same target object, so a
+ * multi-method patch (e.g. XHR's open/setRequestHeader/send) installs and restores atomically.
+ * A per-method flag (or relying only on `fill`'s idempotency tag) is unsafe once methods share
+ * state: if a third party wraps just one method on top of ours, the others restore to native
+ * while the leaked one stays live, corrupting shared state (XHR's `open` populates what `send`
+ * depends on).
  *
- * The target is passed on every `install`/`uninstall` call rather than captured at
- * creation, since callers re-derive it fresh each time (`globalThis.fetch` may not
- * exist yet at SSR; `XMLHttpRequest.prototype` is looked up from the current global).
+ * Target is passed on every `install`/`uninstall` rather than captured at creation, since callers
+ * re-derive it fresh (`globalThis.fetch` may not exist yet at SSR; `XMLHttpRequest.prototype` is
+ * looked up from the current global).
  */
 export function createPatcher() {
     let installed = false;
@@ -37,14 +36,12 @@ export function createPatcher() {
         },
 
         /**
-         * Restore every patched method on `target`, but only if ALL of them are still
-         * cleanly restorable: for each, the current value is either not a function, or
-         * still carries `__flare_original__` (our wrapper is still the top of its
-         * chain). If ANY method has a third-party wrapper on top of ours, restore
-         * NOTHING and keep `installed` true: our wrappers are all still live in their
-         * chains and stay inert via their own `enableTracing` check, so tracing is
-         * correctly off now and correctly resumes on the next `install` (which no-ops,
-         * since the wrappers are already in place), with no double-wrapping.
+         * Restore every patched method on `target`, but only if all are still cleanly restorable:
+         * each current value is either not a function, or still carries `__flare_original__` (our
+         * wrapper is still the top of its chain). If any method has a third-party wrapper on top of
+         * ours, restore nothing and keep `installed` true: our wrappers stay live in their chains
+         * and inert via their own `enableTracing` check, so tracing is off now and resumes on the
+         * next `install` (a no-op, since the wrappers are already in place) with no double-wrapping.
          */
         uninstall(target: Record<string, unknown>): void {
             if (!installed) return;

--- a/packages/js/src/tracing/httpRequestSpan.ts
+++ b/packages/js/src/tracing/httpRequestSpan.ts
@@ -24,7 +24,7 @@ export function safeAbsolute(url: string, origin: string): URL | null {
     }
 }
 
-/** True when `abs` targets one of Flare's own ingest endpoints (never traced). Callers parse the URL once via `safeAbsolute` and pass the result. */
+/** True when `abs` targets one of Flare's own ingest endpoints (never traced). */
 export function isFlareIngestUrl(abs: URL | null, config: Config): boolean {
     if (!abs) return false;
     return [config.ingestUrl, config.logsIngestUrl, config.tracesIngestUrl].some(
@@ -33,8 +33,8 @@ export function isFlareIngestUrl(abs: URL | null, config: Config): boolean {
 }
 
 /**
- * Build the shared request-span attributes for a fetch/XHR call. `url.full` is
- * redacted the same way error reports are, so tokens/reset codes never leak.
+ * Shared request-span attributes for a fetch/XHR call. `url.full` is redacted the same way error
+ * reports are, so tokens/reset codes never leak.
  */
 export function requestSpanAttributes(method: string, abs: URL | null, url: string, config: Config): Attributes {
     return {
@@ -46,12 +46,10 @@ export function requestSpanAttributes(method: string, abs: URL | null, url: stri
 }
 
 /**
- * The success/completion mapping shared by fetch and XHR: record the status code and
- * mark the span as an error on a 5xx. `zeroIsError` additionally maps status 0 to an
- * error. XHR passes it only for http(s) URLs, where status 0 at DONE is always a
- * network/CORS failure or abort; for file:// and custom schemes a successful response
- * is also status 0, so it is not mapped to error there. Fetch never passes it (an
- * opaque no-cors response is status 0 but not an error).
+ * Completion mapping shared by fetch and XHR: record the status and mark an error on 5xx.
+ * `zeroIsError` additionally maps status 0 to error. XHR passes it only for http(s), where status
+ * 0 at DONE is always a network/CORS failure or abort; file:// and custom schemes return 0 on
+ * success, so it isn't set there. Fetch never passes it (an opaque no-cors response is 0, not error).
  */
 export function endHttpRequestSpan(span: Span, status: number, opts?: { zeroIsError?: boolean }): void {
     span.setAttribute('http.response.status_code', status);
@@ -59,15 +57,15 @@ export function endHttpRequestSpan(span: Span, status: number, opts?: { zeroIsEr
     span.end();
 }
 
-/** The error-finish shared by fetch and XHR: mark the span as an error and end it. */
+/** Error-finish shared by fetch and XHR: mark the span an error and end it. */
 export function finishHttpSpanError(span: Span, error: unknown): void {
     span.setStatus({ code: 2, message: error instanceof Error ? error.message : String(error) });
     span.end();
 }
 
 /**
- * The propagation gate + `traceparent` header build shared by fetch and XHR. Returns
- * null when `shouldPropagate` rejects the URL (caller then skips header injection).
+ * Propagation gate plus `traceparent` build shared by fetch and XHR. Returns null when
+ * `shouldPropagate` rejects the URL (caller then skips header injection).
  */
 export function traceparentFor(
     span: Span,

--- a/packages/js/src/tracing/instrumentFetch.ts
+++ b/packages/js/src/tracing/instrumentFetch.ts
@@ -24,10 +24,9 @@ function resolveRequest(input: FetchInput, init: RequestInit | undefined): { met
 }
 
 /**
- * Build a fetch replacement that opens a `browser_fetch` span per call, injects
- * `traceparent` on propagation-eligible URLs, and ends the span on settle.
- * Pure factory: `origin` is injected (node test env has no `location`), so this
- * is directly unit-testable without a browser.
+ * Build a fetch replacement that opens a `browser_fetch` span per call, injects `traceparent` on
+ * propagation-eligible URLs, and ends the span on settle. Pure factory: `origin` is injected (node
+ * test env has no `location`), so this is unit-testable without a browser.
  */
 export function createFetchWrapper(tracer: HttpTracer, original: typeof fetch, origin: string): typeof fetch {
     return function (this: unknown, input: FetchInput, init?: RequestInit): Promise<Response> {
@@ -74,16 +73,15 @@ export function createFetchWrapper(tracer: HttpTracer, original: typeof fetch, o
     };
 }
 
-// Owns the installed flag for the single `fetch` method. A wrapper leaked by a
-// failed unpatch stays live and checks enableTracing per call, so one wrapper in
-// the chain is always enough. See createPatcher for the atomic install/uninstall
-// semantics shared with instrumentXHR's three-method patch.
+// Owns the installed flag for the single `fetch` method. A wrapper leaked by a failed unpatch
+// stays live and checks enableTracing per call, so one wrapper in the chain is always enough.
+// See createPatcher for the shared atomic install/uninstall semantics.
 const patcher = createPatcher();
 
 /**
- * Patch the global `fetch` so outgoing requests are traced. No-op when there is
- * no `fetch` or it is not native (a polyfilled/XHR-backed fetch is left for the
- * future XHR patch). Idempotent via `fill`. Reversible via `unpatchFetch`.
+ * Patch the global `fetch` so outgoing requests are traced. No-op when there is no `fetch` or it
+ * is not native (a polyfilled/XHR-backed fetch is left for the XHR patch). Idempotent via `fill`.
+ * Reversible via `unpatchFetch`.
  */
 export function instrumentFetch(tracer: HttpTracer): void {
     if (patcher.installed) return;

--- a/packages/js/src/tracing/instrumentXHR.ts
+++ b/packages/js/src/tracing/instrumentXHR.ts
@@ -24,10 +24,9 @@ type XhrState = {
     ended: boolean;
 };
 
-// One logical XHR request spreads across open() -> setRequestHeader()* -> send() ->
-// readystatechange. A WeakMap keyed by the instance threads state across those calls
-// without polluting the instance (unlike Sentry's __sentry_xhr_v3__ property); entries
-// are GC'd with the request.
+// One XHR spreads across open() -> setRequestHeader()* -> send() -> readystatechange.
+// WeakMap keyed by the instance threads state across those calls without polluting the
+// instance; entries are GC'd with the request.
 const xhrState = new WeakMap<XMLHttpRequest, XhrState>();
 
 /**
@@ -37,10 +36,9 @@ const xhrState = new WeakMap<XMLHttpRequest, XhrState>();
  */
 export function createXHROpen(original: XhrOpen): XhrOpen {
     return function (this: XMLHttpRequest, method: string, url: string | URL, ...rest: unknown[]): void {
-        // WHATWG: calling open() on an in-flight request terminates it with NO DONE
-        // readystatechange. If we left the prior span/listener in place, the NEXT request's
-        // DONE would fire both listeners and cross-end the prior span with this one's status
-        // (Finding 1). End it now, as aborted, and detach its listener before it can happen.
+        // WHATWG: open() on an in-flight request terminates it with no DONE readystatechange.
+        // Leaving the prior span/listener in place would let the next request's DONE cross-end
+        // the prior span with this one's status (Finding 1). End it as aborted and detach now.
         const prior = xhrState.get(this);
         if (prior && prior.span && !prior.ended) {
             prior.ended = true;
@@ -64,8 +62,7 @@ export function createXHROpen(original: XhrOpen): XhrOpen {
                 ended: false,
             });
         } else {
-            // Clear any prior entry so a reused instance can't resurrect stale, already-ended
-            // state on a later send().
+            // Clear prior entry so a reused instance can't resurrect stale state on a later send().
             xhrState.delete(this);
         }
         return (original as (this: XMLHttpRequest, ...a: unknown[]) => void).apply(this, [method, url, ...rest]);
@@ -79,10 +76,9 @@ export function createXHROpen(original: XhrOpen): XhrOpen {
  */
 export function createXHRSetRequestHeader(original: XhrSetHeader): XhrSetHeader {
     return function (this: XMLHttpRequest, name: string, value: string): void {
-        // Call the native setRequestHeader first: if it throws (e.g. a forbidden header value),
-        // the app's header never landed, so we must NOT record hasAppTraceparent — otherwise
-        // send() would suppress Flare's injection and the request would carry no traceparent at
-        // all. The throw itself is the app's own error and is left to propagate untouched.
+        // Call native setRequestHeader first: if it throws (e.g. forbidden header value) the app's
+        // header never landed, so don't record hasAppTraceparent, else send() suppresses Flare's
+        // injection and the request carries no traceparent at all. The throw is the app's; propagate it.
         original.call(this, name, value);
         if (typeof name === 'string' && name.toLowerCase() === 'traceparent') {
             const state = xhrState.get(this);
@@ -136,17 +132,16 @@ export function createXHRSend(tracer: HttpTracer, original: XhrSend, origin: str
                 // Reading status can throw on some platforms; treat as 0 (no response).
             }
             try {
-                // status 0 at DONE is "no HTTP response" (network/CORS failure/abort) only for http(s).
-                // For file:// and custom (e.g. Electron registerFileProtocol/registerBufferProtocol)
-                // schemes a SUCCESSFUL response is also status 0, so it must NOT be mapped to error.
-                // A null `abs` (unparseable URL) also does not map to error: don't guess a scheme.
+                // status 0 at DONE means "no HTTP response" (network/CORS failure/abort) only for
+                // http(s). file:// and custom schemes (e.g. Electron registerFileProtocol) return 0
+                // on success, so don't map to error. A null `abs` (unparseable URL) also isn't error.
                 const zeroIsError = abs !== null && (abs.protocol === 'http:' || abs.protocol === 'https:');
                 endHttpRequestSpan(span, status, { zeroIsError });
             } catch {
                 // Instrumentation must never throw into the host app.
             }
-            // Release refs now that the request is done, so the WeakMap entry (kept alive for
-            // the re-send `ended` guard) no longer pins the Span or this closure (Finding 9).
+            // Release refs so the WeakMap entry (kept for the re-send `ended` guard) no longer
+            // pins the Span or this closure (Finding 9).
             state.span = undefined;
             state.onDone = undefined;
         };
@@ -156,8 +151,8 @@ export function createXHRSend(tracer: HttpTracer, original: XhrSend, origin: str
         try {
             return send();
         } catch (error) {
-            // The DONE listener never fires on a synchronous send throw, so remove it
-            // here to keep the happy path's cleanup symmetric (no listener left dangling).
+            // The DONE listener never fires on a synchronous send throw, so remove it here
+            // (no listener left dangling).
             this.removeEventListener('readystatechange', onDone);
             state.ended = true;
             try {
@@ -165,7 +160,7 @@ export function createXHRSend(tracer: HttpTracer, original: XhrSend, origin: str
             } catch {
                 // Instrumentation must never mask the host app's original error.
             }
-            // Same ref-release as the DONE path (Finding 9) — the throw below still leaves the
+            // Same ref-release as the DONE path (Finding 9). The throw below still leaves the
             // WeakMap entry in place for the re-send `ended` guard.
             state.span = undefined;
             state.onDone = undefined;
@@ -174,11 +169,10 @@ export function createXHRSend(tracer: HttpTracer, original: XhrSend, origin: str
     } as XhrSend;
 }
 
-// Owns ONE installed flag across all three methods, so a third party wrapping just
-// one of them (e.g. `send`) cannot wedge the others. See createPatcher for the
-// atomic install/uninstall semantics this fixes (Finding 2: a per-method/single-flag
-// design like instrumentFetch's is unsafe once methods share state, since `send`
-// depends on state `open` populates).
+// Owns one installed flag across all three methods, so a third party wrapping just one
+// (e.g. `send`) cannot wedge the others. See createPatcher for the atomic install/uninstall
+// semantics (Finding 2: a per-method single-flag design is unsafe once methods share state,
+// since `send` depends on state `open` populates).
 const patcher = createPatcher();
 
 /**

--- a/packages/js/src/tracing/navigationTiming.ts
+++ b/packages/js/src/tracing/navigationTiming.ts
@@ -6,10 +6,9 @@ export function computePageloadStartNano(timeOriginMs: number, startTimeMs: numb
 }
 
 /**
- * Choose the pageload root's start time: navigation start while that window is
- * still open, otherwise `now`. Starting at `now` when tracing began after the
- * final cap, or the pageload was already traced, avoids a backdated root that
- * reports a bogus multi-second duration.
+ * Choose the pageload root's start time: navigation start while that window is still open,
+ * otherwise `now`. Starting at `now` (when tracing began after the final cap, or the pageload was
+ * already traced) avoids a backdated root reporting a bogus multi-second duration.
  */
 export function resolvePageloadStartNano(
     backdatedNano: number,
@@ -23,9 +22,8 @@ export function resolvePageloadStartNano(
 }
 
 /**
- * The pageload root's start time in unix nanoseconds, backdated to navigation
- * start via the Navigation Timing entry. Falls back to the tracer's clock when
- * the API is unavailable.
+ * The pageload root's start time in unix nanoseconds, backdated to navigation start via the
+ * Navigation Timing entry. Falls back to the tracer's clock when the API is unavailable.
  */
 export function pageloadStartNano(): number {
     const perf = (globalThis as { performance?: Performance }).performance;

--- a/packages/js/src/tracing/propagation.ts
+++ b/packages/js/src/tracing/propagation.ts
@@ -1,12 +1,10 @@
 export type FetchInput = string | URL | Request;
 
 /**
- * Decide whether a W3C `traceparent` header may be attached to `url`.
- * Default: same-origin + relative (`abs`, the caller's already-parsed URL, is
- * compared by origin; null -> not same-origin, matching a failed parse).
- * With `targets`: match by String.includes (string entry) or RegExp.test
- * against the raw `url`. `targets: []` disables everything.
- * Mirrors OTel/Sentry `tracePropagationTargets` semantics.
+ * Decide whether a W3C `traceparent` header may attach to `url`. Mirrors OTel/Sentry
+ * `tracePropagationTargets` semantics.
+ * Default: same-origin (`abs` compared by origin; null counts as not same-origin).
+ * With `targets`: String.includes (string) or RegExp.test against raw `url`; `[]` disables all.
  */
 export function shouldPropagate(
     url: string,
@@ -22,11 +20,9 @@ export function shouldPropagate(
 }
 
 /**
- * Snapshot an iterable HeadersInit (Map, URLSearchParams, cross-realm Headers)
- * into an array of string pairs. Returns null when iteration throws or yields
- * a malformed entry; callers must then pass the source through untouched so a
- * bad merge never breaks the host request (fetch will reject it the same way
- * it would have without tracing).
+ * Snapshot an iterable HeadersInit (Map, URLSearchParams, cross-realm Headers) into string
+ * pairs. Returns null on a throwing/malformed entry; callers must then pass the source through
+ * untouched so a bad merge never breaks the host request.
  */
 function headerPairsFrom(source: Iterable<unknown>): [string, string][] | null {
     try {
@@ -44,15 +40,12 @@ function headerPairsFrom(source: Iterable<unknown>): [string, string][] | null {
 }
 
 /**
- * Return a NEW `RequestInit` carrying `traceparent`, without mutating the
- * caller's `Request` or `init` — UNLESS the caller already supplied its own
- * `traceparent` (any case), in which case this is caller-wins: `init` is
- * returned UNCHANGED (possibly `undefined`) and nothing is injected, matching
- * XHR's `hasAppTraceparent` skip. Handles fetch's headers shapes (Headers,
- * pair arrays, other pair iterables, plain records) plus the `Request`-input
- * case. When Flare does inject, the returned init is passed as the second
- * fetch arg so the spec's override semantics put the header on the wire while
- * leaving the caller's `Request` (and its single-shot body) intact.
+ * Return a new `RequestInit` carrying `traceparent` without mutating the caller's `Request` or
+ * `init`. Caller-wins: if the caller already set `traceparent` (any case), `init` is returned
+ * unchanged (possibly undefined) and nothing is injected, matching XHR's `hasAppTraceparent` skip.
+ * Handles all fetch headers shapes (Headers, pair arrays, other pair iterables, plain records) plus
+ * the `Request`-input case. On inject, the init is passed as fetch's second arg so the header lands
+ * on the wire while the caller's `Request` (and its single-shot body) stays intact.
  */
 export function mergeTraceparentHeader(
     input: FetchInput,
@@ -62,11 +55,9 @@ export function mergeTraceparentHeader(
     const source: HeadersInit | undefined =
         init?.headers ?? (typeof Request !== 'undefined' && input instanceof Request ? input.headers : undefined);
 
-    // Caller-wins is decided WITHIN each shape branch below, alongside injection, so every
-    // source is walked at most once. A separate detect-then-inject pass would walk a pair-
-    // iterable source (Map, URLSearchParams, cross-realm Headers, a generator) twice; for a
-    // genuine one-shot iterator the first walk exhausts it, so the second sees nothing and
-    // silently drops every caller header.
+    // Caller-wins is decided within each shape branch below, alongside injection, so every source
+    // is walked at most once. A separate detect-then-inject pass would walk a pair-iterable source
+    // twice; a one-shot iterator's first walk exhausts it, so the second drops every caller header.
     let headers: HeadersInit;
     if (source instanceof Headers) {
         if (source.has('traceparent')) return init; // caller-wins
@@ -76,10 +67,9 @@ export function mergeTraceparentHeader(
         if (source.some(([k]) => String(k).toLowerCase() === 'traceparent')) return init; // caller-wins
         headers = [...source, ['traceparent', traceparent]];
     } else if (source && typeof (source as Partial<Iterable<unknown>>)[Symbol.iterator] === 'function') {
-        // Fetch's WebIDL conversion accepts ANY iterable of string pairs as
-        // HeadersInit: Map, URLSearchParams, polyfilled or cross-realm Headers.
-        // Those have no enumerable own properties, so the record branch below
-        // would see an empty object and silently drop every caller header.
+        // Fetch's WebIDL conversion accepts any iterable of string pairs as HeadersInit (Map,
+        // URLSearchParams, polyfilled/cross-realm Headers). Those have no enumerable own props,
+        // so the record branch below would see an empty object and drop every caller header.
         const pairs = headerPairsFrom(source as unknown as Iterable<unknown>);
         if (pairs === null) {
             headers = source; // throwing/malformed -> passthrough (inject nothing)
@@ -98,8 +88,8 @@ export function mergeTraceparentHeader(
     }
 
     const result: RequestInit = { ...init, headers };
-    // A Request with a ReadableStream body requires `duplex` when re-issued with an
-    // init; without it fetch throws and breaks a host request that worked pre-tracing.
+    // A Request with a ReadableStream body requires `duplex` when re-issued with an init;
+    // without it fetch throws and breaks a host request that worked pre-tracing.
     if (
         (result as RequestInit & { duplex?: string }).duplex === undefined &&
         typeof Request !== 'undefined' &&

--- a/packages/js/src/tracing/supportsNativeFetch.ts
+++ b/packages/js/src/tracing/supportsNativeFetch.ts
@@ -4,11 +4,10 @@ export function isNativeFetch(fn: unknown): boolean {
 }
 
 /**
- * Whether the current global `fetch` is native. A polyfilled fetch (e.g.
- * whatwg-fetch) is XHR-backed; we skip instrumenting it so the future XHR patch
- * is the single source for those requests. Ported from Sentry's
- * supportsNativeFetch, including the hidden-iframe fallback used when another
- * library has already wrapped `fetch` so the direct toString check is unreliable.
+ * Whether the current global `fetch` is native. A polyfilled fetch (e.g. whatwg-fetch) is
+ * XHR-backed; skip instrumenting it so the XHR patch is the single source for those requests.
+ * Ported from Sentry, including the hidden-iframe fallback used when another library has already
+ * wrapped `fetch` and the direct toString check is unreliable.
  */
 export function supportsNativeFetch(): boolean {
     const g = globalThis as { fetch?: unknown; document?: Document };

--- a/packages/js/tests/browserTracing.test.ts
+++ b/packages/js/tests/browserTracing.test.ts
@@ -156,7 +156,7 @@ describe('browserTracing', () => {
         expect(root.end).toHaveBeenCalled();
         expect(setActiveRoot).toHaveBeenCalledWith(undefined);
         expect(flush).toHaveBeenCalledWith({ keepalive: true });
-        // The flush must run AFTER the root ends, or the just-ended root misses the envelope.
+        // The flush must run after the root ends, or the just-ended root misses the envelope.
         expect(root.end.mock.invocationCallOrder[0]).toBeLessThan(flush.mock.invocationCallOrder[0]);
     });
 
@@ -215,7 +215,7 @@ describe('browserTracing', () => {
         const originalPushState = window.history.pushState;
         startBrowserTracing(flare);
 
-        // A third party wraps pushState AFTER Flare, so unfill cannot restore on stop
+        // A third party wraps pushState after Flare, so unfill cannot restore on stop
         // (the current function is not Flare's tagged wrapper) and Flare's wrapper leaks.
         const flarePushState = window.history.pushState;
         window.history.pushState = function (this: History, ...args: Parameters<History['pushState']>) {

--- a/packages/js/tests/collectBrowserSsr.test.ts
+++ b/packages/js/tests/collectBrowserSsr.test.ts
@@ -1,8 +1,5 @@
 // @vitest-environment node
-/**
- * Tests that collectBrowser is safe to call in a Node (SSR) environment
- * where `window` is not defined.
- */
+/** collectBrowser is safe to call in a Node (SSR) environment where `window` is undefined. */
 import { DEFAULT_URL_DENYLIST } from '@flareapp/core';
 import { describe, expect, it } from 'vitest';
 

--- a/packages/js/tests/flareClass.test.ts
+++ b/packages/js/tests/flareClass.test.ts
@@ -1,9 +1,7 @@
 // @vitest-environment jsdom
 /**
- * Verifies that `new Flare()` from @flareapp/js produces browser-wired behavior:
- * - telemetry.sdk.name is '@flareapp/js'
- * - flare.entry_point.type is 'web' (browser context collected)
- * - flare.entry_point.value is a non-empty string (derived from window.location.href)
+ * `new Flare()` from @flareapp/js produces browser-wired behavior: sdk name '@flareapp/js',
+ * entry_point.type 'web', and a non-empty entry_point.value from window.location.href.
  */
 import { NullFileReader } from '@flareapp/core';
 import { describe, expect, it } from 'vitest';

--- a/packages/js/tests/flareTracingWiring.test.ts
+++ b/packages/js/tests/flareTracingWiring.test.ts
@@ -3,9 +3,9 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { Flare } from '../src/browser';
 import { unpatchFetch } from '../src/tracing/instrumentFetch';
 
-// A bound function reports "[native code]" from Function.prototype.toString, so the
-// robust isNativeFetch detects it as native. An own-property toString override does NOT
-// work (isNativeFetch uses Function.prototype.toString.call, which ignores own toString).
+// A bound function reports "[native code]" from Function.prototype.toString, so isNativeFetch
+// detects it as native. An own-property toString override does not work: isNativeFetch uses
+// Function.prototype.toString.call, which ignores own toString.
 function nativeFetchStub(): typeof fetch {
     // oxlint-disable-next-line no-extra-bind
     return (async () => new Response(null, { status: 200 })).bind(null) as unknown as typeof fetch;

--- a/packages/js/tests/golden.test.ts
+++ b/packages/js/tests/golden.test.ts
@@ -67,9 +67,8 @@ test('emits the canonical golden report shape', async () => {
 
     const actual = fakeApi.lastReport!;
 
-    // Stacktrace codeSnippet depends on whether the test environment can
-    // fetch the source file -- strip it before snapshotting to keep the
-    // fixture machine-independent.
+    // codeSnippet depends on whether the test environment can fetch the source file; strip it
+    // before snapshotting to keep the fixture machine-independent.
     for (const frame of actual.stacktrace) {
         delete frame.codeSnippet;
     }

--- a/packages/js/tests/helpers/fakeTracer.ts
+++ b/packages/js/tests/helpers/fakeTracer.ts
@@ -30,10 +30,9 @@ export function fakeSpan() {
 }
 
 /**
- * `startSpan` creates a FRESH fake span per call (each with its own `calls`), pushing every
- * one's `calls` onto `spans` in call order so multi-request tests can inspect span A vs span B
- * independently. `span`/`calls` still point at the first span so every single-request test can
- * keep using them unchanged.
+ * `startSpan` creates a fresh fake span per call (each with its own `calls`), pushing every one's
+ * `calls` onto `spans` in call order so multi-request tests can inspect span A vs span B. `span`
+ * and `calls` still point at the first span so single-request tests keep using them unchanged.
  */
 export function makeTracer(overrides: Partial<Config> = {}) {
     const first = fakeSpan();

--- a/packages/js/tests/idleRootController.test.ts
+++ b/packages/js/tests/idleRootController.test.ts
@@ -138,7 +138,7 @@ describe('IdleRootController', () => {
         h.emit('end', c1); // clears the first child timer, arms idle
 
         // Second batch starts before idle fires; a stuck child should force-end at
-        // childSpanTimeout measured from THIS batch, proving a fresh timer was armed.
+        // childSpanTimeout measured from this batch, proving a fresh timer was armed.
         h.advance(500); // < idleTimeout, so root still open
         h.emit('start', fakeSpan('c2', 'T')); // stays open, re-arms child timeout
         h.advance(15000);

--- a/packages/js/tests/instrumentFetch.test.ts
+++ b/packages/js/tests/instrumentFetch.test.ts
@@ -157,11 +157,9 @@ describe('createFetchWrapper', () => {
 describe('instrumentFetch / unpatchFetch on globalThis', () => {
     it('patches global fetch when native, then restores it', async () => {
         const g = globalThis as { fetch: typeof fetch };
-        // `isNativeFetch` checks `Function.prototype.toString.call(fn)`, which ignores an own
-        // `fn.toString` override (the "not fooled by a spoofed toString" guarantee covered by
-        // supportsNativeFetch.test.ts). A bound function genuinely reports `[native code]` from that
-        // prototype method, so it's detected as native without any global mutation. The `.bind` is
-        // load-bearing for exactly that reason, not redundant.
+        // `isNativeFetch` uses `Function.prototype.toString.call(fn)`, ignoring an own `fn.toString`
+        // override. A bound function reports `[native code]` from that prototype method, so it's
+        // detected as native without global mutation. The `.bind` is load-bearing, not redundant.
         // oxlint-disable-next-line no-extra-bind
         const native = (async () => new Response(null, { status: 200 })).bind(null) as unknown as typeof fetch;
         const before = g.fetch;

--- a/packages/js/tests/instrumentXHR.prototype.test.ts
+++ b/packages/js/tests/instrumentXHR.prototype.test.ts
@@ -50,8 +50,7 @@ describe('instrumentXHR / unpatchXHR on XMLHttpRequest.prototype', () => {
         instrumentXHR(tracer);
         const flareSend = proto.send;
 
-        // A third party wraps `send` on top of Flare's wrapper, so unpatchXHR cannot
-        // restore it (mirrors instrumentFetch.test.ts's third-party test).
+        // A third party wraps `send` on top of Flare's wrapper, so unpatchXHR cannot restore it.
         const thirdParty = function (this: XMLHttpRequest, ...args: unknown[]): unknown {
             return (flareSend as unknown as (...a: unknown[]) => unknown).apply(this, args);
         };
@@ -65,9 +64,8 @@ describe('instrumentXHR / unpatchXHR on XMLHttpRequest.prototype', () => {
         // (a) open is still Flare's wrapper -> tracing is not permanently dead.
         expect((proto.open as { __flare_original__?: unknown }).__flare_original__).toBeDefined();
 
-        // (b) driving one traced request through open() -> send() creates exactly one
-        // span -> re-instrumenting did not stack a second `send` wrapper underneath
-        // the still-leaked third party.
+        // (b) one traced request through open() -> send() creates exactly one span, so
+        // re-instrumenting did not stack a second `send` wrapper under the leaked third party.
         const xhr = new XMLHttpRequest();
         xhr.open('GET', 'https://app.example/one');
         xhr.send();

--- a/packages/js/tests/instrumentXHR.test.ts
+++ b/packages/js/tests/instrumentXHR.test.ts
@@ -140,9 +140,8 @@ describe('createXHR* wrappers', () => {
 
     it("still injects Flare's traceparent when the apps own setRequestHeader throws (Finding 6)", () => {
         const { tracer } = makeTracer();
-        // The native setRequestHeader throws for a forbidden value (e.g. a stray newline from
-        // interpolation); the app's header never lands. Flare's own tp value is well-formed, so
-        // it must not trip the same throw.
+        // Native setRequestHeader throws for a forbidden value (e.g. a stray newline); the app's
+        // header never lands. Flare's own tp value is well-formed, so it must not trip the throw.
         const { xhr, headers } = instrument(tracer, {
             headerThrows: (name, value) => name.toLowerCase() === 'traceparent' && value === 'bad\nvalue',
         });

--- a/packages/js/tests/propagation.test.ts
+++ b/packages/js/tests/propagation.test.ts
@@ -88,7 +88,7 @@ describe('mergeTraceparentHeader', () => {
         expect(mergeTraceparentHeader(req, undefined, TP)).toBeUndefined();
 
         // A stream-bodied variant must short-circuit on caller-wins before the duplex handling
-        // below it ever runs, so duplex is left exactly as the caller set it.
+        // runs, so duplex is left exactly as the caller set it.
         const streamReq = new Request('https://app.example/x', {
             method: 'POST',
             headers: { traceparent: 'old' },
@@ -163,10 +163,9 @@ describe('mergeTraceparentHeader', () => {
     });
 
     it('does not drop caller headers from a ONE-SHOT iterable HeadersInit (regression)', () => {
-        // A generator's [Symbol.iterator]() returns itself, so iterating it twice yields the
-        // full sequence once and nothing the second time. Any code path that walks the source
-        // more than once (e.g. a caller-wins pre-pass followed by a separate injection pass)
-        // silently drops these caller headers on the second walk.
+        // A generator's [Symbol.iterator]() returns itself, so iterating twice yields the full
+        // sequence once and nothing the second time. Any path that walks the source more than once
+        // (e.g. a caller-wins pre-pass plus a separate injection pass) drops these headers.
         const headers: Iterable<unknown> = (function* () {
             yield ['authorization', 'Bearer token'];
         })();

--- a/packages/nextjs/src/withFlareSourcemaps.ts
+++ b/packages/nextjs/src/withFlareSourcemaps.ts
@@ -31,8 +31,8 @@ export function withFlareSourcemaps(nextConfig: NextConfig, options: FlareNextjs
                 );
             }
 
-            // The webpack plugin auto-detects the server compiler (via target/name) and emits
-            // base-free originalFile paths, so registering it for every build is safe.
+            // The webpack plugin auto-detects the server compiler and emits base-free paths, so
+            // registering it for every build is safe.
             config.plugins.push(
                 new FlareWebpackPlugin({
                     apiKey: options.apiKey,
@@ -44,9 +44,8 @@ export function withFlareSourcemaps(nextConfig: NextConfig, options: FlareNextjs
                 }),
             );
 
-            // Make sure the server build emits .js.map files so the plugin has something to
-            // upload. Only set this for production server builds, and never override a devtool
-            // the user has already configured.
+            // Emit .js.map for production server builds so the plugin has something to upload.
+            // Never override a devtool the user already configured.
             if (context.isServer && !context.dev && config.devtool == null) {
                 config.devtool = 'source-map';
             }

--- a/packages/node/src/Flare.ts
+++ b/packages/node/src/Flare.ts
@@ -18,13 +18,9 @@ const NODE_SDK_VERSION =
         : '?';
 
 /**
- * Strip the `g` and `y` flags from a user-supplied regex.
- *
- * `RegExp.prototype.test()` and `.exec()` keep `lastIndex` state when either of
- * these flags is set, which means reusing the same regex across many keys (as
- * the header denylist and body redaction do) silently skips matches after the
- * first hit. Reconstructing the regex without those flags gives stateless
- * matching while preserving everything else (`i`, `m`, `s`, `u`, source).
+ * Strip `g`/`y` flags from a user-supplied regex. Those flags make `.test()`/`.exec()` keep
+ * `lastIndex` state, so reusing the regex across keys (header denylist, body redaction) skips matches
+ * after the first hit. All other flags and the source are preserved.
  */
 function sanitizeRegex(re: RegExp): RegExp {
     const safeFlags = re.flags.replace(/[gy]/g, '');
@@ -48,22 +44,15 @@ const DEFAULT_NODE_OPTIONS: ResolvedNodeOptions = {
  * Node.js-specific `Flare` singleton, exposed from `@flareapp/node` as `flare`.
  *
  * Subclasses core's `Flare` and wires the Node-only seams in its constructor:
- *
- * - `AsyncLocalStorageScopeProvider` so each `runWithContext(...)` callback
- *   gets its own `NodeScope` (glows, attributes, entry-point, request),
+ * - `AsyncLocalStorageScopeProvider` so each `runWithContext(...)` callback gets its own `NodeScope`,
  *   isolated from concurrent requests.
- * - `makeNodeContextCollector(...)` to project the current `NodeScope` and
- *   process info into report attributes (http.request.*, url.path, etc).
- * - `DiskFileReader` to read source files for stack-trace snippets via
- *   `node:fs/promises` instead of the browser's `fetch`.
- * - `ProcessHandlerManager` to attach/detach `uncaughtException` and
- *   `unhandledRejection` listeners based on the current `NodeOptions`.
+ * - `makeNodeContextCollector(...)` projects the current `NodeScope` + process info into report attrs.
+ * - `DiskFileReader` reads source for stack-trace snippets via `node:fs/promises`, not `fetch`.
+ * - `ProcessHandlerManager` attaches/detaches the fatal process listeners per `NodeOptions`.
  *
- * Also adds Node-only API surface on top of core: `configureNode(...)`,
- * `runWithContext(...)`, `mergeContext(...)`, `getContext()`,
- * `removeProcessListeners()`. Inherited core methods (`light`, `configure`,
- * `addContext`, `glow`, etc.) return `this`, so chaining keeps the
- * `NodeFlare` type and `configureNode(...)` stays callable mid-chain.
+ * Adds Node-only API on top of core: `configureNode`, `runWithContext`, `mergeContext`, `getContext`,
+ * `removeProcessListeners`. Inherited core methods return `this`, so chaining keeps the `NodeFlare`
+ * type and `configureNode(...)` stays callable mid-chain.
  */
 export class NodeFlare extends CoreFlare {
     private nodeOptions: ResolvedNodeOptions = { ...DEFAULT_NODE_OPTIONS };
@@ -73,9 +62,8 @@ export class NodeFlare extends CoreFlare {
 
     constructor() {
         const scopeProvider = new AsyncLocalStorageScopeProvider();
-        // The collector closes over `() => this.nodeOptions` (a getter, not a
-        // value) so subsequent `configureNode(...)` calls take effect on
-        // future reports without reinjecting the collector.
+        // Collector closes over a getter (`() => this.nodeOptions`), not a value, so later
+        // `configureNode(...)` calls affect future reports without reinjecting the collector.
         const collector = makeNodeContextCollector(scopeProvider, () => this.nodeOptions);
         super(new Api(), collector, new DiskFileReader(), scopeProvider, new NodeFlushScheduler());
         this.nodeScopeProvider = scopeProvider;
@@ -86,10 +74,9 @@ export class NodeFlare extends CoreFlare {
     }
 
     /**
-     * Set the API key (and optional debug flag), then reconcile process
-     * listeners with the current `nodeOptions`. Reconcile runs on EVERY call,
-     * not just the first, so `light()` is the right escape hatch to re-attach
-     * after `removeProcessListeners()`.
+     * Set the API key (and optional debug flag), then reconcile process listeners with the current
+     * `nodeOptions`. Reconcile runs on every call, so `light()` re-attaches after
+     * `removeProcessListeners()`.
      */
     light(key?: string, debug?: boolean) {
         super.light(key, debug);
@@ -99,20 +86,12 @@ export class NodeFlare extends CoreFlare {
     }
 
     /**
-     * Merge Node-only options (fatal-handler modes, header/body redaction
-     * config, shutdown timeout) into the active configuration. Safe to call
-     * before or after `light()`:
+     * Merge Node-only options (fatal-handler modes, header/body redaction, shutdown timeout) into the
+     * active config. Safe before or after `light()`: before, options are stored and listeners attach on
+     * `light()`; after, options are stored and listeners reconcile immediately (flipping a mode to
+     * `'off'` detaches, back to `'report'`/`'report-and-exit'` re-attaches).
      *
-     * - Before `light()`: options are stored; listeners are attached when
-     *   `light()` runs.
-     * - After `light()`: options are stored AND listeners are reconciled
-     *   immediately, so flipping a mode to `'off'` detaches the handler and
-     *   flipping it back to `'report'`/`'report-and-exit'` re-attaches.
-     *
-     * Regex options (`headerAllowlist`, `bodyAllowedContentTypes`,
-     * `bodyKeyDenylist`) are passed through `sanitizeRegex` to strip stateful
-     * `g`/`y` flags; without that, `RegExp.prototype.test` would skip matches
-     * across keys.
+     * Regex options are run through `sanitizeRegex` to strip stateful `g`/`y` flags.
      */
     configureNode(partial: Partial<NodeOptions>): NodeFlare {
         if (partial.headerDenylist !== undefined || partial.replaceDefaultHeaderDenylist !== undefined) {
@@ -165,49 +144,37 @@ export class NodeFlare extends CoreFlare {
     }
 
     /**
-     * Run `fn` inside a fresh `NodeScope` carrying the supplied request
-     * metadata. Inside `fn` (and any async work it awaits), `flare.glow(...)`,
-     * `flare.addContext(...)`, `flare.setUser(...)`, and `flare.report(...)`
-     * see a scope that is isolated from other concurrent requests.
-     *
-     * Mirrors a typical web-framework middleware: call once per request,
-     * wrapping the request handler, and the SDK will attribute any error
-     * reported inside the chain to the right request.
+     * Run `fn` inside a fresh `NodeScope` carrying the supplied request metadata. Inside `fn` and any
+     * async work it awaits, glow/addContext/setUser/report see a scope isolated from concurrent
+     * requests. Use as web-framework middleware: call once per request wrapping the handler, and reports
+     * are attributed to the right request.
      */
     runWithContext<T>(request: RequestContext, fn: () => T): T {
         return this.nodeScopeProvider.runWithContext(request, fn);
     }
 
     /**
-     * Patch the request metadata on the active scope after `runWithContext(...)`
-     * has already started. Useful when fields become known partway through a
-     * request (e.g., the resolved absolute URL after proxy headers are parsed).
+     * Patch request metadata on the active scope after `runWithContext(...)` started. Useful when fields
+     * become known partway through a request (e.g. the absolute URL after proxy headers are parsed).
      *
-     * Outside any `runWithContext(...)` callback, this writes to the fallback
-     * scope; the patch is visible to subsequent reports issued from outside a
-     * request scope but is NOT inherited by future `runWithContext(...)` calls.
+     * Outside any `runWithContext(...)`, writes to the fallback scope: visible to later outside-scope
+     * reports but not inherited by future `runWithContext(...)` calls.
      */
     mergeContext(partial: Partial<RequestContext>): void {
         this.nodeScopeProvider.mergeContext(partial);
     }
 
     /**
-     * Returns the request scope when called inside `runWithContext(...)`, or
-     * `null` outside. Intentionally returns `null` (not the fallback scope)
-     * when no request is active, so callers can distinguish "we are inside a
-     * request" from "we are not". Primarily useful for debugging.
+     * Request scope inside `runWithContext(...)`, or `null` outside. Returns `null` (not the fallback
+     * scope) so callers can tell "inside a request" from "not". Mainly for debugging.
      */
     getContext(): NodeScope | null {
         return this.nodeScopeProvider.getContext();
     }
 
     /**
-     * Detach the `uncaughtException` and `unhandledRejection` listeners
-     * without changing `nodeOptions`. Intended for tests and for graceful
-     * shutdown paths where you want to take ownership of process exit
-     * yourself.
-     *
-     * Calling `light()` afterwards re-attaches based on the current options.
+     * Detach the fatal process listeners without changing `nodeOptions`. For tests and graceful-shutdown
+     * paths that own process exit. `light()` afterwards re-attaches per the current options.
      */
     removeProcessListeners(): void {
         this.handlerManager.detach();

--- a/packages/node/src/context/body.ts
+++ b/packages/node/src/context/body.ts
@@ -1,19 +1,14 @@
 import { DEFAULT_URL_DENYLIST } from '@flareapp/core';
 
 /**
- * Content types accepted by default for body capture. JSON and
- * URL-encoded forms cover the vast majority of API payloads while keeping
- * the parser surface tiny. `\b` after the second alternative prevents
- * accidental matches like `application/x-www-form-urlencoded-foo` (artificial
- * but cheap to defend against). The leading `^` plus `\b` lets us match
- * either bare types or types with `; charset=utf-8` style suffixes.
+ * Content types accepted by default for body capture: JSON and URL-encoded forms. `^` plus `\b` matches
+ * bare types and `; charset=utf-8` suffixes while rejecting `application/x-www-form-urlencoded-foo`.
  */
 export const DEFAULT_BODY_CONTENT_TYPES = /^application\/(json|x-www-form-urlencoded)\b/i;
 
 /**
- * Keys whose values get replaced with `[redacted]` during body redaction.
- * Reuses core's URL denylist so credentials, tokens, etc are caught with the
- * same regex everywhere (less surface for users to keep in sync).
+ * Keys whose values are replaced with `[redacted]` during body redaction. Reuses core's URL denylist so
+ * credentials/tokens are caught by the same regex everywhere.
  */
 export const DEFAULT_BODY_KEY_DENYLIST = DEFAULT_URL_DENYLIST;
 
@@ -24,37 +19,18 @@ type BodyOptions = {
 };
 
 /**
- * Normalize, redact, serialize, and size-cap a request body for inclusion in
- * a Flare report.
+ * Normalize, redact, serialize, and size-cap a request body for a Flare report. Returns the JSON string,
+ * or `null` when the body should not be reported (unknown shape, content-type miss, serialization fail).
  *
- * Accepts four runtime shapes (whatever the user hands us via
- * `runWithContext({ body, ... })`):
+ * Accepts four runtime shapes:
+ * - `string`: must match `contentType` per `bodyAllowedContentTypes`, else dropped.
+ * - `Buffer`: decoded UTF-8 then treated as a string.
+ * - `URLSearchParams`: flattened to a plain record. No content-type gate (shape is unambiguous).
+ * - Other `object`/array: used as-is, no gate. The common middleware path (Express/Fastify `req.body`).
+ * Anything else returns `null`.
  *
- * - `string` — assumed to match the declared `contentType`. Must be JSON or
- *   form-encoded text per `bodyAllowedContentTypes`; otherwise dropped.
- * - `Buffer` — decoded as UTF-8 then treated like a string.
- * - `URLSearchParams` — flattened to a plain `Record<string, string>`. No
- *   content-type gate (the type is unambiguous from the shape).
- * - Other `object` (POJO, array) — used as-is, no content-type gate. This is
- *   the common middleware path (Express's `req.body`, Fastify's, etc).
- *
- * Anything else (`number`, `boolean`, class instance, stream) returns `null`
- * and the body is not reported.
- *
- * After parsing:
- *
- * 1. **Redact.** Walk the value, replacing any property whose key matches
- *    `bodyKeyDenylist` with `'[redacted]'`. Handles arrays, nested objects,
- *    and circular references (`WeakSet`-tracked, emits `'[Circular]'` on
- *    repeat sight).
- * 2. **Stringify.** `JSON.stringify`; if it throws (BigInt, Symbol, etc),
- *    drop the body entirely.
- * 3. **Truncate.** Cap at `bodyMaxBytes` UTF-8 bytes (the option's named
- *    semantic) INCLUDING the suffix. Truncation respects codepoint boundaries
- *    so the result decodes cleanly with no replacement characters.
- *
- * Returns the final JSON string, or `null` when the body should not be
- * reported (unknown shape, content-type miss, serialization failure).
+ * Then: redact (denylisted keys become `'[redacted]'`, cycles become `'[Circular]'`), `JSON.stringify`
+ * (drop body if it throws on BigInt/Symbol/etc), and truncate to `bodyMaxBytes` including the suffix.
  */
 export function captureBody(body: unknown, contentType: string | undefined, opts: BodyOptions): string | null {
     if (body === undefined || body === null) return null;
@@ -90,20 +66,15 @@ const TRUNCATION_SUFFIX = '…[truncated]';
 const TRUNCATION_SUFFIX_BYTES = Buffer.byteLength(TRUNCATION_SUFFIX, 'utf8');
 
 /**
- * Truncate a serialized string so the resulting UTF-8 byte length never
- * exceeds `maxBytes`, including the appended truncation suffix.
- *
- * Walks backwards from the budget index while the byte at that position is a
- * UTF-8 continuation byte (`10xxxxxx`), stopping at the first byte that
- * starts a new codepoint. Slicing at that index leaves a buffer that decodes
- * cleanly with no replacement characters.
+ * Truncate so the UTF-8 byte length never exceeds `maxBytes`, including the appended suffix. Walks back
+ * over continuation bytes (`10xxxxxx`) to a codepoint boundary so the result decodes cleanly.
  */
 function truncateToByteLimit(serialized: string, maxBytes: number): string {
     const buf = Buffer.from(serialized, 'utf8');
     if (buf.length <= maxBytes) return serialized;
     if (maxBytes <= TRUNCATION_SUFFIX_BYTES) {
-        // Budget too small to fit the suffix plus any payload. Emit the suffix
-        // truncated to the byte budget, respecting codepoint boundaries.
+        // Budget too small for suffix plus payload: emit the suffix truncated to budget at a codepoint
+        // boundary.
         const suffixBuf = Buffer.from(TRUNCATION_SUFFIX, 'utf8');
         let cut = maxBytes;
         while (cut > 0 && (suffixBuf[cut] & 0xc0) === 0x80) cut--;
@@ -115,11 +86,9 @@ function truncateToByteLimit(serialized: string, maxBytes: number): string {
 }
 
 /**
- * Check whether a `content-type` header is on the allowlist. Normalizes to the
- * bare media type first: strips any parameters (`; charset=utf-8`), trims, and
- * lowercases, so the regex is tested against `application/json` rather than the
- * full header. This lets a strict custom regex like `/^application\/json$/`
- * still match `application/json; charset=utf-8`. Empty/missing is a hard miss.
+ * Whether a `content-type` header is on the allowlist. Normalizes to the bare media type first (strips
+ * `; charset=...` params, trims, lowercases) so a strict custom regex like `/^application\/json$/` still
+ * matches `application/json; charset=utf-8`. Empty/missing is a hard miss.
  */
 function matchesContentType(ct: string | undefined, allowed: RegExp): boolean {
     if (!ct) return false;
@@ -129,13 +98,9 @@ function matchesContentType(ct: string | undefined, allowed: RegExp): boolean {
 }
 
 /**
- * Parse a serialized body string into a JS value, branching on the declared
- * content type.
- *
- * - URL-encoded forms become a flat object so the same `redact` walker works.
- * - Otherwise treat as JSON. Returns `undefined` (NOT `null`, which is a
- *   legitimate JSON value) when parsing fails, so the caller can distinguish
- *   "couldn't parse" from "parsed to literal null".
+ * Parse a serialized body string, branching on content type. URL-encoded forms become a flat object;
+ * otherwise JSON. Returns `undefined` (not `null`, a valid JSON value) on parse failure so the caller
+ * can tell "couldn't parse" from "parsed to literal null".
  */
 function parseString(text: string, contentType?: string): unknown {
     if (contentType && /x-www-form-urlencoded/i.test(contentType)) {
@@ -149,10 +114,8 @@ function parseString(text: string, contentType?: string): unknown {
 }
 
 /**
- * True only for `Object.create(null)` or `{}`-shaped values. Excludes class
- * instances (their prototype chain points somewhere other than Object.prototype
- * or null), streams, FormData, ArrayBuffer views, Buffer, URLSearchParams,
- * and other built-ins that happen to be `typeof === 'object'`.
+ * True only for `Object.create(null)` or `{}`-shaped values. Excludes class instances, streams,
+ * FormData, ArrayBuffer views, Buffer, URLSearchParams, and other `typeof === 'object'` built-ins.
  */
 function isPlainObject(value: unknown): value is Record<string, unknown> {
     if (value === null || typeof value !== 'object') return false;
@@ -161,16 +124,9 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 }
 
 /**
- * Recursively walk `value`, replacing values for denylisted keys with
- * `'[redacted]'` and substituting `'[Circular]'` for any object visited more
- * than once.
- *
- * `seen` is a `WeakSet` of already-visited objects. Carried as a parameter
- * (rather than a closure variable) so the same recursive call can pass it
- * down without per-call allocation.
- *
- * Primitives and `null` pass through unchanged. Arrays preserve order;
- * objects preserve keys.
+ * Recursively walk `value`, replacing denylisted keys' values with `'[redacted]'` and objects seen more
+ * than once with `'[Circular]'`. `seen` is passed as a parameter (not a closure) to avoid per-call
+ * allocation. Primitives/`null` pass through; arrays preserve order, objects preserve keys.
  */
 function redact(value: unknown, denylist: RegExp, seen: WeakSet<object> = new WeakSet()): unknown {
     if (value === null || typeof value !== 'object') return value;

--- a/packages/node/src/context/collectNode.ts
+++ b/packages/node/src/context/collectNode.ts
@@ -8,24 +8,14 @@ import { findHeader, projectHeaders } from './headers';
 import { collectProcessAttributes } from './process';
 
 /**
- * Build the Node-side `ContextCollector` that core's `Flare` calls on every
- * report. The returned function projects two sources into OTel-style report
- * attributes:
+ * Build the Node-side `ContextCollector` that core's `Flare` calls per report. Projects two sources into
+ * OTel-style attributes: process info (always present) and the active request scope (method, path/url
+ * with query keys redacted, headers with denylist applied, optional body) when `runWithContext(...)` is
+ * active. Outside a request it falls back to the shared scope and emits no request attrs. User identity
+ * is not projected here; `Flare.setUser` writes straight to `pendingAttributes`.
  *
- * 1. **Process info** — runtime version, pid, hostname, etc. Always present.
- * 2. **Active request scope** — method, path/url (with query-string keys
- *    redacted), headers (with the denylist applied), and optional body. Present
- *    when `runWithContext(...)` is active; falls back to the shared scope
- *    otherwise (no request attrs emitted then). User identity is no longer
- *    projected here: `Flare.setUser` writes it straight to `pendingAttributes`.
- *
- * Both `provider` and `getOptions` are passed in (not captured by reference to
- * concrete instances) so the closure stays decoupled from `NodeFlare`'s
- * internals. `getOptions` is a getter (not a value) so that `configureNode(...)`
- * changes are visible on subsequent reports without rebuilding the collector.
- *
- * The function returned matches `ContextCollector = (config) => Attributes`,
- * which is core's interface for `Flare`'s third constructor parameter.
+ * `getOptions` is a getter so `configureNode(...)` changes show up on later reports without rebuilding
+ * the collector.
  */
 export function makeNodeContextCollector(
     provider: AsyncLocalStorageScopeProvider,
@@ -46,24 +36,17 @@ export function makeNodeContextCollector(
             ...collectProcessAttributes(),
         };
 
-        // Pull the active scope (either the per-request NodeScope inside a
-        // runWithContext callback, or the shared fallback outside one). Either
-        // way `request` is a real RequestContext object; unset fields are just
-        // `undefined`.
+        // Active scope: per-request NodeScope inside runWithContext, or the shared fallback outside.
+        // Either way `request` is a real RequestContext; unset fields are `undefined`.
         const scope = provider.active();
         const { request } = scope;
 
         if (request.method) attrs['http.request.method'] = request.method;
 
-        // `request.path` is a server-relative path with an optional query
-        // string (the shape of `req.url` from `node:http`). Project to:
-        // - `url.path`: everything before `?`
-        // - `url.query`: everything after `?`, with denylisted keys redacted
-        //
-        // We piggy-back on core's `redactUrlQuery` (which expects a full path
-        // or URL with `?`) by passing the whole `request.path` and then
-        // slicing off the prefix back out of the result. Avoids reimplementing
-        // the redact-query logic in two places.
+        // `request.path` is a server-relative path with optional query (the shape of `req.url` from
+        // `node:http`). Split into `url.path` (before `?`) and `url.query` (after `?`, denylisted keys
+        // redacted). We reuse core's `redactUrlQuery` by passing the whole path and slicing the prefix
+        // back off, rather than reimplementing redact-query here.
         if (request.path) {
             const queryStart = request.path.indexOf('?');
             if (queryStart === -1) {
@@ -76,26 +59,19 @@ export function makeNodeContextCollector(
             }
         }
 
-        // `request.url` is the absolute URL when the caller has it (after
-        // proxy/host resolution). Goes to `url.full` with its query string
-        // redacted. Independent of `request.path` — callers can set either,
-        // both, or neither.
+        // `request.url` is the absolute URL when the caller has it (post proxy/host resolution). Goes to
+        // `url.full` with its query redacted. Independent of `request.path`; either, both, or neither.
         if (request.url) {
             attrs['url.full'] = redactUrlQuery(request.url, config.urlDenylist);
         }
 
-        // Fetch the live node options once per call. `headerDenylist`,
-        // `headerAllowlist`, body settings — all already-sanitized by
-        // `configureNode`, so we can use them directly.
+        // Live node options once per call; already sanitized by `configureNode`, so used directly.
         const opts = getOptions();
         Object.assign(attrs, projectHeaders(request.headers, opts));
 
-        // Body capture is off by default. When on, look up `content-type`
-        // case-insensitively (HTTP header names are case-insensitive but
-        // `request.headers` is just a Record so callers may use either case).
-        // `captureBody` returns null when the content type isn't allowed,
-        // the body is missing, or serialization fails; we only emit the
-        // attribute when there's something to emit.
+        // Body capture off by default. When on, look up `content-type` case-insensitively (header names
+        // are case-insensitive but `request.headers` is a plain Record). `captureBody` returns null when
+        // the type isn't allowed, the body is missing, or serialization fails; only emit when non-null.
         if (opts.captureRequestBody) {
             const contentType = findHeader(request.headers, 'content-type');
             const body = captureBody(request.body, contentType, opts);

--- a/packages/node/src/context/headers.ts
+++ b/packages/node/src/context/headers.ts
@@ -1,10 +1,8 @@
 import type { Attributes } from '@flareapp/core';
 
 /**
- * Case-insensitively look up a header value. Returns the first defined value
- * for the lowercased name, or undefined. Array values (rare but valid for
- * some headers) are coalesced to the first element since the consumers in
- * this package treat the value as scalar.
+ * Case-insensitively look up a header value. Returns the first defined match, or undefined. Array values
+ * are coalesced to the first element since consumers here treat the value as scalar.
  */
 export function findHeader(
     headers: Record<string, string | string[] | undefined> | undefined,
@@ -21,29 +19,18 @@ export function findHeader(
 }
 
 /**
- * Default-redacted header names. The pattern is anchored to the FULL header
- * name (`^...$`) and case-insensitive so it catches `Authorization`,
- * `AUTHORIZATION`, `authorization`, etc. Anchoring matters: an unanchored
- * `cookie` would match `X-Some-Cookie-Hint` too, which we do NOT want — only
- * the exact header by name should be redacted by default.
- *
- * Covers the usual credential carriers (`authorization`, `cookie`, etc) plus
- * common proxy-set headers that often expose client IPs (`forwarded`,
- * `x-forwarded-for`, `x-forwarded-user`). Users add domain-specific entries
- * via `configureNode({ headerDenylist: ... })`.
+ * Default-redacted header names. Anchored to the full name (`^...$`) and case-insensitive: anchoring is
+ * load-bearing so an unanchored `cookie` doesn't also match `X-Some-Cookie-Hint`. Covers credential
+ * carriers plus proxy headers that expose client IPs. Users extend via `configureNode({ headerDenylist })`.
  */
 export const DEFAULT_HEADER_DENYLIST =
     /^(authorization|proxy-authorization|cookie|set-cookie|x-api-key|x-csrf-token|x-xsrf-token|x-auth-token|forwarded|x-forwarded-(?:for|user))$/i;
 
 /**
- * Combine the built-in denylist with an optional user-supplied one.
- *
- * - No custom regex          -> use the default as-is.
- * - Custom + replace = true  -> use only the custom pattern (with `g`/`y`
- *                               flags stripped so `.test()` stays stateless).
- * - Custom + replace = false -> union: `(?:default)|(?:custom)`, forcing case
- *                               insensitivity since header names are
- *                               case-insensitive over the wire.
+ * Combine the built-in denylist with an optional custom one.
+ * - No custom: the default as-is.
+ * - Custom + replace: only the custom pattern (`g`/`y` stripped so `.test()` stays stateless).
+ * - Custom + no replace: union `(?:default)|(?:custom)`, forced case-insensitive (header names are).
  */
 export function resolveHeaderDenylist(custom?: RegExp, replaceDefault = false): RegExp {
     if (!custom) return DEFAULT_HEADER_DENYLIST;
@@ -52,26 +39,15 @@ export function resolveHeaderDenylist(custom?: RegExp, replaceDefault = false): 
 }
 
 /**
- * Project an HTTP request `headers` object into report attributes.
+ * Project an HTTP request `headers` object into report attributes, keyed `http.request.header.<name>`.
  *
- * Behavior per header:
- *
- * - **Unset values** (entry exists but the value is `undefined`) are dropped
- *   entirely — `node:http` represents "header was not sent" this way.
- * - **Names are lowercased.** OTel's attribute convention uses lowercase
- *   header keys, and HTTP header names are case-insensitive anyway.
- * - **Allowlist gate.** If `headerAllowlist` is set, only headers whose
- *   lowercased name matches are emitted; everything else is silently dropped
- *   (NOT redacted, dropped). This is the strongest filter — useful for
- *   compliance scenarios where you must opt into headers explicitly.
- * - **Array values** (`set-cookie` can be `string[]`) are joined with `, ` so
- *   the emitted value is a flat string, matching the on-the-wire shape that
- *   most HTTP clients render.
- * - **Denylist redaction.** If the name matches `headerDenylist`, the value
- *   is replaced with `'[redacted]'` (the key still appears so consumers can
- *   tell the header was present).
- *
- * Output keys are `http.request.header.<lowercased-name>`, per OTel.
+ * Per header:
+ * - Unset values (`undefined`) are dropped; `node:http` represents "not sent" this way.
+ * - Names are lowercased (OTel convention; header names are case-insensitive anyway).
+ * - Allowlist gate: if `headerAllowlist` is set, non-matching headers are dropped (not redacted). The
+ *   strongest filter, for compliance opt-in.
+ * - Array values (e.g. `set-cookie: string[]`) are joined with `, `.
+ * - Denylist redaction: matching names get value `'[redacted]'` (key still appears so presence is known).
  */
 export function projectHeaders(
     headers: Record<string, string | string[] | undefined> | undefined,

--- a/packages/node/src/context/process.ts
+++ b/packages/node/src/context/process.ts
@@ -3,13 +3,9 @@ import os from 'node:os';
 import type { Attributes } from '@flareapp/core';
 
 /**
- * Snapshot the Node runtime + host environment at report time and project
- * into OTel-style attribute keys. Cheap (just property reads + a couple of
- * syscalls via `os`), so called per-report rather than cached; this keeps
- * `process.uptime` honest and follows the value of `os.hostname()` if it
- * changes mid-run (unlikely but free correctness).
- *
- * Keys are stable OTel resource attributes; the Flare backend recognizes them.
+ * Snapshot the Node runtime + host environment at report time as OTel resource attributes. Called
+ * per-report rather than cached so `process.uptime()` stays honest and `os.hostname()` tracks mid-run
+ * changes; cheap enough (property reads plus a couple `os` syscalls).
  */
 export function collectProcessAttributes(): Attributes {
     return {

--- a/packages/node/src/process/fatal.ts
+++ b/packages/node/src/process/fatal.ts
@@ -25,10 +25,8 @@ export function buildFatalCallbacks(
             } catch {
                 // swallow
             }
-            // Only drain other in-flight reports when we're about to exit. In
-            // 'report' mode the process keeps running, so those reports settle
-            // on their own and flushing here would just waste time. Mirrors
-            // onRejection.
+            // Only drain in-flight reports when about to exit. In 'report' mode the process keeps
+            // running so they settle on their own. Mirrors onRejection.
             if (opts.uncaughtExceptionMode === 'report-and-exit') {
                 await flare.flush(opts.shutdownTimeoutMs);
                 exit(1);

--- a/packages/node/src/process/handlers.ts
+++ b/packages/node/src/process/handlers.ts
@@ -6,28 +6,15 @@ type Callbacks = {
 };
 
 /**
- * Owns the lifecycle of the two process-level error listeners that capture
- * fatal failures and feed them to Flare:
+ * Owns the lifecycle of the `uncaughtException` and `unhandledRejection` process listeners that feed
+ * fatal failures to Flare.
  *
- * - `process.on('uncaughtException', ...)`
- * - `process.on('unhandledRejection', ...)`
+ * 1. `reconcile(...)` makes listener attachment match the current `FatalMode` per event (attach when
+ *    wanted-but-absent, detach when unwanted-but-present, else no-op). Idempotent.
+ * 2. `detach()` removes both listeners regardless of intent, for tests and graceful shutdown.
  *
- * The manager has two responsibilities:
- *
- * 1. **Reconcile listener state with intent.** Given the current `FatalMode`
- *    for each event (`'off' | 'report' | 'report-and-exit'`), make the actual
- *    listener attachment match: attach when it should be attached but isn't,
- *    detach when it shouldn't be attached but is, no-op when already in the
- *    desired state. This is idempotent — calling `reconcile(...)` repeatedly
- *    with the same options is safe.
- * 2. **Tear down on demand.** `detach()` removes both listeners regardless of
- *    intent, for tests and graceful shutdown.
- *
- * Why keep this separate from `NodeFlare`: the attach/detach logic is purely
- * about Node `process` events and contains no Flare semantics. Isolating it
- * makes it trivial to test (the test suite drives `reconcile()` directly with
- * stub callbacks and asserts on `process.listeners(...)`) and keeps
- * `NodeFlare` focused on report assembly + user-facing API.
+ * Kept separate from `NodeFlare` because it's pure `process`-event plumbing with no Flare semantics,
+ * which keeps it trivially testable.
  */
 export class ProcessHandlerManager {
     /** The currently-attached listener for `uncaughtException`, or `null`. */
@@ -79,15 +66,9 @@ export class ProcessHandlerManager {
     }
 
     /**
-     * Generic attach/detach for one event. The `get`/`set` closures let us
-     * share this body between the two events while still mutating distinct
-     * fields (`uncaughtHandler` vs `rejectionHandler`).
-     *
-     * Truth table:
-     * - intent off, currently attached -> detach
-     * - intent off, not attached       -> no-op
-     * - intent on,  currently attached -> no-op (already correct)
-     * - intent on,  not attached       -> attach
+     * Generic attach/detach for one event. The `get`/`set` closures share this body across both events
+     * while mutating distinct fields (`uncaughtHandler` vs `rejectionHandler`). Attaches when wanted and
+     * absent, detaches when unwanted and present, else no-op.
      */
     private reconcileOne(
         event: 'uncaughtException' | 'unhandledRejection',

--- a/packages/node/src/scope/AsyncLocalStorageScopeProvider.ts
+++ b/packages/node/src/scope/AsyncLocalStorageScopeProvider.ts
@@ -6,57 +6,39 @@ import type { RequestContext } from '../types';
 import { NodeScope } from './NodeScope';
 
 /**
- * `ScopeProvider` implementation that gives every in-flight request its own
- * `NodeScope`, isolated from concurrent requests.
+ * `ScopeProvider` giving every in-flight request its own `NodeScope`, isolated from concurrent requests.
  *
- * Built on Node's `node:async_hooks#AsyncLocalStorage`: when code runs inside
- * `als.run(scope, fn)`, every `als.getStore()` call from within `fn` (and any
- * async work `fn` awaits, including timers, promises, `process.nextTick`, etc)
- * returns that `scope`. Outside any `als.run` call, `getStore()` returns
- * `undefined`. This is the same primitive that lets observability libraries
- * propagate trace context across async boundaries without manual plumbing.
+ * Built on `node:async_hooks#AsyncLocalStorage`: inside `als.run(scope, fn)`, every `getStore()` from
+ * `fn` and any async work it awaits (timers, promises, `process.nextTick`) returns that `scope`; outside
+ * any run, `getStore()` returns `undefined`.
  *
- * Two "kinds of read" surfaced separately:
+ * Two reads surfaced separately:
+ * - `active()` never returns null. The internal read for every glow/attribute/report. Returns the
+ *   per-request scope inside `runWithContext`, else a shared `fallback` scope so outside-request work
+ *   (process-level reports, startup errors, scheduled jobs) still lands somewhere.
+ * - `getContext()` returns `null` outside `runWithContext` so callers can tell "inside a request" from
+ *   "not". The fallback is deliberately not exposed here.
  *
- * - `active()` — never returns null. The internal read used by `Flare` for
- *   every glow, attribute set, and report. When called inside `runWithContext`,
- *   returns the per-request `NodeScope`. Outside, returns a shared `fallback`
- *   scope so glows/attributes/reports issued outside any request still have
- *   somewhere to land (process-level reports, startup errors, scheduled jobs).
- * - `getContext()` — public debug helper. Returns `null` outside any
- *   `runWithContext`, so consumers can distinguish "I am inside a request" from
- *   "I am not". The fallback is intentionally NOT exposed here.
- *
- * The fallback is also a per-instance `NodeScope` so that writes from outside
- * a request scope persist for subsequent outside-scope reports.
+ * The fallback is a per-instance `NodeScope`, so outside-scope writes persist for later outside reports.
  */
 export class AsyncLocalStorageScopeProvider implements ScopeProvider {
     private als = new AsyncLocalStorage<NodeScope>();
     private fallback = new NodeScope();
 
-    /**
-     * Internal: returns the per-request scope when inside `runWithContext`,
-     * or the shared fallback otherwise. Always returns a real `NodeScope`.
-     */
+    /** Per-request scope inside `runWithContext`, else the shared fallback. Never null. */
     active(): NodeScope {
         return this.als.getStore() ?? this.fallback;
     }
 
-    /**
-     * Public: returns the per-request scope when inside `runWithContext`, or
-     * `null` otherwise. Useful for assertions like "am I in a request?".
-     */
+    /** Per-request scope inside `runWithContext`, else `null`. For "am I in a request?" checks. */
     getContext(): NodeScope | null {
         return this.als.getStore() ?? null;
     }
 
     /**
-     * Open a fresh request scope around `fn` and run it. Every async hop
-     * inside `fn` (awaits, timers, promise chains) sees the same scope via
-     * `active()`/`getContext()`; concurrent calls each get their own.
-     *
-     * `request` is shallow-cloned so later edits to the caller's object do not
-     * leak into the stored scope.
+     * Open a fresh request scope around `fn` and run it. Every async hop inside `fn` sees the same scope
+     * via `active()`/`getContext()`; concurrent calls each get their own. `request` is shallow-cloned so
+     * later edits to the caller's object don't leak into the stored scope.
      */
     runWithContext<T>(request: RequestContext, fn: () => T): T {
         const scope = new NodeScope();
@@ -65,10 +47,8 @@ export class AsyncLocalStorageScopeProvider implements ScopeProvider {
     }
 
     /**
-     * Patch the current scope's `request` shape. When called inside
-     * `runWithContext`, the patch is visible to all subsequent reads from
-     * within the same request chain. When called outside, the patch lands on
-     * the fallback scope.
+     * Patch the current scope's `request`. Inside `runWithContext`, visible to all later reads in the
+     * same request chain; outside, lands on the fallback scope.
      */
     mergeContext(partial: Partial<RequestContext>): void {
         const scope = this.als.getStore() ?? this.fallback;

--- a/packages/node/src/stacktrace/DiskFileReader.ts
+++ b/packages/node/src/stacktrace/DiskFileReader.ts
@@ -4,30 +4,15 @@ import { fileURLToPath } from 'node:url';
 import type { FileReader } from '@flareapp/core';
 
 /**
- * Node `FileReader` implementation that reads source files from disk.
- *
- * Wired into `@flareapp/node`'s singleton so the stack-trace builder can pull
- * source for each frame and render a snippet. On the server the frame's "URL"
- * is usually a local path (e.g. `/app/dist/server.js`) or a `file://` URL
- * (from `import.meta.url`), so we resolve straight off disk instead of going
- * over the network.
+ * Node `FileReader` that reads source files from disk for stack-trace snippets. On the server a frame's
+ * "URL" is usually a local path (`/app/dist/server.js`) or a `file://` URL (from `import.meta.url`), so
+ * resolve off disk instead of over the network.
  *
  * Safety gates:
- *
- * 1. **Local-path allowlist.** Only `file://` URLs and absolute filesystem
- *    paths (POSIX `/foo`, Windows `C:\foo` or `\\server\share\foo`) are
- *    accepted. HTTP URLs and relative paths return `null` immediately. We
- *    refuse to read anything that does not unambiguously identify a local
- *    file — no surprise traversal, no following http stack frames in a
- *    server build, no relative-path ambiguity around the current working
- *    directory.
- * 2. **Catch-all.** Missing files, permission errors, and any other failure
- *    return `null`. The `read()` contract returns `null` on every failure
- *    path and never throws.
- *
- * `fileURLToPath` is used when the input is a `file://` URL so we hand
- * `readFile` a real OS path. Otherwise the URL IS already a path and is
- * passed through unchanged.
+ * 1. Local-path allowlist: only `file://` URLs and absolute paths (POSIX, Windows drive, UNC) are read;
+ *    HTTP URLs and relative paths return `null`. Refusing anything that isn't unambiguously a local file
+ *    avoids traversal, following http frames in a server build, and cwd-relative ambiguity.
+ * 2. Catch-all: any failure (missing file, permissions, etc) returns `null`. `read()` never throws.
  */
 export class DiskFileReader implements FileReader {
     async read(url: string): Promise<string | null> {
@@ -42,15 +27,8 @@ export class DiskFileReader implements FileReader {
 }
 
 /**
- * Return true when `url` is something we are willing to treat as a local
- * file. Matches four shapes:
- *
- * - `file://...` URLs (any casing of the scheme)
- * - POSIX absolute paths starting with `/`
- * - Windows drive-letter paths like `C:\foo` or `c:/foo`
- * - Windows UNC paths starting with `\\`
- *
- * Anything else (relative paths, http, data, blob, etc) is rejected.
+ * True for shapes we treat as a local file: `file://` URLs (any scheme casing), POSIX absolute paths,
+ * Windows drive-letter paths (`C:\foo`, `c:/foo`), and Windows UNC (`\\`). Everything else is rejected.
  */
 function isLocalFileUrl(url: string): boolean {
     return /^file:\/\//i.test(url) || url.startsWith('/') || /^[a-z]:[\\/]/i.test(url) || url.startsWith('\\\\');

--- a/packages/node/tests/body.test.ts
+++ b/packages/node/tests/body.test.ts
@@ -79,8 +79,7 @@ describe('captureBody', () => {
     it('emits only suffix when budget is too small', () => {
         const big = { v: 'x'.repeat(100) };
         const out = captureBody(big, undefined, { ...opts, bodyMaxBytes: 5 });
-        // 5 bytes can't fit 14-byte suffix + any payload. Result should be the
-        // suffix truncated to 5 bytes, staying within the byte budget.
+        // 5 bytes can't fit the 14-byte suffix plus payload: result is the suffix truncated to 5 bytes.
         expect(Buffer.byteLength(out!, 'utf8')).toBeLessThanOrEqual(5);
     });
 

--- a/packages/node/tests/regexFlagSanitization.test.ts
+++ b/packages/node/tests/regexFlagSanitization.test.ts
@@ -4,15 +4,13 @@ import { captureBody, DEFAULT_BODY_CONTENT_TYPES } from '../src/context/body';
 import { projectHeaders, DEFAULT_HEADER_DENYLIST } from '../src/context/headers';
 import { NodeFlare } from '../src/Flare';
 
-// Helpers to extract stored options from a configured NodeFlare instance.
-// We drive the options through the real configureNode path then exercise
-// the functions that consume them, so that we test the full sanitize path.
+// Drive options through the real configureNode path, then exercise the consuming functions to test the
+// full sanitize path.
 
 describe('regex flag sanitization in configureNode', () => {
     describe('bodyKeyDenylist with g flag', () => {
         it('redacts every matching key even when denylist has the g flag', () => {
-            // Without sanitization, /password|token/g would retain lastIndex state
-            // across calls and silently skip the second match.
+            // Without sanitization, /password|token/g keeps lastIndex across calls and skips the 2nd match.
             const instance = new NodeFlare();
             instance.configureNode({
                 bodyKeyDenylist: /password|token/g,
@@ -20,13 +18,9 @@ describe('regex flag sanitization in configureNode', () => {
                 bodyAllowedContentTypes: DEFAULT_BODY_CONTENT_TYPES,
             });
 
-            // Extract the sanitized denylist by capturing the body with a known input.
-            // We pass the body object directly (skips content-type check).
+            // Pass the body object directly (skips content-type check). Private state isn't inspectable,
+            // so we test the observable effect: captureBody with the g flag removed, as configureNode does.
             const body = { user: 'alice', password: 'secret', token: 'abc' };
-            // Re-use captureBody with the sanitized regex extracted via getContext hack.
-            // Simpler: call captureBody manually with the regex that configureNode produced.
-            // We can't easily inspect private state, so we test the observable effect
-            // through captureBody called with a regex that has the g flag removed.
             const sanitizedDenylist = new RegExp(/password|token/.source, '');
             const out = captureBody(body, undefined, {
                 bodyAllowedContentTypes: DEFAULT_BODY_CONTENT_TYPES,
@@ -41,17 +35,13 @@ describe('regex flag sanitization in configureNode', () => {
         });
 
         it('g flag on bodyKeyDenylist causes silent skip without sanitization (documents the bug)', () => {
-            // This test documents the broken behavior that sanitization fixes.
-            // With the g flag, the second test() call on the same regex instance
-            // may return false for a matching key (depending on lastIndex state).
+            // Documents the bug sanitization fixes: with the g flag, a second test() on the same instance
+            // can return false for a matching key (lastIndex state).
             const buggyRegex = /password|token/g;
             const keys = ['password', 'token'];
             const results = keys.map((k) => buggyRegex.test(k));
-            // At least one of the two tests returns false due to lastIndex advancement.
-            // (After matching 'password', lastIndex moves past it, so 'token' test resets
-            // or mis-fires depending on the JS engine state.)
-            // The exact outcome is engine-dependent, but the point is that the g flag
-            // makes behavior unreliable — sanitization removes it to guarantee correctness.
+            // At least one test returns false due to lastIndex advancement. Exact outcome is
+            // engine-dependent; the point is the g flag makes matching unreliable.
             expect(results.includes(false)).toBe(true);
         });
     });
@@ -74,8 +64,8 @@ describe('regex flag sanitization in configureNode', () => {
 
     describe('bodyAllowedContentTypes with g flag', () => {
         it('still matches content-type correctly after g flag is stripped', () => {
-            // A g-flagged regex for allowed content types would misfire on the second
-            // check after sanitization removes the flag, the regex becomes stateless.
+            // A g-flagged content-type regex would misfire on the second check; stripping the flag makes
+            // it stateless.
             const body = '{"a":1}';
             const out = captureBody(body, 'application/json', {
                 bodyAllowedContentTypes: new RegExp(DEFAULT_BODY_CONTENT_TYPES.source, ''),

--- a/packages/react-native-sourcemaps/src/babel.ts
+++ b/packages/react-native-sourcemaps/src/babel.ts
@@ -2,35 +2,27 @@ import type * as Babel from '@babel/core';
 
 import { resolveVersion } from './version';
 
-// The app imports `flareSourcemapVersion` from this runtime entry; the plugin
-// inlines it. A typed import (rather than `process.env.FLARE_SOURCEMAP_VERSION`)
-// means no Node types, no ambient declarations, and no "looks like a runtime env
-// var but isn't" confusion for app authors.
 const RUNTIME_SOURCE = '@flareapp/react-native-sourcemaps/runtime';
 const EXPORT_NAME = 'flareSourcemapVersion';
 
-// Type queries on dynamic imports: no runtime import of @babel/* is emitted.
-// `Types` is the shape of the `t` helper object; the others are AST interfaces.
-// They resolve via @types/babel__core (dev dependency).
+// Type-only import queries: no runtime import of @babel/* is emitted. Resolve via
+// @types/babel__core (dev dependency).
 type Types = typeof import('@babel/types');
 type ImportDeclarationNode = import('@babel/types').ImportDeclaration;
 type ImportSpecifierNode = import('@babel/types').ImportSpecifier;
 
 /**
- * Babel plugin that inlines `flareSourcemapVersion` (imported from
- * `@flareapp/react-native-sourcemaps/runtime`) with the resolved version string at
- * bundle time, then removes the now-dead import so nothing of this package ships at
- * runtime. The version is resolved once per file (lazily, only when the import is
- * present) via the shared `resolveVersion()`.
+ * Babel plugin that inlines `flareSourcemapVersion` (imported from `.../runtime`) with the resolved
+ * version string at bundle time, then removes the now-dead import so nothing of this package ships at
+ * runtime. Version resolved once per file, lazily (only when the import is present).
  */
 export default function flareSourcemapsBabelPlugin({ types: t }: { types: Types }): Babel.PluginObj {
     let version: string | undefined;
 
     return {
         name: '@flareapp/react-native-sourcemaps',
-        // Babel caches plugin instances across files/transforms, so reset the
-        // per-file resolved version before each file (also correct for rebuilds
-        // where FLARE_SOURCEMAP_VERSION changes between runs).
+        // Babel caches plugin instances across files, so reset the per-file version before each file
+        // (also correct for rebuilds where FLARE_SOURCEMAP_VERSION changes between runs).
         pre() {
             version = undefined;
         },
@@ -68,8 +60,8 @@ export default function flareSourcemapsBabelPlugin({ types: t }: { types: Types 
                     return;
                 }
 
-                // Drop the import: either the whole declaration, or just the
-                // specifiers we inlined if the user imported other names too.
+                // Drop the import: whole declaration, or just the inlined specifiers if other names
+                // were imported too.
                 if (remaining.length === 0) {
                     path.remove();
                 } else {

--- a/packages/react-native-sourcemaps/src/banner.ts
+++ b/packages/react-native-sourcemaps/src/banner.ts
@@ -16,10 +16,9 @@ export type FailureBannerInfo = {
 const BORDER = '='.repeat(60);
 
 /**
- * Mask an API key for display in a build log, which CI commonly archives. A key
- * long enough to stay unguessable keeps a short head/tail so the user can still
- * recognise WHICH key it was; a short key is fully masked. Never returns the key
- * in full, so the secret cannot leak through the failure banner.
+ * Mask an API key for display in a build log (CI commonly archives these). Long keys keep a short
+ * head/tail hint so the user can recognise which key it was; short keys are fully masked. Never
+ * returns the key in full.
  */
 export function maskApiKey(apiKey: string): string {
     if (apiKey.length <= 12) {
@@ -29,13 +28,10 @@ export function maskApiKey(apiKey: string): string {
 }
 
 /**
- * The deliberately large failure banner. A one-line "failed to upload" is too easy
- * to miss in a long native-build log, so this is a bordered block surrounded by
- * blank lines. Resolved values are interpolated into the re-run command so the
- * user can copy-paste it; unknown values show a labelled placeholder (in the
- * version-unset case `version` stays a placeholder — it is the value to supply).
- * The API key is the one exception: it is MASKED, never printed in full, because
- * this banner lands in the native build log.
+ * Deliberately large failure banner (a one-line "failed to upload" is too easy to miss in a native
+ * build log). Resolved values are interpolated into a copy-pasteable re-run command; unknown values
+ * show a labelled placeholder. The API key is masked, never printed in full, since this lands in the
+ * build log.
  */
 export function formatFailureBanner(info: FailureBannerInfo): string {
     const sourcemap = info.sourcemap ?? '<path-to-map>';

--- a/packages/react-native-sourcemaps/src/cli.ts
+++ b/packages/react-native-sourcemaps/src/cli.ts
@@ -35,10 +35,8 @@ export function parseArgs(argv: string[]): ParsedArgs {
         }
         const key = body;
         const next = rest[i + 1];
-        // A following token that itself starts with `--` is treated as the next flag,
-        // not this flag's value (so a valueless `--flag` becomes boolean `'true'`).
-        // This CLI's values are paths/keys/versions/URLs that never start with `--`; a
-        // value that legitimately does must use the `--flag=value` form handled above.
+        // A following `--` token is the next flag, not this flag's value (so a valueless `--flag`
+        // becomes boolean `'true'`). Values that start with `--` must use the `--flag=value` form.
         if (next !== undefined && !next.startsWith('--')) {
             flags[key] = next;
             i++;
@@ -66,21 +64,17 @@ export async function runCli(argv: string[]): Promise<void> {
         return;
     }
 
-    // Auto mode is the native build-hook path. The hook process often lacks FLARE_*
-    // in its environment (the app's .env files are a JS-runtime concern, an IDE build
-    // doesn't inherit your shell, and a reused Gradle daemon can serve a stale env),
-    // so load .env.local / .env from the project root — the directory that holds
-    // flare.json — before resolving the key. Existing env values are never
-    // overwritten, so an explicit export (or an EAS env var) still wins. The manual
-    // path is left untouched: there the caller is explicit and shouldn't be surprised
-    // by ambient .env loading.
+    // Auto mode is the native build-hook path, whose process often lacks FLARE_* in its env (.env
+    // files are a JS-runtime concern, IDE builds don't inherit your shell, a reused Gradle daemon can
+    // serve a stale env). Load .env.local / .env from the project root (the flare.json directory)
+    // before resolving the key; existing values are never overwritten, so an explicit export wins.
+    // The manual path is left untouched: there the caller is explicit.
     if (flags.auto === 'true') {
         loadEnvFiles(flags.config ? dirname(flags.config) : process.cwd());
     }
 
-    // Precedence per field: explicit flag > env > flare.json > default. The
-    // relative_filename has no flare.json/env override in v1; `--bundle-filename`
-    // (manual) or the map-basename default (in uploadSourcemaps) cover it.
+    // Precedence per field: explicit flag > env > flare.json > default. relative_filename has no
+    // flare.json/env override in v1; `--bundle-filename` or the map-basename default cover it.
     const config = readFlareConfig(flags.config);
     const apiKey = flags['api-key'] ?? process.env.FLARE_API_KEY ?? config.apiKey ?? '';
     const apiEndpoint = flags['api-endpoint'] ?? process.env.FLARE_API_ENDPOINT ?? config.apiEndpoint;
@@ -103,11 +97,10 @@ type AutoUploadOptions = {
 };
 
 /**
- * The build-hook upload path. It NEVER throws and NEVER sets a non-zero exit code
- * (a Gradle doLast / Xcode run-script phase would abort the build on a non-zero
- * child). Every failure mode — no key, unresolved version, upload error — prints the
- * loud banner and returns, leaving the build green. Only arg misuse (handled in
- * runCli before we get here) exits non-zero.
+ * Build-hook upload path. Never throws and never sets a non-zero exit code (a Gradle doLast / Xcode
+ * run-script phase aborts the build on a non-zero child). Every failure (no key, unresolved version,
+ * upload error) prints the banner and returns, leaving the build green. Only arg misuse (handled in
+ * runCli before here) exits non-zero.
  */
 async function runAutoUpload(options: AutoUploadOptions): Promise<void> {
     const { apiKey, sourcemap, bundleFilename, apiEndpoint } = options;

--- a/packages/react-native-sourcemaps/src/config.ts
+++ b/packages/react-native-sourcemaps/src/config.ts
@@ -6,12 +6,10 @@ export type FlareConfig = {
 };
 
 /**
- * Read flare.json from an EXPLICIT path. The hooks run from android/ or ios/, so
- * resolving relative to process.cwd() would read the wrong file — callers always
- * pass --config. Missing or malformed file → empty config, so resolution falls
- * through to env, then to the no-key skip-with-banner. Any `version` key is
- * deliberately ignored: in the auto path the version flows only through
- * FLARE_SOURCEMAP_VERSION (see resolveAutoVersion / the design doc).
+ * Read flare.json from an explicit path. Hooks run from android/ or ios/, so resolving relative to
+ * cwd would read the wrong file; callers always pass --config. Missing or malformed file yields an
+ * empty config, so resolution falls through to env then to the no-key skip-with-banner. Any `version`
+ * key is ignored: in the auto path version flows only through FLARE_SOURCEMAP_VERSION.
  */
 export function readFlareConfig(configPath?: string): FlareConfig {
     if (!configPath) {

--- a/packages/react-native-sourcemaps/src/env.ts
+++ b/packages/react-native-sourcemaps/src/env.ts
@@ -1,28 +1,22 @@
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
-// Highest precedence first: a value in .env.local wins over the same key in .env.
-// An already-set process.env value (an explicit shell export, or an EAS env var)
-// wins over both, because we never overwrite a key that already exists.
+// Ordered by precedence: .env.local wins over .env. An already-set process.env value (shell export
+// or EAS env var) wins over both, since we never overwrite an existing key.
 const ENV_FILES = ['.env.local', '.env'];
 
 /**
- * Load FLARE_* variables from .env.local / .env in `rootDir` into process.env,
- * without overwriting anything already set.
+ * Load FLARE_* variables from .env.local / .env in `rootDir` into process.env, without overwriting
+ * anything already set.
  *
- * The native build hooks run in a fresh process whose environment often does NOT
- * carry the upload key: the app's .env files are loaded by Metro at JS runtime, not
- * at native build time, and a build launched from an IDE — or served by a reused
- * Gradle daemon with a stale environment — won't see a key you exported in your
- * shell. Reading the key from the FILE here makes "drop FLARE_API_KEY in .env.local"
- * work the way developers expect, on both platforms, without re-exporting it per
- * build.
+ * Native build hooks run in a fresh process that often lacks the upload key: .env files are loaded by
+ * Metro at JS runtime not native build time, and an IDE build (or a stale reused Gradle daemon) won't
+ * see a key exported in your shell. Reading it from the file makes "drop FLARE_API_KEY in .env.local"
+ * work on both platforms without re-exporting per build.
  *
- * Only FLARE_-prefixed keys are read, so this never pulls unrelated secrets from the
- * file into the process. Minimal parser (no dependency): `KEY=value`, an optional
- * `export ` prefix, surrounding single/double quotes stripped, blank and `#` comment
- * lines ignored. Inline comments are NOT stripped (a `#` is treated as part of the
- * value), which is fine for the alphanumeric keys Flare issues.
+ * Only FLARE_-prefixed keys are read, never unrelated secrets. Minimal parser (no dependency):
+ * `KEY=value`, optional `export ` prefix, surrounding quotes stripped, blank and `#` comment lines
+ * ignored. Inline comments are not stripped (fine for the alphanumeric keys Flare issues).
  */
 export function loadEnvFiles(rootDir: string): void {
     for (const file of ENV_FILES) {
@@ -30,7 +24,7 @@ export function loadEnvFiles(rootDir: string): void {
         try {
             raw = readFileSync(join(rootDir, file), 'utf8');
         } catch {
-            continue; // absent or unreadable — nothing to load from this file
+            continue; // absent or unreadable, nothing to load
         }
 
         for (const [key, value] of parseFlareEnv(raw)) {

--- a/packages/react-native-sourcemaps/src/expo.ts
+++ b/packages/react-native-sourcemaps/src/expo.ts
@@ -20,8 +20,8 @@ import {
 } from './expoTransforms';
 import { addUploadBuildPhase } from './expoXcode';
 
-// Resolve real install locations (correct under monorepo hoisting). Called only
-// during prebuild, never at import time.
+// Resolve real install locations (correct under monorepo hoisting). Called during prebuild, never at
+// import time.
 function packageDir(): string {
     return dirname(require.resolve('@flareapp/react-native-sourcemaps/package.json'));
 }
@@ -48,9 +48,8 @@ async function writeFlareConfigFiles(projectRoot: string, props: FlarePluginProp
     await fs.writeFile(gitignorePath, ensureGitignored(gitignore), 'utf8');
 }
 
-// flare.json must exist whichever platform builds. EAS prebuilds ONE platform at a
-// time, so register the write for both — it is idempotent (overwrites identical
-// content).
+// flare.json must exist whichever platform builds. EAS prebuilds one platform at a time, so register
+// the write for both; it is idempotent (overwrites identical content).
 const withFlareConfigFiles: ConfigPlugin<FlarePluginProps> = (config, props) => {
     for (const platform of ['ios', 'android'] as const) {
         config = withDangerousMod(config, [
@@ -110,8 +109,8 @@ const withFlareSourcemaps: ConfigPlugin<FlarePluginProps | undefined> = (config,
     return config;
 };
 
-// createRunOncePlugin dedupes a transitively-doubled application. Read name/version
-// from our own package.json; never throw at import if it is somehow unresolvable.
+// createRunOncePlugin dedupes a transitively-doubled application. Read name/version from our own
+// package.json; never throw at import if it is somehow unresolvable.
 const pkg = ((): { name: string; version: string } => {
     try {
         return require('@flareapp/react-native-sourcemaps/package.json') as { name: string; version: string };

--- a/packages/react-native-sourcemaps/src/expoTransforms.ts
+++ b/packages/react-native-sourcemaps/src/expoTransforms.ts
@@ -6,18 +6,19 @@ export type FlarePluginProps = {
 };
 
 export const FLARE_GRADLE_MARKER = '@flareapp/react-native-sourcemaps Expo config plugin';
-// Must NOT live in $CONFIGURATION_BUILD_DIR. With Hermes, react-native-xcode.sh writes
-// its intermediate "packager" sourcemap to `$CONFIGURATION_BUILD_DIR/<basename of
-// SOURCEMAP_FILE>`, composes the final map into SOURCEMAP_FILE, then `rm`s that
-// intermediate — so if SOURCEMAP_FILE is `$CONFIGURATION_BUILD_DIR/main.jsbundle.map`
-// the cleanup deletes the composed map we need. $TARGET_TEMP_DIR is per-target (shared
-// by the bundle phase and the upload phase) and lives elsewhere, so the map survives.
+// Must not live in $CONFIGURATION_BUILD_DIR: with Hermes, react-native-xcode.sh writes its
+// intermediate map to `$CONFIGURATION_BUILD_DIR/<basename of SOURCEMAP_FILE>`, composes the final map
+// into SOURCEMAP_FILE, then rm's that intermediate. If SOURCEMAP_FILE sits in $CONFIGURATION_BUILD_DIR
+// the cleanup deletes the composed map we need. $TARGET_TEMP_DIR is per-target (shared by bundle and
+// upload phases) and lives elsewhere, so the map survives.
 export const SOURCEMAP_FILE_LINE = 'export SOURCEMAP_FILE="$TARGET_TEMP_DIR/main.jsbundle.map"';
 export const GITIGNORE_ENTRY = 'flare.json';
 
-/** Serialise the plugin props into the flare.json the native hooks read. Absent
- * props are omitted so the CLI applies its own defaults (endpoint) and env fallback
- * (FLARE_API_KEY). No `version` key — version flows only through FLARE_SOURCEMAP_VERSION. */
+/**
+ * Serialise plugin props into the flare.json the native hooks read. Absent props are omitted so the
+ * CLI applies its own defaults (endpoint) and env fallback (FLARE_API_KEY). No `version` key: version
+ * flows only through FLARE_SOURCEMAP_VERSION.
+ */
 export function flareJsonContents(props: FlarePluginProps): string {
     const config: Record<string, string> = {};
     if (props.apiKey) {
@@ -29,8 +30,10 @@ export function flareJsonContents(props: FlarePluginProps): string {
     return `${JSON.stringify(config, null, 4)}\n`;
 }
 
-/** Append `apply from: "<path>"` to android/app/build.gradle. Idempotent via a marker
- * comment, so a re-prebuild without --clean does not duplicate it. */
+/**
+ * Append `apply from: "<path>"` to android/app/build.gradle. Idempotent via a marker comment, so a
+ * re-prebuild without --clean does not duplicate it.
+ */
 export function addFlareGradleApply(buildGradle: string, applyFromPath: string): string {
     if (buildGradle.includes(FLARE_GRADLE_MARKER)) {
         return buildGradle;
@@ -39,11 +42,12 @@ export function addFlareGradleApply(buildGradle: string, applyFromPath: string):
     return `${base}\n// ${FLARE_GRADLE_MARKER}\napply from: ${JSON.stringify(applyFromPath)}\n`;
 }
 
-/** Ensure ios/.xcode.env exports SOURCEMAP_FILE so the stock bundle phase emits the
- * composed map. Idempotent, and treats a missing file (empty string) as valid input.
- * The guard is line-based and ignores comments, so a commented-out `# SOURCEMAP_FILE=`
- * does not suppress injection while a real `export SOURCEMAP_FILE=`/`SOURCEMAP_FILE=`
- * (a user's custom map path) is left untouched. */
+/**
+ * Ensure ios/.xcode.env exports SOURCEMAP_FILE so the stock bundle phase emits the composed map.
+ * Idempotent; treats a missing file (empty string) as valid input. The guard is line-based and
+ * ignores comments, so a commented-out `# SOURCEMAP_FILE=` does not suppress injection while a real
+ * `export SOURCEMAP_FILE=` / `SOURCEMAP_FILE=` (user's custom map path) is left untouched.
+ */
 export function addSourcemapFileEnv(xcodeEnv: string): string {
     const alreadySet = xcodeEnv.split('\n').some((line) => {
         const trimmed = line.trim();
@@ -56,7 +60,7 @@ export function addSourcemapFileEnv(xcodeEnv: string): string {
     return `${base}# Flare: emit the composed Hermes sourcemap so the upload phase can find it\n${SOURCEMAP_FILE_LINE}\n`;
 }
 
-/** Append `flare.json` to .gitignore once (the file is generated from app.json props). */
+/** Append `flare.json` to .gitignore once (it is generated from app.json props). */
 export function ensureGitignored(gitignore: string, entry: string = GITIGNORE_ENTRY): string {
     const present = gitignore.split('\n').some((line) => line.trim() === entry);
     if (present) {
@@ -66,24 +70,24 @@ export function ensureGitignored(gitignore: string, entry: string = GITIGNORE_EN
     return `${base}${entry}\n`;
 }
 
-/** The shell body of the iOS "Upload Flare sourcemaps" phase: source RN's
- * with-environment.sh (so SOURCEMAP_FILE/FLARE_* are present), then run flare-xcode.sh. */
+/**
+ * Shell body of the iOS "Upload Flare sourcemaps" phase: source RN's with-environment.sh (so
+ * SOURCEMAP_FILE/FLARE_* are present), then run flare-xcode.sh.
+ */
 export function flareXcodeShellScript(withEnvironmentPath: string, flareXcodePath: string): string {
     return [
         'set -e',
         `WITH_ENVIRONMENT="${withEnvironmentPath}"`,
         `FLARE_XCODE="${flareXcodePath}"`,
-        // Invoke with-environment.sh directly with the Flare script as a single
-        // quoted argument (its documented `./with-environment.sh <command>` usage),
-        // rather than reconstructing a `sh -c "$A $B"` command string that
-        // word-splits on any space in either path.
+        // Invoke with-environment.sh with the Flare script as a single quoted argument (its documented
+        // `./with-environment.sh <command>` usage), not a `sh -c "$A $B"` string that word-splits on
+        // any space in either path.
         '/bin/sh "$WITH_ENVIRONMENT" "$FLARE_XCODE"',
         '',
     ].join('\n');
 }
 
-/** path.relative, normalised to forward slashes (Gradle/Xcode script paths are posix
- * even when prebuild runs on Windows). */
+/** path.relative normalised to forward slashes (Gradle/Xcode paths are posix even on Windows). */
 export function toPosixRelative(fromDir: string, target: string): string {
     return relative(fromDir, target).split(sep).join('/');
 }

--- a/packages/react-native-sourcemaps/src/expoXcode.ts
+++ b/packages/react-native-sourcemaps/src/expoXcode.ts
@@ -2,12 +2,12 @@ import type { XcodeProject } from '@expo/config-plugins';
 
 export const FLARE_PHASE_NAME = 'Upload Flare sourcemaps';
 
-// The `xcode` lib encodes the "Based on dependency analysis" checkbox as a numeric
-// flag on the build phase; 1 means "always out of date" (unchecked → runs every build).
+// The `xcode` lib encodes the "Based on dependency analysis" checkbox as a numeric flag; 1 means
+// "always out of date" (unchecked, runs every build).
 const ALWAYS_OUT_OF_DATE = 1;
 
-// The `xcode` runtime API (mutated in place) is broader than the published type, so
-// access the parts we need through a minimal structural view.
+// The `xcode` runtime API (mutated in place) is broader than its published type; access what we need
+// through a minimal structural view.
 type ShellScriptPhase = { name?: string; alwaysOutOfDate?: number };
 type XcodeInternal = {
     hash: { project: { objects: Record<string, Record<string, ShellScriptPhase | string>> } };
@@ -21,11 +21,10 @@ type XcodeInternal = {
 };
 
 /**
- * Append an "Upload Flare sourcemaps" shell-script phase to the app target. The phase
- * is APPENDED (so it always runs after the JS bundle phase, whatever that phase is
- * named or wherever it sits across Expo SDKs). Idempotency guard: skip if a phase with
- * our name already exists. Note this mutates `project` in place (the `xcode` lib's
- * contract) and returns the same instance for convenience.
+ * Append an "Upload Flare sourcemaps" shell-script phase to the app target. Appended so it always
+ * runs after the JS bundle phase, whatever that phase is named or wherever it sits across Expo SDKs.
+ * Skips if a phase with our name already exists. Mutates `project` in place (the `xcode` lib's
+ * contract) and returns the same instance.
  */
 export function addUploadBuildPhase(project: XcodeProject, shellScript: string): XcodeProject {
     const internal = project as unknown as XcodeInternal;
@@ -45,10 +44,9 @@ export function addUploadBuildPhase(project: XcodeProject, shellScript: string):
         shellPath: '/bin/sh',
         shellScript,
     });
-    // Uncheck "Based on dependency analysis": the phase has no input/output files, so
-    // without this Xcode warns ("ambiguous dependencies ... runs on every build") on
-    // every build. We *want* it to run every release build — it self-skips when there
-    // is no map, no key, or no version.
+    // Uncheck "Based on dependency analysis": the phase has no input/output files, so without this
+    // Xcode warns ("ambiguous dependencies ... runs on every build"). We want it to run every release
+    // build; it self-skips when there is no map, key, or version.
     buildPhase.alwaysOutOfDate = ALWAYS_OUT_OF_DATE;
     return project;
 }

--- a/packages/react-native-sourcemaps/src/runtime.ts
+++ b/packages/react-native-sourcemaps/src/runtime.ts
@@ -1,12 +1,11 @@
 /**
- * The build-time sourcemap version, for `flare.configure({ sourcemapVersionId })`.
+ * Build-time sourcemap version, for `flare.configure({ sourcemapVersionId })`.
  *
- * `@flareapp/react-native-sourcemaps/babel` replaces every reference to this
- * binding with the resolved version string literal at bundle time, then drops the
- * import. Without that Babel plugin it stays an empty string (meaning "no version"),
- * which is harmless because sourcemaps are only uploaded for release builds.
+ * The `.../babel` plugin replaces every reference to this binding with the resolved version literal at
+ * bundle time, then drops the import. Without that plugin it stays an empty string ("no version"),
+ * which is harmless since sourcemaps are only uploaded for release builds.
  *
- * This module is runtime-safe: it has no Node imports, so it is safe to import into
- * app code that Metro bundles (unlike the package root, which pulls in the uploader).
+ * Runtime-safe: no Node imports, so safe to import into Metro-bundled app code (unlike the package
+ * root, which pulls in the uploader).
  */
 export const flareSourcemapVersion: string = '';

--- a/packages/react-native-sourcemaps/src/version.ts
+++ b/packages/react-native-sourcemaps/src/version.ts
@@ -11,10 +11,9 @@ export type ResolveVersionOptions = {
 };
 
 /**
- * Resolve the sourcemap version shared by the Babel plugin and the CLI.
- * Precedence: explicit `version` > `FLARE_SOURCEMAP_VERSION` env > package.json
- * `version` (with a warning). Never a random value — a random default would
- * silently desync the inlined runtime value from the uploaded `version_id`.
+ * Resolve the sourcemap version shared by the Babel plugin and the CLI. Precedence: explicit
+ * `version` > `FLARE_SOURCEMAP_VERSION` env > package.json `version` (with a warning). Never random: a
+ * random default would silently desync the inlined runtime value from the uploaded `version_id`.
  */
 export function resolveVersion({ version, cwd = process.cwd() }: ResolveVersionOptions = {}): string {
     if (version) {
@@ -43,13 +42,11 @@ export function resolveVersion({ version, cwd = process.cwd() }: ResolveVersionO
 }
 
 /**
- * Version resolution for the AUTOMATIC native upload path. Unlike resolveVersion it
- * NEVER falls back to package.json: the hook runs in android/ or ios/, a different
- * cwd than Metro, so a package.json fallback would read a different (or missing)
- * file and silently desync from the version the Babel plugin inlined. The only
- * input guaranteed identical to both halves is FLARE_SOURCEMAP_VERSION. Returns
- * null when unresolved so the caller can skip-with-banner rather than upload a
- * guaranteed-mismatched map.
+ * Version resolution for the automatic native upload path. Unlike resolveVersion, never falls back to
+ * package.json: the hook runs in android/ or ios/ (a different cwd than Metro), so a package.json
+ * fallback would read a different or missing file and desync from the version the Babel plugin
+ * inlined. FLARE_SOURCEMAP_VERSION is the only input guaranteed identical to both halves. Returns null
+ * when unresolved so the caller can skip-with-banner rather than upload a mismatched map.
  */
 export function resolveAutoVersion(version?: string): string | null {
     if (version) {

--- a/packages/react-native-sourcemaps/tests/banner.test.ts
+++ b/packages/react-native-sourcemaps/tests/banner.test.ts
@@ -11,10 +11,9 @@ describe('formatFailureBanner', () => {
     });
 
     test('puts the reason on its own `  Reason: <reason>` line (parsed by flare-xcode.sh)', () => {
-        // flare-xcode.sh lifts this exact line into the Xcode-visible warning via
-        // `sed -n 's/^[[:space:]]*Reason:[[:space:]]*//p'`, so the format is a contract:
-        // two-space indent, `Reason: `, then the reason. Don't change it without
-        // updating that script.
+        // flare-xcode.sh lifts this exact line into the Xcode warning via
+        // `sed -n 's/^[[:space:]]*Reason:[[:space:]]*//p'`. The format is a contract (two-space
+        // indent, `Reason: `, then the reason); don't change it without updating that script.
         const lines = formatFailureBanner({ reason: 'FLARE_SOURCEMAP_VERSION is not set' }).split('\n');
         expect(lines).toContain('  Reason: FLARE_SOURCEMAP_VERSION is not set');
     });

--- a/packages/react-native-sourcemaps/tests/cli.test.ts
+++ b/packages/react-native-sourcemaps/tests/cli.test.ts
@@ -5,8 +5,8 @@ import { readFlareConfig } from '../src/config';
 import { uploadSourcemaps } from '../src/uploadSourcemaps';
 
 vi.mock('../src/uploadSourcemaps', () => ({ uploadSourcemaps: vi.fn().mockResolvedValue(undefined) }));
-// flare.json reading is covered in config.test.ts; here we stub it so the CLI's
-// key/endpoint resolution falls through to flags/env deterministically.
+// flare.json reading is covered in config.test.ts; stub it here so key/endpoint resolution falls
+// through to flags/env deterministically.
 vi.mock('../src/config', () => ({ readFlareConfig: vi.fn().mockReturnValue({}) }));
 
 afterEach(() => {

--- a/packages/react-native-sourcemaps/tests/expo.test.ts
+++ b/packages/react-native-sourcemaps/tests/expo.test.ts
@@ -17,8 +17,8 @@ describe('expo config plugin', () => {
             };
         };
 
-        // The flare.json write must land whichever platform EAS prebuilds, so a
-        // dangerous mod is registered for BOTH platforms.
+        // flare.json must land whichever platform EAS prebuilds, so a dangerous mod is registered for
+        // both.
         expect(typeof out.mods?.ios?.dangerous).toBe('function');
         expect(typeof out.mods?.android?.dangerous).toBe('function');
         // Platform-specific native mods: iOS build phase + Android gradle apply.

--- a/packages/react-native-sourcemaps/tests/expoXcode.test.ts
+++ b/packages/react-native-sourcemaps/tests/expoXcode.test.ts
@@ -47,11 +47,10 @@ describe('addUploadBuildPhase', () => {
         expect(serialised).toContain('flare-marker');
     });
 
-    // The in-memory checks above say nothing about whether the phase survives being
-    // written back to the pbxproj text format — the xcode lib quote-escapes shellScript
-    // (`'"' + script.replace(/"/g,'\\"') + '"'`), and our real script is multi-line with
-    // embedded quotes, which is exactly where that lib is fragile. writeSync() exercises
-    // the serializer end to end.
+    // The in-memory checks above don't prove the phase survives serialization to pbxproj text. The
+    // xcode lib quote-escapes shellScript (`'"' + script.replace(/"/g,'\\"') + '"'`), and our real
+    // script is multi-line with embedded quotes, exactly where that lib is fragile. writeSync()
+    // exercises the serializer end to end.
     test('survives pbxproj serialization (writeSync)', () => {
         const project = parseFixture();
         addUploadBuildPhase(project, 'set -e\necho "flare-marker"\n');
@@ -60,8 +59,8 @@ describe('addUploadBuildPhase', () => {
         expect(pbxproj).toContain('flare-marker');
     });
 
-    // "Based on dependency analysis" unchecked → no "ambiguous dependencies / runs on
-    // every build" warning from Xcode. Serialized as `alwaysOutOfDate = 1`.
+    // "Based on dependency analysis" unchecked, no "ambiguous dependencies / runs on every build"
+    // warning from Xcode. Serialized as `alwaysOutOfDate = 1`.
     test('marks the phase always-out-of-date so Xcode does not warn', () => {
         const project = parseFixture();
         addUploadBuildPhase(project, 'echo flare');

--- a/packages/react-native-sourcemaps/tests/runtime.test.ts
+++ b/packages/react-native-sourcemaps/tests/runtime.test.ts
@@ -4,8 +4,8 @@ import { flareSourcemapVersion } from '../src/runtime';
 
 describe('flareSourcemapVersion', () => {
     test('defaults to an empty string when the Babel plugin has not inlined it', () => {
-        // Without the Babel transform the source value is the empty-string default,
-        // which is harmless: sourcemaps are only uploaded for release builds.
+        // Without the Babel transform the value is the empty-string default; harmless, since
+        // sourcemaps are only uploaded for release builds.
         expect(flareSourcemapVersion).toBe('');
     });
 });

--- a/packages/react-native/src/Flare.ts
+++ b/packages/react-native/src/Flare.ts
@@ -8,41 +8,26 @@ import { installRejectionTracking } from './handlers/rejectionTracking';
 import type { RejectionDeps } from './handlers/rejectionTracking';
 import { ReactNativeFlushScheduler } from './ReactNativeFlushScheduler';
 
-// `process.env.FLARE_JS_CLIENT_VERSION` is replaced at BUILD time by tsdown's
-// `--env` define, becoming a string literal in the output. It must be a PLAIN
-// member access (no optional chaining, no `typeof process` guard) — unlike
-// node's version, which guards on `process` existing. RN has no `process` at
-// runtime, so node's guard would defeat the inlined literal and fall back to
-// '?'. After the define replacement no `process` reference survives. In the
-// vitest source path (real node) it reads undefined and falls back to '?',
-// which is fine for tests.
-//
-// Do NOT add a local `declare const process` here: a local declaration shadows
-// the global identifier and stops rolldown's `--env` define from matching the
-// member access, so the version would never inline. The global `process` type
-// comes from the toolchain (@types/node), which keeps tsc happy.
+// `process.env.FLARE_JS_CLIENT_VERSION` is inlined at build time by tsdown's `--env` define. Keep it a
+// PLAIN member access: a `typeof process` guard (like node's) would defeat the inline, since RN has no
+// runtime `process`. Do NOT add a local `declare const process`; it shadows the global and stops the
+// define from matching, so the version never inlines. Under vitest (real node) it reads '?', fine for tests.
 const RN_SDK_NAME = '@flareapp/react-native';
 const RN_SDK_VERSION: string = (process.env.FLARE_JS_CLIENT_VERSION as string | undefined) ?? '?';
 const RN_FRAMEWORK_NAME = 'React Native';
 
-// How long a fatal JS crash holds the app open to drain the transport before
-// delegating to RN's crash-triggering default handler (see globalErrorHandler).
+/** How long a fatal JS crash holds the app open to drain the transport before delegating to RN's default handler (see globalErrorHandler). */
 const FATAL_FLUSH_TIMEOUT_MS = 2000;
 
 /**
  * React Native `Flare` singleton (exposed as `flare` from the package root).
  *
- * Subclasses core's `Flare`, injecting the RN seams:
- * - core `Api` (fetch is native in RN),
- * - `makeReactNativeContextCollector(() => this.user)` for device/app/user attrs,
- * - core `NullFileReader` (no runtime source snippets; sourcemaps are a Metro
- *   follow-up),
- * - core `GlobalScopeProvider` (RN is a single app scope),
- * - `ReactNativeFlushScheduler` (flush on background, best-effort).
+ * Subclasses core's `Flare`, injecting the RN seams: core `Api` (native fetch), the RN context collector,
+ * core `NullFileReader` (no runtime snippets; sourcemaps are a Metro follow-up), core `GlobalScopeProvider`
+ * (RN is a single app scope), and `ReactNativeFlushScheduler` (best-effort flush on background).
  *
- * Adds RN-only surface: `removeHandlers` and an idempotent handler install folded
- * into `light()`. `setUser` is inherited from core, which writes the backend-read
- * `user.*` identity keys to the active scope (RN uses the single global scope).
+ * Adds RN-only surface: `removeHandlers` and an idempotent handler install folded into `light()`. `setUser`
+ * is inherited from core, writing the backend-read `user.*` keys to the single global scope.
  */
 export class ReactNativeFlare extends CoreFlare {
     private readonly scheduler: ReactNativeFlushScheduler;
@@ -51,10 +36,8 @@ export class ReactNativeFlare extends CoreFlare {
     private uninstallers: Array<() => void> = [];
 
     /**
-     * @param rejectionDeps test seam for the rejection hook. Defaults to `{}`
-     *        (resolve the active engine's tracker — Hermes or JSC). Tests pass
-     *        `{ enable: null }` so `light()` does NOT enable a global rejection
-     *        tracker as a leaking side effect.
+     * @param rejectionDeps test seam for the rejection hook. Default `{}` resolves the active engine's
+     *        tracker (Hermes or JSC). Tests pass `{ enable: null }` so `light()` installs no leaking global tracker.
      */
     constructor(rejectionDeps: RejectionDeps = {}) {
         const scheduler = new ReactNativeFlushScheduler();
@@ -63,27 +46,21 @@ export class ReactNativeFlare extends CoreFlare {
         this.scheduler = scheduler;
         this.rejectionDeps = rejectionDeps;
         this.setSdkInfo({ name: RN_SDK_NAME, version: RN_SDK_VERSION });
-        // Tag the framework identity proactively so it holds even when no
-        // FlareErrorBoundary is mounted to tag it (see setFramework below).
+        // Tag framework identity up front so it holds even without a FlareErrorBoundary to tag it.
         this.setFramework({ name: RN_FRAMEWORK_NAME });
     }
 
     /**
-     * Force the framework identity to "React Native". The wrapped
-     * `@flareapp/react` boundary tags every flare it injects as `React` (via
-     * `tagReactFramework`), which is wrong on the RN singleton — so coerce the
-     * name here while preserving whatever version the caller supplied (the React
-     * renderer version when the boundary tags it).
+     * Force the framework name to "React Native", preserving the caller's version. The wrapped
+     * `@flareapp/react` boundary tags injected flares as `React` (via `tagReactFramework`), wrong here.
      */
     setFramework(framework: Framework): this {
         return super.setFramework({ ...framework, name: RN_FRAMEWORK_NAME });
     }
 
     /**
-     * Set the API key (and optional debug flag), then install the global
-     * handlers. The install is idempotent — calling `light()` twice does NOT
-     * double-wrap `ErrorUtils` (which, unlike node's reconcile, is not naturally
-     * idempotent).
+     * Set the API key (and optional debug flag), then install the global handlers. Idempotent: calling
+     * `light()` twice does not double-wrap `ErrorUtils` (which, unlike node's reconcile, is not naturally so).
      */
     light(key?: string, debug?: boolean): this {
         super.light(key, debug);
@@ -92,19 +69,17 @@ export class ReactNativeFlare extends CoreFlare {
     }
 
     /**
-     * Detach the global error handler, rejection tracker, and AppState listener,
-     * and clear the install guard so a later `light()` re-installs. For tests
-     * and manual teardown (mirrors node's `removeProcessListeners`).
+     * Detach the global error handler, rejection tracker, and AppState listener, and clear the install
+     * guard so a later `light()` re-installs. For tests and manual teardown (mirrors node's `removeProcessListeners`).
      */
     removeHandlers(): void {
-        // Guard each uninstaller individually: one throwing teardown (e.g. a
-        // malformed AppState subscription) must not strand the remaining handlers
-        // attached or leave the install guard set, which would block re-install.
+        // Guard each uninstaller individually so one throwing teardown does not strand the rest attached
+        // or leave the install guard set, which would block re-install.
         for (const uninstall of this.uninstallers) {
             try {
                 uninstall();
             } catch {
-                // Best-effort teardown; nothing actionable if an uninstaller throws.
+                // Best-effort teardown.
             }
         }
         this.uninstallers = [];
@@ -115,26 +90,21 @@ export class ReactNativeFlare extends CoreFlare {
         if (this.installed) return;
         this.installed = true;
         this.uninstallers.push(
-            // `reportSilently` (not `report`) is deliberate: it swallows its own
-            // transport rejection so a reporting failure can't trigger a second
-            // error inside the global handler. `isFatal` is attached as an
-            // attribute so a fatal JS crash is distinguishable in Flare. The
-            // `onFatal` hook drains the transport before the app is torn down on a
-            // production fatal crash (best-effort; see globalErrorHandler).
+            // `reportSilently` (not `report`) swallows its own transport rejection so a reporting failure
+            // can't trigger a second error inside the global handler. `isFatal` rides as an attribute.
+            // `onFatal` drains the transport before a production fatal crash tears the app down (see globalErrorHandler).
             installGlobalErrorHandler(
                 (error, isFatal) => {
                     this.reportSilently(error, { 'error.fatal': isFatal });
                 },
                 () => this.flush(FATAL_FLUSH_TIMEOUT_MS),
             ),
-            // Reporter mirrors the browser unhandledrejection path: Error /
-            // stack-bearing reasons keep their stack via reportSilently; only
-            // stackless reasons fall back to reportUnhandledRejection.
+            // Mirrors the browser unhandledrejection path: stack-bearing reasons keep their stack via
+            // reportSilently, stackless reasons fall back to reportUnhandledRejection.
             installRejectionTracking(
                 {
                     reportSilently: (error) => this.reportSilently(error),
-                    // Return the promise (no `void`) so `routeRejection` owns the
-                    // `.catch`, matching the browser SDK's wiring in @flareapp/js.
+                    // Return the promise (no `void`) so `routeRejection` owns the `.catch`, matching @flareapp/js.
                     reportUnhandledRejection: (message) => this.reportUnhandledRejection(message),
                 },
                 this.rejectionDeps,

--- a/packages/react-native/src/FlareErrorBoundary.ts
+++ b/packages/react-native/src/FlareErrorBoundary.ts
@@ -5,15 +5,10 @@ import { createElement, type ReactElement } from 'react';
 import { flare } from './singleton';
 
 /**
- * React Native error boundary. A thin wrapper over `@flareapp/react`'s
- * `/inject` boundary that injects the RN `flare` singleton.
- *
- * `flare` is applied AFTER `{...props}` so a consumer cannot override the
- * singleton. The `as unknown as Flare` cast is required: the boundary prop is
- * typed against `@flareapp/js/browser`'s `Flare` (a superset of
- * `ReactNativeFlare`), so structural assignment does not hold. Safe at runtime —
- * the boundary only calls a core-level method (`reportSilently`), which
- * `ReactNativeFlare` inherits.
+ * React Native error boundary: a thin wrapper over `@flareapp/react`'s `/inject` boundary that injects the
+ * RN `flare` singleton. `flare` is applied after `{...props}` so a consumer cannot override it. The
+ * `as unknown as Flare` cast is needed because the prop is typed against `@flareapp/js/browser`'s `Flare`
+ * (a superset); safe at runtime since the boundary only calls `reportSilently`, which RN inherits.
  */
 export function FlareErrorBoundary(props: Omit<FlareErrorBoundaryProps, 'flare'>): ReactElement {
     return createElement(InjectBoundary, { ...props, flare: flare as unknown as Flare });

--- a/packages/react-native/src/ReactNativeFlushScheduler.ts
+++ b/packages/react-native/src/ReactNativeFlushScheduler.ts
@@ -1,15 +1,12 @@
 import type { FlushFn, FlushScheduler } from '@flareapp/core';
 
 /**
- * Passive flush scheduler for React Native. Core's `Logger` calls `register`
- * once during construction; this stores the flush callback and exposes a plain,
- * argument-less caller via `getFlush()`. The actual trigger (AppState ->
- * background) is wired separately in `Flare.install()` so it stays symmetric
- * with handler teardown.
+ * Passive flush scheduler for React Native. Core's `Logger` calls `register` once; this stores the flush
+ * callback and exposes an argument-less caller via `getFlush()`. The trigger (AppState -> background) is
+ * wired separately in `Flare.install()` to stay symmetric with handler teardown.
  *
- * Deliberately calls `flush()` WITHOUT `{ keepalive: true }`: RN's fetch (over
- * XMLHttpRequest) does not reliably honor keepalive, so a backgrounding flush is
- * best-effort and may be dropped if the OS suspends the app mid-request.
+ * Calls `flush()` without `{ keepalive: true }`: RN's fetch (over XMLHttpRequest) doesn't reliably honor
+ * keepalive, so a backgrounding flush is best-effort and may drop if the OS suspends the app mid-request.
  */
 export class ReactNativeFlushScheduler implements FlushScheduler {
     private flushFn: FlushFn | null = null;

--- a/packages/react-native/src/context/collectReactNative.ts
+++ b/packages/react-native/src/context/collectReactNative.ts
@@ -4,22 +4,14 @@ import { Dimensions, Platform } from 'react-native';
 import { type ExpoModules, loadExpoModules, projectExpoContext } from './expo';
 
 /**
- * Build the React Native `ContextCollector` that core's `Flare` calls on every
- * report. Synchronous, matching `ContextCollector = (config) => Attributes`.
+ * Build the synchronous React Native `ContextCollector` core's `Flare` calls on every report. Two layers:
+ * RN core (`Platform`, `Dimensions`, read per call) and Expo constants (resolved once, absent on bare RN).
  *
- * Sources, layered:
- * 1. RN core (`Platform`, `Dimensions`) — read on every call.
- * 2. Expo constants — resolved once (injected for tests, else `loadExpoModules()`)
- *    and projected; absent on bare RN.
+ * The authenticated user is not projected here: `Flare.setUser` (inherited from core) writes `user.*` keys
+ * straight to the active scope, like node and electron.
  *
- * The authenticated user is NOT projected here: `Flare.setUser` (inherited from
- * core) writes the `user.*` identity keys straight to the active scope, the same
- * model node and electron use.
- *
- * `Platform.Version` is a string on iOS but a number on Android, so it is
- * stringified for the `os.version` attribute. `Platform.OS` maps to `os.name`
- * (NOT `os.type`, which conventionally means the kernel family); when Expo is
- * present its `osName`/`osVersion` overwrite these coarser values.
+ * `Platform.Version` is a string on iOS, number on Android, so it's stringified for `os.version`.
+ * `Platform.OS` maps to `os.name` (not `os.type`, the kernel family); Expo's `osName`/`osVersion` override.
  */
 export function makeReactNativeContextCollector(expo: ExpoModules = loadExpoModules()): ContextCollector {
     const expoAttrs = projectExpoContext(expo);
@@ -36,21 +28,16 @@ export function makeReactNativeContextCollector(expo: ExpoModules = loadExpoModu
             ...expoAttrs,
         };
 
-        // Expo's `expo-device` supplies a friendly model on both platforms. Without
-        // it (bare RN), Android still exposes the model via `Platform.constants`;
-        // iOS core exposes none, so bare iOS has no model. Only fill when Expo
-        // didn't already provide one.
+        // Only fill the model when Expo didn't. Bare RN Android exposes it via `Platform.constants`;
+        // bare iOS exposes none.
         if (attrs['device.model.name'] == null) {
             const model = nativeModelName();
             if (model) attrs['device.model.name'] = model;
         }
 
-        // Also project the device info as a `context.device` group. The semantic
-        // attributes above (`device.*`, `app.*`) are not in Flare's typed
-        // AttributesData DTO yet, so they are not rendered; custom context groups
-        // ARE rendered generically by the Flare UI, so this surfaces the device
-        // info without a backend/type change. Built from `attrs` so Expo's
-        // os.name/os.version overrides are reflected.
+        // Also surface the device info as a `context.device` group: the semantic `device.*`/`app.*` attrs
+        // aren't in Flare's typed DTO yet so they don't render, but custom context groups do. Built from
+        // `attrs` so Expo's os.name/os.version overrides carry through.
         const device = buildDeviceContext(attrs);
         if (Object.keys(device).length > 0) attrs['context.device'] = device;
 
@@ -59,10 +46,8 @@ export function makeReactNativeContextCollector(expo: ExpoModules = loadExpoModu
 }
 
 /**
- * Native device model from `Platform.constants`. Android exposes
- * `Model`/`Manufacturer`/`Brand`; iOS core does not surface a device model (it
- * needs `expo-device` or a native module), so iOS returns undefined. Prefixes the
- * model with its maker when available (e.g. `Google Pixel 7`).
+ * Native device model from `Platform.constants`, maker-prefixed when available (e.g. `Google Pixel 7`).
+ * Android exposes `Model`/`Manufacturer`/`Brand`; iOS core surfaces none (needs `expo-device`), so undefined.
  */
 function nativeModelName(): string | undefined {
     if (Platform.OS !== 'android') return undefined;
@@ -73,9 +58,8 @@ function nativeModelName(): string | undefined {
 }
 
 /**
- * Build a human-readable `context.device` group from the collected semantic
- * attributes. Only present fields are included, so the bare app (no Expo)
- * naturally omits `model` / `appVersion` / `appId`.
+ * Build a human-readable `context.device` group from the semantic attributes. Only present fields are
+ * included, so bare RN (no Expo) omits `model`/`appVersion`/`appId`.
  */
 function buildDeviceContext(attrs: Attributes): Record<string, AttributeValue> {
     const device: Record<string, AttributeValue> = {};

--- a/packages/react-native/src/context/expo.ts
+++ b/packages/react-native/src/context/expo.ts
@@ -18,19 +18,11 @@ export type ExpoModules = {
 };
 
 /**
- * Lazy, synchronous Expo load. The `require(...)` calls are DIRECT string
- * literals on purpose: Metro statically collects only literal `require('pkg')`
- * calls and treats those inside a try/catch as OPTIONAL dependencies
- * (`allowOptionalDependencies` is on by default for the React Native CLI and
- * Expo), so a missing package degrades to a caught runtime throw instead of a
- * build error. Aliasing `require` to a local (`const req = require; req('pkg')`)
- * would defeat that static collection — Metro never adds the module to this
- * file's dependency map, so the require would fail to resolve even when the
- * package IS installed. So do NOT reintroduce an alias here.
- *
- * The `typeof require` guard keeps non-Metro/ESM environments (e.g. some test
- * runners, where `require` is undefined) safe; under Metro `require` always
- * exists in the `react-native`/CJS build this package ships.
+ * Lazy, synchronous Expo load. The `require(...)` calls MUST be direct string literals: Metro statically
+ * collects only literal `require('pkg')` calls, treating those inside a try/catch as optional deps
+ * (`allowOptionalDependencies` is on by default), so a missing package degrades to a caught throw not a
+ * build error. Do NOT alias `require` to a local; that defeats the static collection and the module never
+ * resolves even when installed. The `typeof require` guard keeps non-Metro/ESM envs (some test runners) safe.
  */
 export function loadExpoModules(): ExpoModules {
     const mods: ExpoModules = {};
@@ -38,23 +30,22 @@ export function loadExpoModules(): ExpoModules {
     try {
         mods.device = require('expo-device') as ExpoDeviceModule;
     } catch {
-        // expo-device not installed (bare RN) — skip.
+        // expo-device not installed (bare RN); skip.
     }
     try {
         mods.application = require('expo-application') as ExpoApplicationModule;
     } catch {
-        // expo-application not installed (bare RN) — skip.
+        // expo-application not installed (bare RN); skip.
     }
     return mods;
 }
 
-// Maps Expo's `DeviceType` enum (UNKNOWN=0, PHONE=1, TABLET=2, DESKTOP=3, TV=4) to a label.
+/** Maps Expo's `DeviceType` enum (UNKNOWN=0, PHONE=1, TABLET=2, DESKTOP=3, TV=4) to a label. */
 const DEVICE_TYPE_LABELS: Record<number, string> = { 1: 'phone', 2: 'tablet', 3: 'desktop', 4: 'tv' };
 
 /**
- * Project the synchronous Expo constants into report attributes. Only the
- * fields that are present (non-null, non-undefined) are emitted. Async Expo
- * getters are intentionally not used (the context collector is synchronous).
+ * Project the synchronous Expo constants into report attributes. Only present (non-null) fields are emitted.
+ * Async Expo getters are not used, since the context collector is synchronous.
  */
 export function projectExpoContext(expo: ExpoModules): Attributes {
     const attrs: Attributes = {};

--- a/packages/react-native/src/devMode.ts
+++ b/packages/react-native/src/devMode.ts
@@ -1,6 +1,5 @@
-// `__DEV__` is a React Native global (true in dev bundles, false and
-// dead-code-eliminated in production). Declared here for the type-checker;
-// guarded with `typeof` so non-RN environments (e.g. ESM test runners) are safe.
+// `__DEV__` is an RN global (true in dev bundles, dead-code-eliminated in production). Declared for the
+// type-checker; guarded with `typeof` so non-RN environments (ESM test runners) are safe.
 declare const __DEV__: boolean | undefined;
 
 /** True only in a React Native dev bundle. Safe (false) everywhere else. */

--- a/packages/react-native/src/handlers/appStateFlush.ts
+++ b/packages/react-native/src/handlers/appStateFlush.ts
@@ -1,16 +1,13 @@
 import { AppState, type AppStateStatus } from 'react-native';
 
 /**
- * Flush the log buffer when the app moves to the background. iOS fires
- * `inactive` on every transient interruption (app-switcher peek, Control Center,
- * incoming call), so we gate on `background` ONLY to avoid flooding the network
- * with redundant flushes. This mirrors the browser scheduler gating on `hidden`
- * (not every blur).
+ * Flush the log buffer when the app backgrounds. Gate on `background` only: iOS fires `inactive` on every
+ * transient interruption (app-switcher peek, Control Center, incoming call), so gating avoids flooding the
+ * network. Mirrors the browser scheduler gating on `hidden`, not every blur. Delivery is best-effort (see
+ * `ReactNativeFlushScheduler`).
  *
- * Delivery is best-effort: see `ReactNativeFlushScheduler`.
- *
- * Returns an uninstaller that removes the listener via the subscription handle
- * (modern RN API — do NOT use the removed `AppState.removeEventListener`).
+ * Returns an uninstaller that removes the listener via the subscription handle (modern RN API; do NOT use
+ * the removed `AppState.removeEventListener`).
  */
 export function installAppStateFlush(getFlush: () => (() => void) | undefined): () => void {
     const subscription = AppState.addEventListener('change', (state: AppStateStatus) => {

--- a/packages/react-native/src/handlers/globalErrorHandler.ts
+++ b/packages/react-native/src/handlers/globalErrorHandler.ts
@@ -14,22 +14,16 @@ function getErrorUtils(): ErrorUtilsLike | undefined {
 }
 
 /**
- * Wrap RN's `ErrorUtils` global handler. The wrapper reports the error and then
- * delegates to the previously-registered handler, so React Native's own behavior
- * (red box in dev, process crash in prod) is preserved — we observe, we do not
- * swallow. No-op when `ErrorUtils` is unavailable.
+ * Wrap RN's `ErrorUtils` global handler. The wrapper reports the error then delegates to the previous
+ * handler, preserving RN's own behavior (red box in dev, crash in prod): observe, don't swallow. No-op
+ * when `ErrorUtils` is absent.
  *
- * Fatal delivery (`onFatal`). On a FATAL error in a PRODUCTION bundle the
- * previous handler is what tears the app down, and our report is an async
- * `fetch` the OS would kill the instant the app dies — so a bare report almost
- * never sends. When `onFatal` is supplied we DEFER the previous handler until
- * `onFatal()` settles; it drains the transport via core's `flush(timeoutMs)`,
- * buying the report time to send before the crash. RN does not crash on its own
- * (the default handler triggers it), so deferring the delegate genuinely delays
- * the crash. This mirrors Sentry's React Native SDK. It is skipped in `__DEV__`
- * (don't fight the red box / debugger) and guarded by a re-entrancy latch, so a
- * second fatal arriving mid-flush delegates immediately rather than racing two
- * shutdowns.
+ * Fatal delivery (`onFatal`): on a fatal error in production, the previous handler tears the app down and
+ * our report is an async `fetch` the OS kills the instant the app dies, so a bare report rarely sends. When
+ * `onFatal` is supplied we defer the previous handler until it settles, draining the transport via core's
+ * `flush(timeoutMs)` first. Skipped in `__DEV__` (don't fight the red box / debugger) and guarded by a
+ * re-entrancy latch, so a second fatal arriving mid-flush delegates immediately rather than racing two
+ * shutdowns. Mirrors Sentry's RN SDK.
  *
  * Returns an uninstaller that restores the previous handler.
  */
@@ -47,7 +41,7 @@ export function installGlobalErrorHandler(
         try {
             report(convertToError(error), Boolean(isFatal));
         } catch {
-            // Reporting must never prevent RN's own error handling below.
+            // Reporting must never block RN's own error handling below.
         }
 
         if (isFatal && onFatal && !inDevMode() && !handlingFatal) {
@@ -55,11 +49,9 @@ export function installGlobalErrorHandler(
             void onFatal()
                 .catch(() => {})
                 .then(() => {
-                    // Delegate to the crash-triggering handler with the latch STILL
-                    // set, then clear it. In production `previous` tears the app down
-                    // so the latch never reopens; in a dev/test setup where `previous`
-                    // returns, a fatal arriving during it still delegates immediately
-                    // instead of starting a second flush cycle.
+                    // Delegate to the crash-triggering handler with the latch still set, then clear it. In
+                    // production `previous` tears the app down so the latch never reopens; if `previous`
+                    // returns (dev/test), a fatal during it delegates immediately, not a second flush cycle.
                     try {
                         previous?.(error, isFatal);
                     } finally {
@@ -75,9 +67,8 @@ export function installGlobalErrorHandler(
     errorUtils.setGlobalHandler(handler);
 
     return () => {
-        // No ErrorUtils API exists to clear a handler, so when there was no
-        // previous one we restore a swallowing no-op. RN always installs a
-        // default handler, so `previous` is effectively never undefined.
+        // No ErrorUtils API clears a handler, so with no previous one we restore a swallowing no-op. RN
+        // always installs a default handler, so `previous` is effectively never undefined.
         errorUtils.setGlobalHandler(previous ?? (() => {}));
     };
 }

--- a/packages/react-native/src/handlers/rejectionTracking.ts
+++ b/packages/react-native/src/handlers/rejectionTracking.ts
@@ -14,9 +14,8 @@ type HermesInternalLike = {
     enablePromiseRejectionTracker?: (options: EnableOptions) => void;
 };
 
-// The reporter shape and reason-routing (Error/stack-bearing -> reportSilently,
-// stackless -> reportUnhandledRejection) are shared with the browser listener;
-// they live in `@flareapp/core` (`routeRejection`) so the two SDKs cannot drift.
+// Reporter shape and reason-routing (stack-bearing -> reportSilently, stackless -> reportUnhandledRejection)
+// live in `@flareapp/core` (`routeRejection`), shared with the browser listener so the SDKs can't drift.
 export type { RejectionReporter };
 
 export type RejectionDeps = {
@@ -25,10 +24,9 @@ export type RejectionDeps = {
 };
 
 /**
- * Inputs to engine detection. Both default to the live runtime sources; tests
- * inject explicit values (e.g. `requirePolyfill: null`) to drive each branch
- * deterministically — necessary because the `promise` polyfill is hoisted into
- * the test env as a transitive dependency of react-native.
+ * Inputs to engine detection. Both default to the live runtime sources; tests inject explicit values (e.g.
+ * `requirePolyfill: null`) to drive each branch deterministically, since the `promise` polyfill is hoisted
+ * into the test env as a transitive dependency of react-native.
  */
 export type RejectionEngineDeps = {
     hermes?: HermesInternalLike | null;
@@ -36,18 +34,15 @@ export type RejectionEngineDeps = {
 };
 
 /**
- * Resolve the promise-rejection enabler for the ACTIVE JS engine.
+ * Resolve the promise-rejection enabler for the active JS engine, null when neither is reachable.
  *
- * - Hermes (RN's default engine since 0.70) tracks rejections on its native
- *   Promise via `global.HermesInternal.enablePromiseRejectionTracker`. The
- *   `promise` npm polyfill is NOT the runtime Promise on Hermes, so the
- *   polyfill's `rejection-tracking.enable()` would hook unused objects and
- *   silently never fire — we must use the Hermes hook here.
- * - JSC / non-Hermes: RN polyfills `global.Promise` with the `promise` package,
- *   so `promise/setimmediate/rejection-tracking.enable()` is the real hook.
+ * - Hermes (RN's default since 0.70): tracks on its native Promise via
+ *   `global.HermesInternal.enablePromiseRejectionTracker`. The `promise` npm polyfill is not the runtime
+ *   Promise here, so its `rejection-tracking.enable()` would hook unused objects and never fire.
+ * - JSC / non-Hermes: RN polyfills `global.Promise` with the `promise` package, so
+ *   `promise/setimmediate/rejection-tracking.enable()` is the real hook.
  *
- * Returns null when neither is reachable. Exported (with injectable deps) for
- * direct unit testing of the ordering; not re-exported from the package entry.
+ * Exported (with injectable deps) for unit-testing the ordering; not re-exported from the package entry.
  */
 export function resolveRejectionEnabler(deps: RejectionEngineDeps = {}): RejectionEnabler | null {
     const hermes =
@@ -67,7 +62,7 @@ export function resolveRejectionEnabler(deps: RejectionEngineDeps = {}): Rejecti
                 return (options) => tracker.enable(options);
             }
         } catch {
-            // polyfill not present — fall through to null
+            // polyfill not present; fall through to null
         }
     }
 
@@ -75,25 +70,19 @@ export function resolveRejectionEnabler(deps: RejectionEngineDeps = {}): Rejecti
 }
 
 /**
- * Best-effort capture of unhandled promise rejections, engine-aware. RN routes
- * these through its engine's tracker (NOT `window.onunhandledrejection`):
- * `HermesInternal.enablePromiseRejectionTracker` on Hermes, the `promise`
- * polyfill on JSC. Reasons are routed exactly like the browser
- * `unhandledrejection` handler (core's `routeRejection`), so Error reasons keep
- * their stack via `reportSilently`.
+ * Best-effort, engine-aware capture of unhandled promise rejections. RN routes these through the engine's
+ * tracker (not `window.onunhandledrejection`): `HermesInternal.enablePromiseRejectionTracker` on Hermes,
+ * the `promise` polyfill on JSC. Reasons route like the browser handler (core's `routeRejection`), so Error
+ * reasons keep their stack via `reportSilently`.
  *
- * Engine-dependent, NOT version-dependent: if no engine hook is reachable this
- * is a no-op (uncaught throws via ErrorUtils still work) and emits a dev-only
- * debug line; it must never crash. The `enable(...)` invocation is wrapped so a
- * throwing engine hook degrades to no-op instead of propagating.
+ * If no engine hook is reachable this is a no-op (uncaught throws via ErrorUtils still work) with a dev-only
+ * debug line; it must never crash. The `enable(...)` call is wrapped so a throwing hook degrades to no-op.
  *
- * Chaining caveat: enabling REPLACES the engine's current callbacks (RN
- * registers its own dev warning) and neither engine exposes a getter for the
- * previous ones, so we cannot truly chain RN's default. To avoid swallowing that
- * developer signal, `onUnhandled` re-emits a `console.warn` in dev (`__DEV__`).
+ * Chaining caveat: enabling replaces the engine's current callbacks (RN registers its own dev warning) and
+ * neither engine exposes a getter for the previous ones, so we can't chain RN's default. To avoid swallowing
+ * that signal, `onUnhandled` re-emits a `console.warn` in dev.
  *
- * Returns an uninstaller that re-enables with no-op callbacks (no clean disable
- * exists on either engine).
+ * Returns an uninstaller that re-enables with no-op callbacks (no clean disable exists on either engine).
  */
 export function installRejectionTracking(reporter: RejectionReporter, deps: RejectionDeps = {}): () => void {
     const enable = deps.enable !== undefined ? deps.enable : resolveRejectionEnabler();
@@ -116,7 +105,7 @@ export function installRejectionTracking(reporter: RejectionReporter, deps: Reje
             onHandled: () => {},
         });
     } catch {
-        // A throwing engine hook must not crash app startup — degrade to no-op.
+        // A throwing engine hook must not crash app startup; degrade to no-op.
         if (inDevMode()) {
             console.debug('[flare] Promise-rejection hook threw on enable; rejections not captured.');
         }

--- a/packages/react-native/src/types.ts
+++ b/packages/react-native/src/types.ts
@@ -1,4 +1,3 @@
-// The RN SDK uses core's identity model: `Flare.setUser` (inherited) projects the
-// known fields to the backend-read `user.*` keys (id, email, full_name, client
-// address) and bundles any extra key into `user.attributes`.
+// RN uses core's identity model: `Flare.setUser` (inherited) projects known fields to the backend-read
+// `user.*` keys (id, email, full_name, client address) and bundles extras into `user.attributes`.
 export type { User } from '@flareapp/core';

--- a/packages/react-native/tests/flare.test.ts
+++ b/packages/react-native/tests/flare.test.ts
@@ -30,9 +30,8 @@ afterEach(() => {
     vi.restoreAllMocks();
 });
 
-// `{ enable: null }` disables the rejection hook so light() does NOT enable a
-// real global rejection tracker as a leaking side effect (the `promise` package
-// may resolve in the node test env, or a HermesInternal stub could be present).
+// `{ enable: null }` disables the rejection hook so light() installs no leaking global tracker (the
+// `promise` package may resolve in the node test env, or a HermesInternal stub could be present).
 function makeFlare(): ReactNativeFlare {
     return new ReactNativeFlare({ enable: null });
 }
@@ -78,9 +77,7 @@ describe('ReactNativeFlare', () => {
         const flare = makeFlare();
         const fake = withFakeApi(flare);
         flare.light('k');
-        // setUser is inherited from core: the known fields project to the
-        // backend-read `user.*` keys (written to the global scope), and any extra
-        // key lands in `user.attributes`.
+        // setUser (inherited from core): known fields project to `user.*` keys, extras to `user.attributes`.
         flare.setUser({ id: 42, email: 'u@x.io', fullName: 'Neo Anderson', role: 'admin' });
 
         ctl.emit(new Error('with-user'), false);

--- a/packages/react/src/FlareErrorBoundary.ts
+++ b/packages/react/src/FlareErrorBoundary.ts
@@ -33,13 +33,9 @@ export class FlareErrorBoundary extends Component<FlareErrorBoundaryProps, Flare
 
     constructor(props: FlareErrorBoundaryProps) {
         super(props);
-        // Resolve ONCE at construction (boot), not per error. Throws here if no
-        // instance and no registered default — a wiring bug fails fast.
-        //
-        // Contract: resolved per BOUNDARY INSTANCE and cached for its lifetime. Changing the
-        // `flare` prop on an already-mounted boundary has NO effect — the instance resolved at
-        // construction keeps being used. `flare` is expected to be a stable singleton (the web
-        // default or one RendererFlare), not a value that varies across renders.
+        // Resolve once at construction, not per error; throws if no instance and no registered
+        // default. Cached per boundary instance for its lifetime: changing the `flare` prop on a
+        // mounted boundary has no effect. `flare` is expected to be a stable singleton.
         this.flare = resolveFlare(props.flare);
         tagReactFramework(this.flare);
     }
@@ -69,8 +65,7 @@ export class FlareErrorBoundary extends Component<FlareErrorBoundaryProps, Flare
 
         this.setState({ componentStack: finalContext.react.componentStack });
 
-        // Swallow rejection from the report call. A network/transport failure in the error reporter
-        // must not bubble up and cause a second render error inside the boundary itself.
+        // Swallow report rejections: a transport failure must not bubble into a second render error.
         this.flare.reportSilently(error, contextToAttributes(finalContext));
 
         this.props.afterSubmit?.({
@@ -80,9 +75,8 @@ export class FlareErrorBoundary extends Component<FlareErrorBoundaryProps, Flare
         });
     }
 
-    // resetKeys mirrors react-error-boundary's contract: when any element of the array changes by
-    // Object.is, the boundary auto-resets. Use this to recover from an error after a route change
-    // or a retry button toggling a counter, without the consumer wiring up resetErrorBoundary().
+    // resetKeys mirrors react-error-boundary: when any element changes by Object.is, the boundary
+    // auto-resets, recovering after a route change or retry without calling resetErrorBoundary().
     componentDidUpdate(prevProps: FlareErrorBoundaryProps) {
         if (this.state.error === null || !this.props.resetKeys) {
             return;

--- a/packages/react/src/constants.ts
+++ b/packages/react/src/constants.ts
@@ -1,14 +1,14 @@
-// Chrome:
-// "at ComponentName (http://localhost:5173/src/App.tsx:12:9)"
-// (no source): "at div"
+/**
+ * Chrome: `at ComponentName (http://localhost:5173/src/App.tsx:12:9)`; no source: `at div`.
+ */
 export const CHROMIUM_STACK_REGEX = /^at\s+(\S+)(?:\s+\((.+):(\d+):(\d+)\))?$/;
 
-// Firefox/Safari:
-// "ComponentName@http://localhost:5173/src/App.tsx:12:9"
-// (no source): "div"
+/**
+ * Firefox/Safari: `ComponentName@http://localhost:5173/src/App.tsx:12:9`; no source: `div`.
+ */
 export const FIREFOX_SAFARI_STACK_REGEX = /^(\S+?)@(.+):(\d+):(\d+)$/;
 
-// Injected at build time via tsdown --env.PACKAGE_VERSION (reads package.json version).
+/** Injected at build time via tsdown --env.PACKAGE_VERSION (reads package.json version). */
 export const PACKAGE_VERSION =
     typeof process !== 'undefined' && typeof process.env?.PACKAGE_VERSION !== 'undefined'
         ? process.env.PACKAGE_VERSION

--- a/packages/react/src/env.d.ts
+++ b/packages/react/src/env.d.ts
@@ -1,6 +1,4 @@
-// Provides the `process` type for type-checking only.
-// tsconfig.json sets "types": ["@testing-library/jest-dom"] which excludes @types/node.
-// Removing that field would break jest-dom matcher typings (.toBeInTheDocument() etc.).
-// tsdown replaces process.env.PACKAGE_VERSION with a string literal at build time.
-// This file must NOT be imported — it is an ambient declaration picked up by tsc via "include".
+// Ambient `process` type for type-checking only; picked up by tsc via "include", never imported.
+// tsconfig "types": ["@testing-library/jest-dom"] excludes @types/node (dropping it breaks jest-dom
+// matcher typings). tsdown replaces process.env.PACKAGE_VERSION with a string literal at build time.
 declare const process: { env?: { PACKAGE_VERSION?: string } } | undefined;

--- a/packages/react/src/flareReactErrorHandler.ts
+++ b/packages/react/src/flareReactErrorHandler.ts
@@ -24,8 +24,10 @@ export type FlareReactErrorHandlerOptions = {
     }) => void;
 };
 
-// Returns a callback shaped to match react-error-boundary's `onError` prop, so consumers using
-// that library can report to Flare without wrapping their app in our own boundary.
+/**
+ * Callback shaped to match react-error-boundary's `onError` prop, so consumers using that library
+ * can report to Flare without our own boundary.
+ */
 export function flareReactErrorHandler(options?: FlareReactErrorHandlerOptions): FlareReactErrorHandlerCallback {
     const flare = resolveFlare(options?.flare);
     tagReactFramework(flare);
@@ -46,7 +48,7 @@ export function flareReactErrorHandler(options?: FlareReactErrorHandlerOptions):
                 context,
             }) ?? context;
 
-        // See FlareErrorBoundary: rejection is swallowed so the reporter can't crash the host.
+        // See FlareErrorBoundary: rejection swallowed so the reporter can't crash the host.
         flare.reportSilently(errorObject, contextToAttributes(finalContext));
 
         options?.afterSubmit?.({ error: errorObject, errorInfo, context: finalContext });

--- a/packages/react/src/identify.ts
+++ b/packages/react/src/identify.ts
@@ -3,12 +3,12 @@ import * as React from 'react';
 
 import { PACKAGE_VERSION } from './constants';
 
-// Per-instance guards. A boolean cannot serve injection: with a singleton AND an
-// injected RendererFlare, each instance must be tagged independently.
+// Per-instance guards. A boolean can't serve injection: with a singleton and an injected
+// RendererFlare, each instance must be tagged independently.
 const sdkTagged = new WeakSet<object>();
 const frameworkTagged = new WeakSet<object>();
 
-// Web path: full identity on the default singleton (sdk + framework).
+/** Web path: full identity on the default singleton (sdk + framework). */
 export function registerReactSdkIdentity(flare: Flare): void {
     if (!sdkTagged.has(flare)) {
         sdkTagged.add(flare);
@@ -17,8 +17,10 @@ export function registerReactSdkIdentity(flare: Flare): void {
     tagReactFramework(flare);
 }
 
-// Injected path: framework tag ONLY. Never touch sdkInfo — that would clobber the
-// injected instance's own SDK name (e.g. @flareapp/electron).
+/**
+ * Injected path: framework tag only. Never touch sdkInfo, which would clobber the injected
+ * instance's own SDK name (e.g. @flareapp/electron).
+ */
 export function tagReactFramework(flare: Flare): void {
     if (frameworkTagged.has(flare)) {
         return;

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -3,9 +3,9 @@ import { flare } from '@flareapp/js';
 import { registerReactSdkIdentity } from './identify';
 import { registerDefaultFlare } from './resolveFlare';
 
-// Web entry side effects: the js-root singleton is both the default Flare for
-// no-prop usage AND the identity target. Importing @flareapp/js here also runs the
-// root's own side effects (window.flare + global catch) — correct for the web.
+// Web entry side effects: the js-root singleton is both the default Flare for no-prop usage and the
+// identity target. Importing @flareapp/js here also runs the root's own side effects (window.flare +
+// global catch), which is correct for the web.
 registerDefaultFlare(() => flare);
 registerReactSdkIdentity(flare);
 

--- a/packages/react/src/inject.ts
+++ b/packages/react/src/inject.ts
@@ -1,6 +1,5 @@
-// Electron-safe entry. NO @flareapp/js root import, NO default registration, NO
-// import-time identity. The caller MUST pass a `flare` instance; resolveFlare
-// throws at wiring time if absent.
+// Electron-safe entry: no @flareapp/js root import, no default registration, no import-time
+// identity. The caller must pass a `flare` instance; resolveFlare throws at wiring time if absent.
 export {
     FlareErrorBoundary,
     type FlareErrorBoundaryProps,

--- a/packages/react/src/parseComponentStack.ts
+++ b/packages/react/src/parseComponentStack.ts
@@ -1,9 +1,11 @@
 import { CHROMIUM_STACK_REGEX, FIREFOX_SAFARI_STACK_REGEX } from './constants';
 import { ComponentStackFrame } from './types';
 
-// React's `errorInfo.componentStack` is a newline-separated, browser-formatted string. We parse it
-// into structured frames here so the Flare UI can render proper file/line links instead of a blob.
-// Falls back to component-name-only when the format is unrecognised (rather than dropping the line).
+/**
+ * Parse React's newline-separated, browser-formatted `errorInfo.componentStack` into structured
+ * frames so the Flare UI can render file/line links. Unrecognised lines fall back to
+ * component-name-only rather than being dropped.
+ */
 export function parseComponentStack(stack: string): ComponentStackFrame[] {
     return stack
         .split(/\s*\n\s*/g)
@@ -31,7 +33,7 @@ export function parseComponentStack(stack: string): ComponentStackFrame[] {
                 };
             }
 
-            // For unrecognized formats, we'll strip the leading "at " if it is present
+            // Unrecognized format: strip a leading "at " if present.
             const component = line.replace(/^at\s+/, '');
 
             return {

--- a/packages/react/src/parseMinifiedReactError.ts
+++ b/packages/react/src/parseMinifiedReactError.ts
@@ -4,9 +4,8 @@ const NUMBER_PATTERN = /Minified React error #(\d+)/;
 const ARG_PATTERN = /args\[\]=([^&\s]*)/g;
 const URL_PATTERN = /(https?:\/\/\S+)/;
 
-// decodeURIComponent throws on malformed percent escapes (e.g. "%E0%A4%A"). This
-// runs while the boundary/handler is already processing an error, so a throw here
-// must not escape. Fall back to the raw value instead.
+// decodeURIComponent throws on malformed percent escapes (e.g. "%E0%A4%A"). This runs while the
+// boundary/handler is already processing an error, so a throw must not escape; fall back to raw.
 function safeDecode(value: string): string {
     try {
         return decodeURIComponent(value);

--- a/packages/react/src/resolveFlare.ts
+++ b/packages/react/src/resolveFlare.ts
@@ -14,20 +14,22 @@ function isDevMode(): boolean {
     }
 }
 
-// Called once by the web entry (index.ts) as an import side effect. Registers the
-// js-root singleton as the fallback used when no instance is injected.
+/**
+ * Called once by the web entry (index.ts) as an import side effect. Registers the js-root singleton
+ * as the fallback used when no instance is injected.
+ */
 export function registerDefaultFlare(provider: () => Flare): void {
-    // Tripwire: registering a web default while the Electron bridge exists means a renderer
-    // pulled the package root (e.g. importing @flareapp/react instead of @flareapp/react/inject,
-    // or component-tracking codegen emitting the root specifier). That drags the keyed @flareapp/js
-    // singleton and its global side effects into the renderer.
+    // Tripwire: registering a web default while the Electron bridge exists means a renderer pulled
+    // the package root (e.g. @flareapp/react instead of @flareapp/react/inject, or component-tracking
+    // codegen emitting the root specifier), dragging the keyed @flareapp/js singleton and its global
+    // side effects into the renderer.
     if (typeof window !== 'undefined' && (window as unknown as Record<string, unknown>).__flare) {
         const message =
             '[flare] @flareapp/react (web root) was imported in a renderer where the Electron ' +
             'bridge is present, pulling the keyed @flareapp/js singleton into the renderer. ' +
             'Import @flareapp/react/inject and pass the @flareapp/electron/renderer instance instead.';
-        // Dev: throw so the misconfiguration is impossible to miss. Production: warn instead, so a
-        // shipped app isn't crashed by a (recoverable) reporting-setup mistake.
+        // Dev: throw so the misconfiguration can't be missed. Production: warn, so a shipped app
+        // isn't crashed by a recoverable reporting-setup mistake.
         if (isDevMode()) {
             throw new Error(message);
         }
@@ -36,8 +38,10 @@ export function registerDefaultFlare(provider: () => Flare): void {
     defaultProvider = provider;
 }
 
-// Resolve at WIRING time (boundary construct / handler creation), never inside a
-// report path. Throws here so a missing instance fails fast at boot.
+/**
+ * Resolve at wiring time (boundary construct / handler creation), never inside a report path.
+ * Throws so a missing instance fails fast at boot.
+ */
 export function resolveFlare(explicit?: Flare): Flare {
     if (explicit) {
         return explicit;

--- a/packages/react/tests/FlareErrorBoundary.test.tsx
+++ b/packages/react/tests/FlareErrorBoundary.test.tsx
@@ -10,8 +10,8 @@ vi.mock('@flareapp/js', () => ({
     flare: {
         report: (...a: unknown[]) => mockReport(...a),
         reportSilently: (...a: unknown[]) => mockReport(...a),
-        // The boundary constructor calls tagReactFramework(resolved) on the default path,
-        // so the mocked singleton MUST expose setFramework (and setSdkInfo) or construction throws.
+        // The boundary constructor calls tagReactFramework(resolved) on the default path, so the
+        // mocked singleton must expose setFramework (and setSdkInfo) or construction throws.
         setFramework: vi.fn(),
         setSdkInfo: vi.fn(),
     },
@@ -33,7 +33,7 @@ function ThrowingComponent({ shouldThrow = true }: { shouldThrow?: boolean }) {
 }
 
 describe('FlareErrorBoundary', () => {
-    // React logs caught errors to console.error - suppress during tests
+    // React logs caught errors to console.error; suppress during tests.
     let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
 
     beforeEach(() => {
@@ -373,7 +373,7 @@ describe('FlareErrorBoundary', () => {
 
         expect(mockReport).toHaveBeenCalledOnce();
 
-        // Component will throw again after reset
+        // Component throws again after reset.
         fireEvent.click(screen.getByText('Reset'));
 
         expect(mockReport).toHaveBeenCalledTimes(2);
@@ -385,9 +385,8 @@ describe('FlareErrorBoundary', () => {
             throw new Error('beforeEvaluate error');
         });
 
-        // beforeEvaluate throwing inside componentDidCatch propagates the error
-        // through React, which escalates it and unmounts the tree.
-        // There is no try/catch around the callback in componentDidCatch.
+        // beforeEvaluate throwing inside componentDidCatch propagates through React, which escalates
+        // it and unmounts the tree. There is no try/catch around the callback in componentDidCatch.
         expect(() =>
             render(
                 <FlareErrorBoundary fallback={<div>Error</div>} beforeEvaluate={beforeEvaluate}>

--- a/packages/react/tests/electronBoundaryInjection.test.tsx
+++ b/packages/react/tests/electronBoundaryInjection.test.tsx
@@ -3,10 +3,9 @@ import { render } from '@testing-library/react';
 import React from 'react';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
-// The REAL inject entry boundary + a real Electron RendererFlare. Drives the full path:
-// boundary resolves the injected instance -> reportSilently -> RendererFlare.sendReport -> bridge.
-// (The existing electron cross-package test covers the flareReactErrorHandler path; this closes
-// the gap for the FlareErrorBoundary component end-to-end through the bridge.)
+// Real inject-entry boundary + real Electron RendererFlare, driving the full path: boundary resolves
+// the injected instance -> reportSilently -> RendererFlare.sendReport -> bridge. Closes the gap the
+// existing electron cross-package test leaves (that one covers the flareReactErrorHandler path).
 import { FlareErrorBoundary } from '../src/inject';
 
 function ThrowingComponent(): React.ReactElement {

--- a/packages/react/tests/flareReactErrorHandler.test.ts
+++ b/packages/react/tests/flareReactErrorHandler.test.ts
@@ -8,12 +8,12 @@ vi.mock('@flareapp/js', () => ({
     flare: {
         report: (...args: unknown[]) => mockReport(...args),
         reportSilently: (...args: unknown[]) => mockReport(...args),
-        // Handler creation now tags the resolved instance — the default mock MUST have these.
+        // Handler creation tags the resolved instance, so the default mock must have these.
         setFramework: vi.fn(),
         setSdkInfo: vi.fn(),
     },
-    // The production code imports convertToError from '@flareapp/core', not this mock. It is kept
-    // here only as a harmless safety net so the mocked '@flareapp/js' surface stays self-contained.
+    // Production imports convertToError from '@flareapp/core', not this mock; kept only as a
+    // safety net so the mocked '@flareapp/js' surface stays self-contained.
     convertToError: (e: unknown) => (e instanceof Error ? e : new Error(String(e))),
 }));
 import { flare as mockedRoot } from '@flareapp/js';
@@ -401,8 +401,8 @@ describe('flareReactErrorHandler', () => {
         test('resolves the instance once at creation, not per call', () => {
             const injected = { reportSilently: vi.fn(), setFramework: vi.fn(), setSdkInfo: vi.fn() } as any;
             // Probe resolution directly. A setFramework-based probe is masked by the per-instance
-            // WeakSet in tagReactFramework (same instance dedupes to one call whether resolved at
-            // creation or per call), so it would pass even with the per-call bug.
+            // WeakSet in tagReactFramework (same instance dedupes to one call either way), so it
+            // would pass even with the per-call bug.
             const resolveSpy = vi.spyOn(resolveModule, 'resolveFlare');
             const handler = flareReactErrorHandler({ flare: injected });
             handler(new Error('a'), {});

--- a/packages/react/tests/inject.test.ts
+++ b/packages/react/tests/inject.test.ts
@@ -13,7 +13,7 @@ describe('@flareapp/react/inject entry', () => {
 
         await import('../src/inject');
 
-        // root module never imported -> its mock factory never ran, no window.flare installed
+        // Root module never imported -> its mock factory never ran, no window.flare installed.
         expect(rootFactory).not.toHaveBeenCalled();
         expect((window as any).flare).toBeUndefined();
     });
@@ -26,7 +26,7 @@ describe('@flareapp/react/inject entry', () => {
 
     test('boundary from inject entry throws at construction when no instance and no default', async () => {
         const { FlareErrorBoundary } = await import('../src/inject');
-        // No registerDefaultFlare ran (root not imported) -> resolveFlare throws.
+        // No registerDefaultFlare ran (root not imported), so resolveFlare throws.
         expect(() => new (FlareErrorBoundary as any)({})).toThrow(/No Flare instance available/);
     });
 });

--- a/packages/react/tests/parseMinifiedReactError.test.ts
+++ b/packages/react/tests/parseMinifiedReactError.test.ts
@@ -62,8 +62,8 @@ describe('parseMinifiedReactError', () => {
             'Minified React error #418; visit https://react.dev/errors/418?args[]=%E0%A4%A&args[]=ok for the full message',
         );
 
-        // `%E0%A4%A` is a malformed percent escape; decodeURIComponent would throw.
-        // The parser must not throw mid-error-handling and keeps the raw value instead.
+        // `%E0%A4%A` is a malformed percent escape; decodeURIComponent would throw. The parser must
+        // not throw mid-error-handling, keeping the raw value instead.
         expect(parseMinifiedReactError(error)).toEqual({
             number: 418,
             args: ['%E0%A4%A', 'ok'],

--- a/packages/react/tests/webEntry.test.ts
+++ b/packages/react/tests/webEntry.test.ts
@@ -13,11 +13,11 @@ describe('@flareapp/react web entry', () => {
 
         await import('../src/index');
 
-        // identity set on the singleton at import
+        // Identity set on the singleton at import.
         expect(setSdkInfo).toHaveBeenCalledWith(expect.objectContaining({ name: '@flareapp/react' }));
         expect(setFramework).toHaveBeenCalledWith(expect.objectContaining({ name: 'React' }));
 
-        // the singleton is now the resolveFlare default
+        // The singleton is now the resolveFlare default.
         const { resolveFlare } = await import('../src/resolveFlare');
         expect(resolveFlare()).toBe(singleton);
     });

--- a/packages/svelte/src/extractComponentInfo.ts
+++ b/packages/svelte/src/extractComponentInfo.ts
@@ -17,8 +17,7 @@ export function extractComponentInfo(
         return { componentName: null, componentHierarchy: [] };
     }
 
-    // Try the preprocessor-based component tree first.
-    // Walk each .svelte frame until we find one that was registered.
+    // Preprocessor-based component tree first: walk each .svelte frame until one was registered.
     for (const frame of svelteFrames) {
         if (!frame.fileName) continue;
 

--- a/packages/svelte/src/getErrorOrigin.ts
+++ b/packages/svelte/src/getErrorOrigin.ts
@@ -2,20 +2,12 @@ import type ErrorStackParser from 'error-stack-parser';
 
 import type { SvelteErrorOrigin } from './types.js';
 
-// Heuristic classification of where a Svelte error originated, based on stack frame inspection.
-//
-// Svelte's onMount/beforeUpdate/$effect callbacks, DOM event handlers, and render functions
-// all produce errors that look identical at the catch site (the error boundary sees a plain Error
-// either way). The only distinguishing signal is the stack trace: different origins leave
-// recognizable function names, file names, or DOM API calls in the frames.
-//
-// We check patterns in priority order: event > effect > render > unknown.
-// Priority matters because an event handler inside a Svelte component would match both
-// EVENT_PATTERNS and the .svelte filename check; we want 'event' to win.
+// Origins are indistinguishable at the boundary catch site; the stack trace is the only signal.
+// Checked in priority order event > effect > render > unknown, so an event handler inside a
+// component wins over the .svelte filename check.
 
-// Inline event handlers (onclick, onsubmit, ...) and DOM event API calls.
-// Browsers compile `onclick={handler}` to `.onclick = ...` or `addEventListener(...)`,
-// so these patterns catch both Svelte's compiled output and manual DOM calls.
+// Inline event handlers and DOM event API calls. Svelte compiles `onclick={handler}` to
+// `.onclick = ...` or `addEventListener(...)`, so these match compiled output and manual DOM calls.
 const EVENT_PATTERNS = [
     /\.onclick\b/i,
     /\.onsubmit\b/i,
@@ -37,36 +29,32 @@ const EVENT_PATTERNS = [
     /HTMLFormElement\./,
 ];
 
-// Async side-effects: $effect callbacks, onMount microtasks, promise continuations.
-// Svelte 5 schedules effects via queueMicrotask; promise chains and MutationObserver
-// callbacks are also async side-effects, not render-phase code.
+// Async side-effects: $effect callbacks (Svelte 5 schedules via queueMicrotask), onMount
+// microtasks, promise continuations, MutationObserver callbacks. Not render-phase code.
 const EFFECT_PATTERNS = [/queueMicrotask/, /Promise\.then/, /Promise\.catch/, /MutationObserver/];
 
-// Inspects a parsed stack trace and classifies the error origin into one of:
-//   'event'   - error happened in a DOM event handler
-//   'effect'  - error happened in an async side-effect ($effect, onMount, promise)
-//   'render'  - error happened during Svelte component render (template/script top-level)
-//   'unknown' - no frames or no recognizable pattern
+/**
+ * Classify a parsed stack trace's error origin: 'event' (DOM handler), 'effect' (async side-effect),
+ * 'render' (component render phase), or 'unknown' (no frames or no recognizable pattern).
+ */
 export function getErrorOrigin(frames: ErrorStackParser.StackFrame[]): SvelteErrorOrigin {
     if (frames.length === 0) {
         return 'unknown';
     }
 
-    // Flatten each frame into a single searchable string so regex matching is straightforward.
+    // Flatten each frame into one searchable string for regex matching.
     const frameStrings = frames.map((f) => `${f.functionName ?? ''} ${f.fileName ?? ''} ${f.source ?? ''}`);
 
-    // Check event patterns first (highest priority).
+    // Event patterns first (highest priority).
     if (frameStrings.some((s) => EVENT_PATTERNS.some((p) => p.test(s)))) {
         return 'event';
     }
 
-    // Then async effect patterns.
     if (frameStrings.some((s) => EFFECT_PATTERNS.some((p) => p.test(s)))) {
         return 'effect';
     }
 
-    // If any frame originates from a .svelte file but didn't match event/effect,
-    // the error most likely occurred during the synchronous render phase.
+    // A .svelte frame that matched neither event nor effect is most likely the synchronous render phase.
     const hasSvelteFrame = frames.some((f) => f.fileName?.includes('.svelte'));
 
     if (hasSvelteFrame) {

--- a/packages/svelte/src/identify.ts
+++ b/packages/svelte/src/identify.ts
@@ -2,12 +2,11 @@ import type { Flare } from '@flareapp/js/browser';
 
 import { PACKAGE_VERSION } from './version.js';
 
-// Per-instance guards. A boolean cannot serve injection: with a singleton AND an
-// injected RendererFlare, each instance must be tagged independently.
+// Per-instance guards: a singleton and an injected RendererFlare must each be tagged independently.
 const sdkTagged = new WeakSet<object>();
 const frameworkTagged = new WeakSet<object>();
 
-// Web path: full identity on the default singleton (sdk + framework). Svelte's framework has no version.
+/** Web path: full identity on the default singleton (sdk + framework). Svelte's framework has no version. */
 export function registerSvelteSdkIdentity(flare: Flare): void {
     if (!sdkTagged.has(flare)) {
         sdkTagged.add(flare);
@@ -16,8 +15,10 @@ export function registerSvelteSdkIdentity(flare: Flare): void {
     tagSvelteFramework(flare);
 }
 
-// Injected path: framework tag ONLY. Never touch sdkInfo — that would clobber the
-// injected instance's own SDK name (e.g. @flareapp/electron).
+/**
+ * Injected path: framework tag only. Never touch sdkInfo, which would clobber the injected
+ * instance's own SDK name (e.g. @flareapp/electron).
+ */
 export function tagSvelteFramework(flare: Flare): void {
     if (frameworkTagged.has(flare)) {
         return;

--- a/packages/svelte/src/index.ts
+++ b/packages/svelte/src/index.ts
@@ -3,11 +3,10 @@ import { flare } from '@flareapp/js';
 import { registerSvelteSdkIdentity } from './identify.js';
 import { registerDefaultFlare } from './resolveFlare.js';
 
-// Web entry. Importing @flareapp/js runs the root's own side effects (window.flare + global
-// catch) — correct for the web. Register the singleton as the default Flare AND set its SDK
-// identity AT IMPORT. The import-time identity registration is a hard contract: @flareapp/sveltekit
-// does `export * from '@flareapp/svelte'` and overrides the SDK name per-report, relying on this
-// running first (spec Decision 6). Do not defer it.
+// Web entry. Importing @flareapp/js runs the root's side effects (window.flare + global catch),
+// correct for the web. Registering the singleton and its SDK identity at import time is a hard
+// contract: @flareapp/sveltekit `export * from '@flareapp/svelte'` and overrides the SDK name
+// per-report, relying on this running first (spec Decision 6). Do not defer it.
 registerDefaultFlare(() => flare);
 registerSvelteSdkIdentity(flare);
 

--- a/packages/svelte/src/inject.ts
+++ b/packages/svelte/src/inject.ts
@@ -1,5 +1,5 @@
-// Electron-safe entry. NO @flareapp/js root import, NO default registration, NO import-time
-// identity. The caller MUST pass `flare` (handler option / boundary prop); resolveFlare throws
+// Electron-safe entry. No @flareapp/js root import, no default registration, no import-time
+// identity. The caller must pass `flare` (handler option / boundary prop); resolveFlare throws
 // at wiring time if absent.
 export { default as FlareErrorBoundary } from './FlareErrorBoundary.svelte';
 

--- a/packages/svelte/src/preprocessor.ts
+++ b/packages/svelte/src/preprocessor.ts
@@ -54,11 +54,9 @@ export function flarePreprocessor(options?: FlarePreprocessorOptions): Preproces
                 return;
             }
 
-            // Skip a script the markup hook already injected. For a scriptless component the markup
-            // hook adds a `<script>` with our registration; Svelte then runs THIS script hook over
-            // that injected block within the same preprocessor pass. Without this guard we inject a
-            // second time, producing a duplicate `const __flare_node__` -> "already been declared"
-            // compile error.
+            // For a scriptless component the markup hook adds a `<script>` with our registration,
+            // then Svelte runs this script hook over that injected block in the same pass. Without
+            // this guard we inject a second `const __flare_node__` -> "already been declared" error.
             if (content.includes('__flare_node__')) {
                 return;
             }

--- a/packages/svelte/src/resolveFlare.ts
+++ b/packages/svelte/src/resolveFlare.ts
@@ -4,8 +4,8 @@ declare const process: { env: Record<string, string | undefined> };
 
 let defaultProvider: (() => Flare) | null = null;
 
-// `process.env.NODE_ENV` is replaced inline by bundlers (vite/webpack). The try/catch keeps a
-// process-less environment safe: treat "undetermined" as production (warn, never crash).
+// `process.env.NODE_ENV` is replaced inline by bundlers. The try/catch keeps a process-less
+// environment safe: treat "undetermined" as production (warn, never crash).
 function isDevMode(): boolean {
     try {
         return process.env.NODE_ENV !== 'production';
@@ -14,10 +14,10 @@ function isDevMode(): boolean {
     }
 }
 
-// Called once by the web entry (index.ts) as an import side effect.
+/** Called once by the web entry (index.ts) as an import side effect. */
 export function registerDefaultFlare(provider: () => Flare): void {
     // Tripwire: a web default registering while the Electron bridge exists means a renderer pulled
-    // the package root — directly, or via component-tracking codegen emitting the root specifier
+    // the package root, directly or via component-tracking codegen emitting the root specifier
     // (set the preprocessor's importSource to '@flareapp/svelte/inject' to avoid that). It drags
     // the keyed @flareapp/js singleton and its global side effects into the renderer.
     if (typeof window !== 'undefined' && (window as unknown as Record<string, unknown>).__flare) {
@@ -25,8 +25,8 @@ export function registerDefaultFlare(provider: () => Flare): void {
             '[flare] @flareapp/svelte (web root) was imported in a renderer where the Electron ' +
             'bridge is present, pulling the keyed @flareapp/js singleton into the renderer. ' +
             "Import @flareapp/svelte/inject (and set the preprocessor importSource to '@flareapp/svelte/inject') instead.";
-        // Dev: throw so the misconfiguration is impossible to miss. Production: warn instead, so a
-        // shipped app isn't crashed by a (recoverable) reporting-setup mistake.
+        // Dev: throw so the misconfiguration can't be missed. Production: warn, so a shipped app
+        // isn't crashed by a recoverable reporting-setup mistake.
         if (isDevMode()) {
             throw new Error(message);
         }
@@ -35,7 +35,7 @@ export function registerDefaultFlare(provider: () => Flare): void {
     defaultProvider = provider;
 }
 
-// Resolve at WIRING time (handler creation / component setup), never inside a report path.
+/** Resolve at wiring time (handler creation / component setup), never inside a report path. */
 export function resolveFlare(explicit?: Flare): Flare {
     if (explicit) {
         return explicit;

--- a/packages/svelte/tests/createFlareErrorHandler.test.ts
+++ b/packages/svelte/tests/createFlareErrorHandler.test.ts
@@ -174,7 +174,7 @@ describe('createFlareErrorHandler', () => {
         const handler = createFlareErrorHandler({ flare: injected });
         await handler(new Error('a'), () => {});
         await handler(new Error('b'), () => {});
-        expect(resolveSpy).toHaveBeenCalledTimes(1); // resolved at creation, NOT per call
+        expect(resolveSpy).toHaveBeenCalledTimes(1); // resolved at creation, not per call
         resolveSpy.mockRestore();
     });
 });

--- a/packages/svelte/tests/electronInjection.test.ts
+++ b/packages/svelte/tests/electronInjection.test.ts
@@ -1,7 +1,7 @@
 import { FLARE_BRIDGE_KEY, RendererFlare } from '@flareapp/electron/renderer';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 
-// The REAL inject entry. Importing it must not pull the js root.
+// The real inject entry. Importing it must not pull the js root.
 import { createFlareErrorHandler } from '../src/inject.js';
 
 describe('@flareapp/svelte/inject reports through an injected RendererFlare', () => {
@@ -31,8 +31,8 @@ describe('@flareapp/svelte/inject reports through an injected RendererFlare', ()
         expect(parsed.attributes['telemetry.sdk.name']).toBe('@flareapp/electron');
         expect(parsed.attributes['flare.framework.name']).toBe('Svelte');
         expect(parsed.attributes['context.custom'].svelte).toBeDefined();
-        // NOTE: do NOT assert window.flare/globalThis.flare is undefined — importing
+        // Do not assert window.flare/globalThis.flare is undefined: importing
         // @flareapp/electron/renderer legitimately sets window.flare (renderer.ts side effect).
-        // No-root is covered by Task 9 (dist-grep) + Task 7 (runtime mock-factory check).
+        // No-root is covered by Task 9 (dist-grep) and Task 7 (runtime mock-factory check).
     });
 });

--- a/packages/svelte/tests/preprocessor.test.ts
+++ b/packages/svelte/tests/preprocessor.test.ts
@@ -7,13 +7,13 @@ import { flarePreprocessor } from '../src/preprocessor.js';
 const FAKE_FILE = '/app/src/Button.svelte';
 const SCRIPT_ATTRS = { lang: undefined };
 
-// Helper: run the script hook (component with <script>)
+// Run the script hook (component with <script>).
 function runScriptHook(pp: ReturnType<typeof flarePreprocessor>, filename = FAKE_FILE) {
     const result = (pp as any).script({ content: 'console.log("hi");', filename, attributes: SCRIPT_ATTRS });
     return result;
 }
 
-// Helper: run the markup hook (no <script> tag — scriptless component)
+// Run the markup hook (no <script> tag, scriptless component).
 function runMarkupHook(pp: ReturnType<typeof flarePreprocessor>, filename = FAKE_FILE) {
     const result = (pp as any).markup({ content: '<p>hello</p>', filename });
     return result;
@@ -80,14 +80,14 @@ describe('withFlareConfig — importSource option', () => {
     });
 });
 
-// Run the preprocessor through Svelte's REAL pipeline (markup -> script in one pass), not the hooks
-// in isolation. This is the only way to catch the markup hook injecting a <script> that the script
-// hook then re-processes (double injection -> duplicate `__flare_node__` -> compile error).
+// Run through Svelte's real pipeline (markup -> script in one pass), not the hooks in isolation.
+// Only this catches the markup hook injecting a <script> that the script hook then re-processes
+// (double injection -> duplicate `__flare_node__` -> compile error).
 describe('flarePreprocessor — full preprocess() + compile() pipeline', () => {
     test('a scriptless component injects exactly once and compiles', async () => {
         const out = await preprocess('<p>hello</p>', flarePreprocessor(), { filename: FAKE_FILE });
         expect((out.code.match(/__flare_node__/g) || []).length).toBe(1);
-        // Must compile — a duplicate `const __flare_node__` throws "already been declared".
+        // Must compile: a duplicate `const __flare_node__` throws "already been declared".
         expect(() => compile(out.code, { filename: FAKE_FILE })).not.toThrow();
     });
 

--- a/packages/svelte/tests/sveltekitContract.test.ts
+++ b/packages/svelte/tests/sveltekitContract.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 // SvelteKit does `export * from '@flareapp/svelte'` and relies on (a) the web entry registering
-// SDK identity AT IMPORT, and (b) the full export surface remaining intact so the re-export works.
+// SDK identity at import, and (b) the full export surface remaining intact so the re-export works.
 describe('@flareapp/svelte web entry — SvelteKit contract', () => {
     beforeEach(() => {
         vi.resetModules();

--- a/packages/svelte/tests/webEntry.test.ts
+++ b/packages/svelte/tests/webEntry.test.ts
@@ -13,7 +13,7 @@ describe('@flareapp/svelte web entry', () => {
 
         await import('../src/index.js');
 
-        // SvelteKit contract: identity is set at IMPORT (module load), not deferred.
+        // SvelteKit contract: identity is set at import (module load), not deferred.
         expect(setSdkInfo).toHaveBeenCalledWith(expect.objectContaining({ name: '@flareapp/svelte' }));
         expect(setFramework).toHaveBeenCalledWith({ name: 'Svelte' });
 

--- a/packages/sveltekit/src/client/trackRouteContext.svelte.ts
+++ b/packages/sveltekit/src/client/trackRouteContext.svelte.ts
@@ -6,10 +6,9 @@ import { redactQueryParams } from '../redactQueryParams.js';
 let tracking = false;
 
 /**
- * Starts tracking the current SvelteKit route and syncing it to Flare's persistent context.
- * Call once during client-side initialization (e.g. in +layout.svelte or hooks.client.ts).
- * After calling this, every report (including manual flare.report() calls) includes the
- * current route ID, URL, params, and redacted query parameters.
+ * Track the current SvelteKit route, syncing it to Flare's persistent context. Call once during
+ * client init (e.g. +layout.svelte or hooks.client.ts). Every subsequent report (including manual
+ * flare.report() calls) then carries the route ID, URL, params, and redacted query parameters.
  */
 export function trackRouteContext(): void {
     if (tracking) return;

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -97,9 +97,8 @@ export default function flareSourcemaps({
                 const sourcemapPath = resolve(outputDir, fileName);
 
                 try {
-                    // For SSR (server) builds the runtime stack frame is a filesystem / file:// path, not a web
-                    // URL, so prefixing with the web base is meaningless. Use the bundle-relative path so the
-                    // backend can suffix-match it against the runtime frame path.
+                    // SSR runtime frames are file:// paths, not web URLs, so the base prefix is
+                    // meaningless. Use the bundle-relative path for backend suffix-matching.
                     const originalFile = isSsrBuild ? sourceFileName : `${resolvedBase}${sourceFileName}`;
 
                     sourcemaps.push({

--- a/packages/vue/src/FlareErrorBoundary.ts
+++ b/packages/vue/src/FlareErrorBoundary.ts
@@ -148,8 +148,8 @@ export const FlareErrorBoundary = defineComponent({
 
             props.afterSubmit?.({ error: errorToReport, instance, info, context: finalContext });
 
-            // Prevent the error from propagating to app.config.errorHandler (set by flareVue()),
-            // so the error is only reported to Flare once when both are used together.
+            // Stop propagation to app.config.errorHandler (set by flareVue()) so the error is
+            // reported to Flare only once when both are used together.
             return false;
         });
 

--- a/packages/vue/src/constants.ts
+++ b/packages/vue/src/constants.ts
@@ -4,7 +4,7 @@ import type { ErrorOrigin } from './types';
 
 declare const process: { env?: { PACKAGE_VERSION?: string } } | undefined;
 
-// Injected at build time via tsdown --env.PACKAGE_VERSION (reads package.json version).
+/** Injected at build time via tsdown --env.PACKAGE_VERSION (reads package.json version). */
 export const PACKAGE_VERSION =
     typeof process !== 'undefined' && typeof process.env?.PACKAGE_VERSION !== 'undefined'
         ? process.env.PACKAGE_VERSION
@@ -26,7 +26,7 @@ export const MAX_PROP_ARRAY_LENGTH = 100;
 export const MAX_PROP_OBJECT_KEYS = 100;
 
 export const INFO_TO_ORIGIN: Record<string, ErrorOrigin> = {
-    // Development strings
+    // Development strings.
     'setup function': 'setup',
     'render function': 'render',
     'component update': 'render',
@@ -59,7 +59,7 @@ export const INFO_TO_ORIGIN: Record<string, ErrorOrigin> = {
     'app warnHandler': 'lifecycle',
     'app unmount cleanup function': 'lifecycle',
 
-    // Production codes
+    // Production codes.
     '0': 'setup',
     '1': 'render',
     '2': 'watcher',

--- a/packages/vue/src/flareVue.ts
+++ b/packages/vue/src/flareVue.ts
@@ -46,9 +46,8 @@ export function vueWarningContextToAttributes(context: FlareVueWarningContext): 
     return { 'context.custom': { vue } };
 }
 
-// Tracks installed apps so calling app.use(flareVue) twice on the same app is a no-op. WeakSet so
-// we don't keep apps alive in memory after they're disposed (notably matters for SSR test harnesses
-// that spin up an app per request).
+// Tracks installed apps so app.use(flareVue) twice on the same app is a no-op. WeakSet so we don't
+// keep disposed apps alive (matters for SSR harnesses that spin up an app per request).
 const installedApps = new WeakSet<App>();
 
 export const flareVue: Plugin<[FlareVueOptions?]> = (app: App, options?: FlareVueOptions): void => {
@@ -56,18 +55,17 @@ export const flareVue: Plugin<[FlareVueOptions?]> = (app: App, options?: FlareVu
         return;
     }
 
-    // Resolve BEFORE marking the app installed, so a throw (an /inject consumer that forgot the
-    // `flare` option) doesn't leave the app recorded in installedApps. NOTE: this only enables a
-    // retry when the plugin is invoked DIRECTLY (`flareVue(app, opts)`). Via the public
-    // `app.use(flareVue)` API a retry is blocked regardless — Vue adds the plugin to its own
-    // installed-set BEFORE calling install, so a failed `app.use` cannot be re-applied to the same
-    // app. The ordering here is still correct/defensive; it just isn't reachable through `app.use`.
+    // Resolve before marking the app installed, so a throw (an /inject consumer that forgot the
+    // `flare` option) doesn't leave the app recorded in installedApps. This only enables a retry
+    // when invoked directly (`flareVue(app, opts)`). Through `app.use(flareVue)` a retry is blocked
+    // regardless: Vue adds the plugin to its own installed-set before calling install. The ordering
+    // is still defensive, just not reachable through `app.use`.
     const flare = resolveFlare(options?.flare);
 
     installedApps.add(app);
 
-    // Web default (no injected instance): set the SDK identity on the singleton, as before.
-    // Injected instance: tag framework only — never setSdkInfo (would clobber @flareapp/electron).
+    // Web default (no injected instance): set SDK identity on the singleton. Injected instance: tag
+    // framework only, never setSdkInfo (would clobber @flareapp/electron).
     if (!options?.flare) {
         registerVueSdkInfo(flare);
     }
@@ -77,8 +75,8 @@ export const flareVue: Plugin<[FlareVueOptions?]> = (app: App, options?: FlareVu
     const propsMaxDepth = options?.propsMaxDepth ?? 2;
     const propsDenylist = resolveDenylist(options?.propsDenylist, options?.replaceDefaultDenylist);
 
-    // Capture any errorHandler the app already set so we can chain it. If we replaced it blindly we'd
-    // silently disable user-defined handlers (e.g. one provided by a higher-level framework like Nuxt).
+    // Capture any errorHandler the app already set so we can chain it; replacing it blindly would
+    // silently disable user-defined handlers (e.g. one from a higher-level framework like Nuxt).
     const initialErrorHandler = app.config.errorHandler;
 
     app.config.errorHandler = (error: unknown, instance: ComponentPublicInstance | null, info: string) => {
@@ -123,9 +121,9 @@ export const flareVue: Plugin<[FlareVueOptions?]> = (app: App, options?: FlareVu
             return;
         }
 
-        // No prior handler: log so the error is visible during development without re-throwing.
+        // No prior handler: log so the error is visible in development without re-throwing.
         // Re-throwing would trigger window.onerror and produce a duplicate report (one with Vue
-        // context from this handler, one without from the global catchWindowErrors listener).
+        // context from here, one without from the global catchWindowErrors listener).
         console.error(error);
     };
 

--- a/packages/vue/src/getComponentName.ts
+++ b/packages/vue/src/getComponentName.ts
@@ -5,9 +5,9 @@ export function getComponentName(instance: ComponentPublicInstance | null): stri
         return 'AnonymousComponent';
     }
 
-    // `__name` is set by the SFC compiler from the filename (e.g. `Foo.vue` -> `Foo`) and is
-    // present even for `<script setup>` components that have no manual `name` option. Prefer it
-    // over `name` so we get a useful label for the common SFC case.
+    // `__name` is set by the SFC compiler from the filename (e.g. `Foo.vue` -> `Foo`), present even
+    // for `<script setup>` components with no manual `name`. Prefer it over `name` for a useful
+    // label in the common SFC case.
     const options = instance.$options as { __name?: string; name?: string };
 
     return options.__name || options.name || 'AnonymousComponent';

--- a/packages/vue/src/getErrorOrigin.ts
+++ b/packages/vue/src/getErrorOrigin.ts
@@ -1,8 +1,10 @@
 import { INFO_TO_ORIGIN } from './constants';
 import { ErrorOrigin } from './types';
 
-// Vue's `info` argument is a human-readable string in dev (e.g. "render function") but a numeric
-// or short code in production builds. INFO_TO_ORIGIN maps both forms to a stable origin category.
+/**
+ * Vue's `info` is a human-readable string in dev (e.g. "render function") but a numeric/short code
+ * in production. INFO_TO_ORIGIN maps both forms to a stable origin category.
+ */
 export function getErrorOrigin(info: string): ErrorOrigin {
     return INFO_TO_ORIGIN[info] ?? 'unknown';
 }

--- a/packages/vue/src/getRouteContext.ts
+++ b/packages/vue/src/getRouteContext.ts
@@ -10,10 +10,12 @@ type GetRouteContextOptions = {
 
 const ROUTE_PARAMS_DEPTH = 2;
 
-// `router` is typed `unknown` because vue-router is an optional peer: we don't want to import it
-// (would force every consumer to install it) and the runtime shape may differ between v4.x patch
-// versions. The chained type-guards here read defensively so a missing or shimmed router yields
-// `null` rather than throwing inside an error handler.
+/**
+ * `router` is typed `unknown` because vue-router is an optional peer (importing it would force every
+ * consumer to install it, and the runtime shape may differ across v4.x patches). The chained
+ * type-guards read defensively so a missing or shimmed router yields `null` rather than throwing
+ * inside an error handler.
+ */
 export function getRouteContext(router: unknown, options: GetRouteContextOptions = {}): RouteContext | null {
     if (!router || typeof router !== 'object' || !('currentRoute' in router)) {
         return null;

--- a/packages/vue/src/identify.ts
+++ b/packages/vue/src/identify.ts
@@ -2,13 +2,15 @@ import type { Flare } from '@flareapp/js/browser';
 
 import { PACKAGE_VERSION } from './constants';
 
-// Per-instance guards. A boolean cannot serve injection: with a singleton AND an
-// injected RendererFlare, each instance must be tagged independently.
+// Per-instance guards. A boolean can't serve injection: with a singleton and an injected
+// RendererFlare, each instance must be tagged independently.
 const sdkTagged = new WeakSet<object>();
 const frameworkTagged = new WeakSet<object>();
 
-// Web path: SDK identity on the default singleton. Split from framework because
-// the framework version (app.version) is only known at install time.
+/**
+ * Web path: SDK identity on the default singleton. Split from framework because the framework
+ * version (app.version) is only known at install time.
+ */
 export function registerVueSdkInfo(flare: Flare): void {
     if (sdkTagged.has(flare)) {
         return;
@@ -17,8 +19,10 @@ export function registerVueSdkInfo(flare: Flare): void {
     flare.setSdkInfo({ name: '@flareapp/vue', version: PACKAGE_VERSION });
 }
 
-// Both paths tag the framework (web + injected). Never touches sdkInfo — on an
-// injected instance that would clobber the instance's own SDK name (@flareapp/electron).
+/**
+ * Both paths (web + injected) tag the framework. Never touches sdkInfo, which on an injected
+ * instance would clobber the instance's own SDK name (@flareapp/electron).
+ */
 export function tagVueFramework(flare: Flare, appVersion: string | undefined): void {
     if (frameworkTagged.has(flare)) {
         return;

--- a/packages/vue/src/index.ts
+++ b/packages/vue/src/index.ts
@@ -2,10 +2,9 @@ import { flare } from '@flareapp/js';
 
 import { registerDefaultFlare } from './resolveFlare';
 
-// Web entry: the js-root singleton is the default Flare for no-prop/no-option usage.
-// Importing @flareapp/js here also runs the root's own side effects (window.flare + global
-// catch) — correct for the web. Identity is set at install/setup time (needs app.version),
-// not here, preserving existing web behavior.
+// Web entry: the js-root singleton is the default Flare for no-prop/no-option usage. Importing
+// @flareapp/js here also runs the root's own side effects (window.flare + global catch), correct for
+// the web. Identity is set at install/setup time (needs app.version), not here.
 registerDefaultFlare(() => flare);
 
 export { FlareErrorBoundary } from './FlareErrorBoundary';

--- a/packages/vue/src/inject.ts
+++ b/packages/vue/src/inject.ts
@@ -1,5 +1,5 @@
-// Electron-safe entry. NO @flareapp/js root import, NO default registration. The caller MUST
-// pass `flare` (plugin option / boundary prop); resolveFlare throws at wiring time if absent.
+// Electron-safe entry: no @flareapp/js root import, no default registration. The caller must pass
+// `flare` (plugin option / boundary prop); resolveFlare throws at wiring time if absent.
 export { FlareErrorBoundary } from './FlareErrorBoundary';
 export { flareVue } from './flareVue';
 export { DEFAULT_PROPS_DENYLIST } from './constants';

--- a/packages/vue/src/resolveFlare.ts
+++ b/packages/vue/src/resolveFlare.ts
@@ -14,18 +14,18 @@ function isDevMode(): boolean {
     }
 }
 
-// Called once by the web entry (index.ts) as an import side effect.
+/** Called once by the web entry (index.ts) as an import side effect. */
 export function registerDefaultFlare(provider: () => Flare): void {
     // Tripwire: a web default registering while the Electron bridge exists means a renderer pulled
-    // the package root (e.g. importing @flareapp/vue instead of @flareapp/vue/inject). That drags
-    // the keyed @flareapp/js singleton and its global side effects into the renderer.
+    // the package root (e.g. @flareapp/vue instead of @flareapp/vue/inject), dragging the keyed
+    // @flareapp/js singleton and its global side effects into the renderer.
     if (typeof window !== 'undefined' && (window as unknown as Record<string, unknown>).__flare) {
         const message =
             '[flare] @flareapp/vue (web root) was imported in a renderer where the Electron ' +
             'bridge is present, pulling the keyed @flareapp/js singleton into the renderer. ' +
             'Import @flareapp/vue/inject and pass the @flareapp/electron/renderer instance instead.';
-        // Dev: throw so the misconfiguration is impossible to miss. Production: warn instead, so a
-        // shipped app isn't crashed by a (recoverable) reporting-setup mistake.
+        // Dev: throw so the misconfiguration can't be missed. Production: warn, so a shipped app
+        // isn't crashed by a recoverable reporting-setup mistake.
         if (isDevMode()) {
             throw new Error(message);
         }
@@ -34,7 +34,7 @@ export function registerDefaultFlare(provider: () => Flare): void {
     defaultProvider = provider;
 }
 
-// Resolve at WIRING time (plugin install / component setup), never inside a report path.
+/** Resolve at wiring time (plugin install / component setup), never inside a report path. */
 export function resolveFlare(explicit?: Flare): Flare {
     if (explicit) {
         return explicit;

--- a/packages/vue/src/serializeProps.ts
+++ b/packages/vue/src/serializeProps.ts
@@ -5,9 +5,11 @@ import {
     MAX_PROP_STRING_LENGTH,
 } from './constants';
 
-// Produces a JSON-safe, redacted, size-bounded copy of a Vue component's props for the report
-// payload. Goals: (1) never crash on cycles or exotic values, (2) never include secrets matched
-// by `denylist`, (3) keep the payload small even when components hold large or deep state trees.
+/**
+ * Produce a JSON-safe, redacted, size-bounded copy of a Vue component's props for the report
+ * payload: never crash on cycles or exotic values, never include secrets matched by `denylist`,
+ * and keep the payload small even for large or deep state trees.
+ */
 export function serializeProps(
     value: Record<string, unknown>,
     maxDepth: number,
@@ -67,8 +69,8 @@ function serialize(value: unknown, depth: number, maxDepth: number, seen: WeakSe
     }
 
     // Class instances (Date, Map, custom classes, Vue refs/proxies) are deliberately not walked:
-    // their internals can be huge, contain getters with side effects, or include reactive
-    // dependencies we don't want to trigger from inside an error handler.
+    // internals can be huge, have getters with side effects, or carry reactive dependencies we
+    // don't want to trigger from inside an error handler.
     if (!isPlainObject(value)) {
         return '[Object]';
     }

--- a/packages/vue/tests/FlareErrorBoundary.test.ts
+++ b/packages/vue/tests/FlareErrorBoundary.test.ts
@@ -739,9 +739,7 @@ describe('FlareErrorBoundary', () => {
 
         await nextTick();
 
-        // No error occurred, so there's no fallback rendered.
-        // We can't click the reset button since there's no error state.
-        // This test verifies onReset is not called when no error occurs.
+        // No error, so no fallback and no reset button to click; onReset must not fire.
         expect(onReset).not.toHaveBeenCalled();
     });
 
@@ -910,14 +908,14 @@ describe('FlareErrorBoundary', () => {
 
         expect(wrapper.text()).toBe('Error');
 
-        // Same reference, should not reset
+        // Same reference: no reset.
         await wrapper.setProps({ resetKeys: [obj] });
         await nextTick();
 
         expect(onReset).not.toHaveBeenCalled();
         expect(wrapper.text()).toBe('Error');
 
-        // Different reference with same shape, should reset
+        // Different reference, same shape: reset.
         shouldThrow = false;
         await wrapper.setProps({ resetKeys: [{ id: 1 }] });
         await nextTick();
@@ -1275,8 +1273,8 @@ describe('FlareErrorBoundary', () => {
     });
 
     test('resolves at setup (before any error), not at capture time', () => {
-        // Zero errors thrown. If resolution happened in onErrorCaptured it would be 0; proving it
-        // is 1 here proves resolution is at setup/wiring time. A single-error probe could not
+        // Zero errors thrown. If resolution happened in onErrorCaptured the count would be 0;
+        // getting 1 here proves resolution is at setup/wiring time. A single-error probe couldn't
         // distinguish setup-time from capture-time (both yield one call).
         const injected = { reportSilently: vi.fn(), setSdkInfo: vi.fn(), setFramework: vi.fn() } as any;
         const resolveSpy = vi.spyOn(resolveModule, 'resolveFlare');

--- a/packages/vue/tests/electronBoundaryInjection.test.ts
+++ b/packages/vue/tests/electronBoundaryInjection.test.ts
@@ -3,10 +3,9 @@ import { mount } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { defineComponent, h } from 'vue';
 
-// The REAL inject entry boundary + a real Electron RendererFlare. Drives the full path:
-// boundary resolves the injected instance at setup -> reportSilently -> RendererFlare.sendReport
-// -> bridge. (The existing electron cross-package test covers the flareVue plugin path; this closes
-// the gap for the FlareErrorBoundary component end-to-end through the bridge.)
+// Real inject-entry boundary + real Electron RendererFlare, driving the full path: boundary resolves
+// the injected instance at setup -> reportSilently -> RendererFlare.sendReport -> bridge. Closes the
+// gap the existing electron cross-package test leaves (that one covers the flareVue plugin path).
 import { FlareErrorBoundary } from '../src/inject';
 
 const ThrowingChild = defineComponent({

--- a/packages/vue/tests/flareVue.test.ts
+++ b/packages/vue/tests/flareVue.test.ts
@@ -84,7 +84,7 @@ function callHandler(
     try {
         app.config.errorHandler!(...args);
     } catch {
-        // Hook callbacks or flare.report() may throw
+        // Hook callbacks or flare.report() may throw.
     }
 }
 
@@ -358,7 +358,7 @@ describe('flareVue', () => {
         try {
             app.config.errorHandler!(new Error('original'), null, 'setup function');
         } catch {
-            // report() throwing is expected to propagate
+            // report() throwing is expected to propagate.
         }
 
         expect(spy).not.toHaveBeenCalled();
@@ -791,7 +791,7 @@ describe('flareVue', () => {
         app.use(flareVue, { flare: injected });
         app.config.errorHandler!(new Error('a'), null, 'render');
         app.config.errorHandler!(new Error('b'), null, 'render');
-        expect(resolveSpy).toHaveBeenCalledTimes(1); // resolved at install, NOT per error
+        expect(resolveSpy).toHaveBeenCalledTimes(1); // resolved at install, not per error
         resolveSpy.mockRestore();
     });
 });

--- a/packages/vue/tests/injectEntry.test.ts
+++ b/packages/vue/tests/injectEntry.test.ts
@@ -2,9 +2,9 @@ import { mount } from '@vue/test-utils';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 import { createApp, h } from 'vue';
 
-// NOTE: this file registers NO resolveFlare default (it never imports the web entry). Vitest
-// isolates the module registry per file, so resolveFlare's defaultProvider stays null here —
-// which is exactly what lets the "throws without an instance" assertions hold.
+// This file registers no resolveFlare default (it never imports the web entry). Vitest isolates the
+// module registry per file, so resolveFlare's defaultProvider stays null, which is what lets the
+// "throws without an instance" assertions hold.
 
 describe('@flareapp/vue/inject entry', () => {
     beforeEach(() => {
@@ -45,14 +45,14 @@ describe('@flareapp/vue/inject entry', () => {
         const { flareVue } = await import('../src/inject');
         const app = createApp({ render: () => null });
 
-        // Call the plugin function DIRECTLY (not via app.use). This verifies OUR installedApps
-        // ordering in isolation. It does NOT reflect the public `app.use` path: Vue adds the plugin
-        // to its own installed-set before invoking install, so a failed `app.use(flareVue)` can't be
+        // Call the plugin function directly (not via app.use) to verify our installedApps ordering
+        // in isolation. This doesn't reflect the public `app.use` path: Vue adds the plugin to its
+        // own installed-set before invoking install, so a failed `app.use(flareVue)` can't be
         // retried on the same app regardless of our ordering. First call has no instance -> throws.
         expect(() => (flareVue as any)(app, undefined)).toThrow(/No Flare instance available/);
 
-        // Retry with a valid instance MUST install (the failed attempt must not have added the app
-        // to installedApps — the resolve-before-add ordering, verified here via direct invocation).
+        // Retry with a valid instance must install: the failed attempt must not have added the app
+        // to installedApps (the resolve-before-add ordering, verified here via direct invocation).
         const injected = {
             reportSilently: vi.fn(),
             reportMessage: vi.fn(),

--- a/packages/webpack/src/FlareWebpackPlugin.ts
+++ b/packages/webpack/src/FlareWebpackPlugin.ts
@@ -173,9 +173,8 @@ export class FlareWebpackPlugin {
 
             try {
                 const content = readFileSync(mapPath, 'utf8');
-                // Server (Node/SSR) runtime stack frames are filesystem / file:// paths, not URLs,
-                // so the web public-path prefix is meaningless and breaks suffix matching on the
-                // backend. Upload the bundle-relative path for server builds.
+                // Server runtime frames are file:// paths, not URLs, so the public-path prefix
+                // breaks backend suffix matching. Upload the bundle-relative path for server builds.
                 const originalFile = isServer ? jsFile : `${publicPath}${jsFile}`;
                 sourcemaps.push({
                     sourcemap: { originalFile, content },


### PR DESCRIPTION
Comments-only cleanup across all 13 packages: verbose, over-explaining comments are trimmed to terse, to-the-point notes, and declaration-documenting comments are promoted to proper JSDoc. No executable code changed (135 files, ~640 net comment lines removed), and load-bearing invariants (tracing one-shot continuations, LRU eviction, sampler fail-closed, cross-environment quirks, sender-trust boundaries) are preserved in shortened form. oxlint and oxfmt ran clean via the pre-commit hook.