### PR TITLE
feat: TanStack Router parameterized route names for browser tracing

### DIFF
--- a/.claude/docs/research/performance-tracing.md
+++ b/.claude/docs/research/performance-tracing.md
@@ -954,14 +954,24 @@ Two integration shapes, both v7:
 
 - First-class events: `router.subscribe(eventName, listener)`. Order: `onBeforeNavigate` (start) → `onBeforeLoad` →
   `onLoad` → `onBeforeRouteMount` → `onResolved` (end) → `onRendered`. Payload: `{ fromLocation?, toLocation,
-pathChanged, hrefChanged, hashChanged }`.
-- Initial pageload distinction: likely `fromLocation === undefined` on first `onResolved` — **not stated explicitly in
-  docs; verify.** (Flagged.)
+pathChanged, hrefChanged, hashChanged }`. **Caveat (added 2026-07-07): `onBeforeNavigate` is suppressed once a
+  loader redirect is pending (`router-core` gates the emit on `!stores.redirect`; TanStack/router#3920), so it does
+  NOT fire for every navigation — use `onBeforeLoad` as the nav-start hook, as Sentry's integration does. A redirect
+  chain emits one `onBeforeLoad` per hop but a single `onResolved`.**
+- Initial pageload distinction: `fromLocation === undefined`. **Confirmed 2026-07-07:** the router-events guide
+  states "fromLocation can be undefined on the initial load", and Sentry's integration uses exactly `!fromLocation`
+  to skip the initial load in its navigation subscriber.
 - Parameterized name: read `router.state.matches[last].fullPath` / `routeId` (TanStack uses `$param`; normalize
   `$postId`→`:postId` if backend expects colon form). Guard against `""` fullPath for pathless routes (issue #4892).
-- **First-party Sentry integration now exists** (`tanstackRouterBrowserTracingIntegration`), exported from
-  `@sentry/react/tanstackrouter`, `@sentry/vue/tanstackrouter`, `@sentry/solid/tanstackrouter`, and
-  `@sentry/tanstackstart-react`. **Doc previously stated "no first-party integration" — corrected 2026-06-15.**
+  Sentry instead resolves matches on demand via `router.matchRoutes(pathname, search, { preload: false,
+throwOnError: false })` — independent of when router state commits — and treats a `__root__`-only match list as
+  "nothing matched" (falls back to the URL name). Verified in source 2026-07-07.
+- **First-party Sentry integration now exists** (`tanstackRouterBrowserTracingIntegration`). **Corrected 2026-07-07:**
+  for React it is exported from the MAIN `@sentry/react` entry — the published exports map has no subpaths; only
+  `@sentry/solid` documents a `/tanstackrouter` subpath import. TanStack Start has the dedicated
+  `@sentry/tanstackstart-react`. It vendors structural router types instead of taking a TanStack peer dep, and pins
+  minimum router version `1.64.0`. (This doc previously claimed `@sentry/{react,vue}/tanstackrouter` entry points;
+  earlier still, "no first-party integration" — corrected 2026-06-15.)
 - Docs: tanstack.com/router/latest/docs/guide/router-events, /api/router/RouterEventsType.
 
 ### 8.3 Vue Router v4
@@ -1006,8 +1016,10 @@ when implementing the Flare equivalents. Paths may drift; re-verify against the 
 
 **TanStack Router** (`tanstackRouterBrowserTracingIntegration(router)`)
 
-- Per-host packages each re-export from a `tanstackrouter` entry point:
-  `@sentry/react/tanstackrouter`, `@sentry/vue/tanstackrouter`, `@sentry/solid/tanstackrouter`.
+- Source per host package (`packages/react/src/tanstackrouter.ts`, vendored types in
+  `packages/react/src/vendor/tanstackrouter-types.ts`), re-exported from the package's MAIN entry for React
+  (**corrected 2026-07-07**: the published `@sentry/react` exports map has no subpaths — this doc previously
+  claimed per-host `tanstackrouter` entry points; only `@sentry/solid` documents a `/tanstackrouter` subpath).
 - TanStack Start dedicated package: `@sentry/tanstackstart-react` (e2e example
   `dev-packages/e2e-tests/test-applications/tanstackstart-react/src/router.tsx`).
 - Underlying instrumentation lives under each host package's source tree (`packages/react/src/tanstackrouter.*`,
@@ -1039,21 +1051,23 @@ when implementing the Flare equivalents. Paths may drift; re-verify against the 
 
 ### 8.6 Cross-router summary
 
-| Router             | Nav start                                    | Nav end                             | Parameterized name                       | Param syntax | Sentry official |
-| ------------------ | -------------------------------------------- | ----------------------------------- | ---------------------------------------- | ------------ | --------------- |
-| React Router v7    | `useLocation` change / data-router subscribe | `useEffect` after commit            | `matchRoutes()` → join `route.path`      | `:id`        | Yes (lib + fw)  |
-| TanStack Router v1 | `subscribe('onBeforeNavigate')`              | `'onResolved'`                      | `state.matches[last].fullPath`/`routeId` | `$id`        | Yes             |
-| Vue Router v4      | `beforeEach`                                 | `afterEach`                         | `to.matched[last].path` / `to.name`      | `:id`        | Yes             |
-| SvelteKit 2        | `navigating` non-null / `beforeNavigate`     | `navigating`→null / `afterNavigate` | `route.id`                               | `[id]`       | Yes (+ server)  |
+| Router             | Nav start                                    | Nav end                             | Parameterized name                     | Param syntax | Sentry official |
+| ------------------ | -------------------------------------------- | ----------------------------------- | -------------------------------------- | ------------ | --------------- |
+| React Router v7    | `useLocation` change / data-router subscribe | `useEffect` after commit            | `matchRoutes()` → join `route.path`    | `:id`        | Yes (lib + fw)  |
+| TanStack Router v1 | `subscribe('onBeforeLoad')` (#3920)          | `'onResolved'`                      | `matchRoutes()` → `fullPath`/`routeId` | `$id`        | Yes             |
+| Vue Router v4      | `beforeEach`                                 | `afterEach`                         | `to.matched[last].path` / `to.name`    | `:id`        | Yes             |
+| SvelteKit 2        | `navigating` non-null / `beforeNavigate`     | `navigating`→null / `afterNavigate` | `route.id`                             | `[id]`       | Yes (+ server)  |
 
 ### Open questions (routers)
 
 1. React Router v7 framework (Remix-style) mode instrumentation API — was Beta; verify.
     - **Resolved 2026-06-15:** shipped as the dedicated `@sentry/react-router` package; see §8.5 for source path.
 2. TanStack initial-pageload detection (no explicit flag confirmed) and absence of a first-party Sentry integration.
-    - **Partly resolved 2026-06-15:** first-party `tanstackRouterBrowserTracingIntegration` now exists across
-      `@sentry/{react,vue,solid,tanstackstart-react}/tanstackrouter`. Initial-pageload detection still unverified —
-      read the integration source and reverify.
+    - **Partly resolved 2026-06-15:** first-party `tanstackRouterBrowserTracingIntegration` exists (export paths
+      corrected 2026-07-07 — see §8.2/§8.5).
+    - **Resolved 2026-07-07:** initial-pageload detection is `fromLocation === undefined` (documented by TanStack,
+      used by Sentry's source). The same review established `onBeforeLoad`, not `onBeforeNavigate`, as the reliable
+      nav-start event (TanStack/router#3920).
 3. Vue: exact name-resolution precedence inside Sentry not source-verified.
 4. Param-syntax normalization — does the backend want one canonical placeholder form across routers? Backend decision.
 5. SvelteKit `$app/stores` → `$app/state` migration timing vs the version we target.

--- a/docs/superpowers/specs/2026-07-07-performance-tracing-framework-router-tanstack-design.md
+++ b/docs/superpowers/specs/2026-07-07-performance-tracing-framework-router-tanstack-design.md
@@ -94,9 +94,10 @@ export type NavigationSource = {
     // generally safe for the seam's future consumers. The parameterized name is
     // applied via setActiveRouteName once known.
     startNavigation(opts?: { path?: string }): void;
-    // Rename the currently-active root (pageload OR navigation) to the parameterized route
-    // and set its source flag. Used both for the initial-pageload enrichment and to upgrade
-    // a navigation root's name when the router resolves. No-op if no root is open / it ended.
+    // Rename the currently-active root (pageload OR navigation) to the parameterized route,
+    // keep its flare.entry_point.handler.identifier attribute in lockstep with the name, and
+    // set its source flag. Used both for the initial-pageload enrichment and to upgrade a
+    // navigation root's name when the router resolves. No-op if no root is open / it ended.
     setActiveRouteName(route: RouteName): void;
     // Restore the default History-based navigation detection.
     unregister(): void;
@@ -126,10 +127,13 @@ Supporting changes in `browserTracing`:
   current root.
 - `startNavigation(opts?)` ends the current `IdleRootController` and opens a `browser_navigation` root
   named after `opts.path ?? location.pathname` (`source: 'url'`) with correct timing.
-- `setActiveRouteName(route)` assigns `root.name = route.name` and sets the source attribute on the
-  currently-active root (pageload or navigation) **only while it is open** (guarded via the controller's
-  `isEnded`); it no-ops otherwise. `Span.name` is a mutable field, so no core change is needed; the guard
-  preserves the "don't mutate an ended span" invariant that `setAttribute`/`setStatus` already enforce.
+- `setActiveRouteName(route)` assigns `root.name = route.name`, rewrites the root's
+  `flare.entry_point.handler.identifier` attribute to the same value (that attribute holds the raw
+  pathname at open and is the identifier the backend reads — leaving it stale while renaming the span
+  would ship two conflicting identifiers), and sets the source attribute, all on the currently-active
+  root (pageload or navigation) **only while it is open** (guarded via the controller's `isEnded`); it
+  no-ops otherwise. `Span.name` is a mutable field, so no core change is needed; the guard preserves the
+  "don't mutate an ended span" invariant that `setAttribute`/`setStatus` already enforce.
 
 Default behavior when no integration registers is unchanged, with one deliberate addition: every root the
 orchestrator opens (pageload and navigation, integration or not) sets the provisional
@@ -177,11 +181,13 @@ Behavior:
   #4892). Resolving via `matchRoutes` instead of reading `router.state.matches` works at any point in the
   lifecycle (no dependency on when router state commits) and matches Sentry.
 - **Initial pageload**: at registration, resolve the current location through `matchRoutes` and call
-  `setActiveRouteName` against the already-running pageload root immediately; subscribe once to
-  `onResolved` to correct the name if a loader redirect changed the route, then drop that listener. The
-  `fromLocation === undefined` initial-load signal is confirmed by TanStack's docs ("fromLocation can be
-  undefined on the initial load") and by Sentry's source (it uses exactly `!fromLocation` to skip the
-  initial load in its navigation subscriber).
+  `setActiveRouteName` against the already-running pageload root immediately; the shared `onResolved`
+  subscription corrects the name if a loader redirect changed the route, gated on
+  `fromLocation === undefined` — a condition only the initial load produces (the router's resolved
+  location is set from the first resolution onward), so the correction is effectively one-shot without
+  separate listener bookkeeping. The `fromLocation === undefined` initial-load signal is confirmed by
+  TanStack's docs ("fromLocation can be undefined on the initial load") and by Sentry's source (it uses
+  exactly `!fromLocation` to skip the initial load in its navigation subscriber).
 - Returns a cleanup that unsubscribes from the router and calls `NavigationSource.unregister()`
   (restoring default History detection; token-guarded, see the seam). Safe to call zero or multiple
   times.
@@ -227,6 +233,9 @@ router; do the same if the optional peer dep creates type-checking friction for 
 
 - The root span **name** is the parameterized route template as the router emits it (native `$id`
   syntax), or the raw URL path when no template is resolvable.
+- The roots' existing `flare.entry_point.handler.identifier` attribute stays in lockstep with the name:
+  it holds the raw pathname at open and `setActiveRouteName` rewrites it to the route template, so the
+  identifier the backend reads never contradicts the span name.
 - A **source flag** attribute distinguishes the two: proposed key `flare.route.source` with values
   `route | url`, set on every browser root at open (`url`) and flipped to `route` by
   `setActiveRouteName`. Both the key and the broader browser-perf attribute contract are **provisional** —

--- a/docs/superpowers/specs/2026-07-07-performance-tracing-framework-router-tanstack-design.md
+++ b/docs/superpowers/specs/2026-07-07-performance-tracing-framework-router-tanstack-design.md
@@ -1,0 +1,232 @@
+# Spec: performance tracing — framework router integration, TanStack Router (React)
+
+Status: design approved 2026-07-07. Branch: `research/tracing-framework-routers`.
+
+Scope: the shared framework-agnostic **navigation-source seam** in `@flareapp/js`, plus the **first**
+framework router integration built on it — **TanStack Router v1**, shipped from `@flareapp/react`.
+React Router v7, Vue Router v4, and SvelteKit 2 (client + server correlation) are explicit follow-on
+slices that reuse this seam and are out of scope here.
+
+## Context
+
+This continues the performance-tracing effort (core foundation, browser fetch, pageload/navigation
+roots, and XHR instrumentation are all merged to `main`). The
+[pageload/navigation roots slice](2026-07-02-performance-tracing-pageload-navigation-roots-design.md)
+introduced framework-agnostic `browser_pageload` / `browser_navigation` root spans with a Sentry-style
+idle lifecycle, detecting navigations by patching the History API and naming each root by the raw
+`location.pathname` (e.g. `/products/123`). That slice explicitly deferred parameterized route names and
+router-event integration to separate per-framework slices. This is the first of those.
+
+The goal: replace the raw-URL root name with the **parameterized route template** (e.g. `/products/$id`)
+supplied by the app's router, plus a `route` vs `url` source flag, so the backend `SpanAggregators`
+group navigations correctly (research doc §8, §2.4). Full research: `.claude/docs/research/performance-tracing.md`
+§8 (router interop) and §8.6 (cross-router summary). Sentry's real source was consulted; where we match
+it and where we diverge is recorded below.
+
+TanStack Router is first because the research doc calls it the cleanest of the four routers
+(first-class `router.subscribe` events with an explicit start/end lifecycle) and the React playground
+already uses it, giving us real end-to-end validation with no new fixture.
+
+## Approved decisions driving this spec
+
+- **Mechanism: router drives navigation; History detection steps aside (Sentry's approach).** When a
+  framework router integration registers as the navigation source, the built-in History-API navigation
+  detection is suppressed (no double roots), and the integration opens each `browser_navigation` root
+  from the router's navigation-start event (URL-named, correct timing) and sets the parameterized name
+  once the router resolves the route. This matches Sentry, whose framework integrations set
+  `instrumentNavigation: false` on the generic browser-tracing and start navigation spans themselves,
+  updating the name after the match resolves.
+- **Pageload = start-generic-then-enrich.** The generic `browser_pageload` root still starts at
+  `configure` time, backdated and URL-named, so early fetch/XHR spans nest correctly. The integration
+  then renames it to the parameterized route (and flips source to `route`) once the router resolves the
+  initial route. Also mirrors Sentry. Navigation and pageload thus share ONE "set the active root's
+  route name" operation.
+- **Emit the router-native parameterized form; no param-syntax normalization.** TanStack's `$id` form is
+  used as-is (span name `/products/$id`), exactly like Sentry. Within an app the router is fixed, so the
+  name is internally consistent and the backend groups occurrences fine. Canonicalizing placeholder
+  syntax across frameworks (`$id` → `:id`) is cosmetic, guesses a backend contract that does not exist
+  yet, and is trivial to add centrally in the seam later if the backend ever wants it. Deferred.
+- **Packaging: existing framework package + subpath entry, not a new package.** The integration ships
+  from `@flareapp/react` at `@flareapp/react/tanstack-router`, matching the existing `./inject` subpath
+  convention and Sentry's `@sentry/react/tanstackrouter` convention. No new published package.
+- **No `@flareapp/core` change.** `Span.name` is already a mutable field, so setting a root's route name
+  is a guarded field assignment in the seam. The whole slice lives in `@flareapp/js` + `@flareapp/react`.
+- **Automated React e2e coverage is in scope.** Unlike the manual-only XHR slice, this slice adds a
+  Playwright spec in the `react` project, because the framework wiring working end-to-end is the point.
+
+## Components
+
+### 1. Navigation-source seam — `@flareapp/js` (`src/tracing/browserTracing.ts` + a small public surface)
+
+Today `browserTracing` holds module-level singletons (`controller`, `uninstall`, `lastPath`,
+`pageloadTraced`), starts the pageload root in `startBrowserTracing`, and starts `browser_navigation`
+roots from `onUrlChanged` on History changes. This slice adds a seam so a framework integration can take
+over navigation:
+
+New public export from `@flareapp/js`'s browser surface (the tracing barrel is not currently public, so
+this is a deliberate, minimal public-API addition that every future framework slice consumes):
+
+```ts
+export function registerNavigationSource(): NavigationSource;
+
+export type RouteName = { name: string; source: 'route' | 'url' };
+
+export type NavigationSource = {
+    // End the active root (if any) and open a new browser_navigation root, URL-named
+    // (source: 'url') with correct timing. This is what onUrlChanged used to do, now
+    // caller-driven. The parameterized name is applied via setActiveRouteName once known.
+    startNavigation(): void;
+    // Rename the currently-active root (pageload OR navigation) to the parameterized route
+    // and set its source flag. Used both for the initial-pageload enrichment and to upgrade
+    // a navigation root's name when the router resolves. No-op if no root is open / it ended.
+    setActiveRouteName(route: RouteName): void;
+    // Restore the default History-based navigation detection.
+    unregister(): void;
+};
+```
+
+Supporting changes in `browserTracing`:
+
+- A module-level flag/reference recording that an external navigation source is registered. While set,
+  `onUrlChanged` early-returns (the History `pushState`/`replaceState`/`popstate` patches may stay
+  installed but do not open navigation roots), so there is exactly one root per navigation.
+  Registration is **order-independent**: registering before `startBrowserTracing` runs makes it skip
+  installing History navigation detection; registering after makes the already-installed handler inert.
+- A module-level reference to the **active tracing flare** (set in `startBrowserTracing`, cleared in
+  `stopBrowserTracing`) and to the **current root span**, so `startNavigation` can open a root (reusing
+  the existing `startRoot` machinery: end the current `IdleRootController`, create a `browser_navigation`
+  root via `flare.startSpan`, wire a fresh `IdleRootController`) and `setActiveRouteName` can rename the
+  current root.
+- `startNavigation()` ends the current `IdleRootController` and opens a `browser_navigation` root
+  URL-named (`source: 'url'`) with correct timing.
+- `setActiveRouteName(route)` assigns `root.name = route.name` and sets the source attribute on the
+  currently-active root (pageload or navigation) **only while it is open** (guarded via the controller's
+  `isEnded`); it no-ops otherwise. `Span.name` is a mutable field, so no core change is needed; the guard
+  preserves the "don't mutate an ended span" invariant that `setAttribute`/`setStatus` already enforce.
+
+Default behavior is unchanged when no integration registers: History detection still names roots by URL
+with `source: 'url'`.
+
+### 2. TanStack integration — `@flareapp/react/tanstack-router` (new subpath entry)
+
+A new tsdown entry and `exports` map entry in `packages/react/package.json` (mirroring `./inject`). One
+exported function:
+
+```ts
+import { traceTanStackRouter } from '@flareapp/react/tanstack-router';
+const stop = traceTanStackRouter(router); // returns a cleanup fn
+```
+
+Behavior:
+
+- Calls `registerNavigationSource()` from `@flareapp/js`.
+- Subscribes to the TanStack router: on a navigation start (`onBeforeNavigate`) → `startNavigation()`
+  (opens the URL-named nav root with correct timing); on resolve (`onResolved`) →
+  `setActiveRouteName({ name, source: 'route' })` (upgrades the active root's name to the parameterized
+  route). The initial pageload uses `setActiveRouteName` against the already-running pageload root. Nav
+  end is handled by the idle controller as today; the router supplies nav start + the name.
+- Reads the parameterized route from `router.state.matches[last].fullPath`, falling back to `routeId`,
+  then leaving the URL name with `source: 'url'` when neither is usable (pathless/layout routes can yield
+  an empty `fullPath` — research §8.2, TanStack issue #4892).
+- Distinguishes the initial pageload (upgrade the existing pageload root via `setActiveRouteName`) from a
+  navigation (`startNavigation()` on start, then `setActiveRouteName` on resolve). Candidate initial-load
+  signal: `fromLocation === undefined` on the first event — flagged for source verification (see Items to
+  verify).
+- Returns a cleanup that unsubscribes from the router and calls `NavigationSource.unregister()`
+  (restoring default History detection). Safe to call zero or multiple times.
+- **No-ops safely when tracing is disabled**, and is order-independent relative to
+  `configure({ enableTracing: true })`.
+- The integration is actually React-agnostic (it only touches the TanStack router core); it ships from
+  `@flareapp/react/tanstack-router` for discoverability. If Vue+TanStack is wanted later, extract; not now.
+
+Dependencies: `@tanstack/react-router` (v1) becomes an **optional** peer dep scoped to this entry via
+`peerDependenciesMeta`, so the main `@flareapp/react` entry is unaffected and apps not using TanStack
+pay nothing. `@flareapp/js` is already a peer dependency of `@flareapp/react`.
+
+### 3. React playground wiring + e2e (`playgrounds/react`, `e2e/`)
+
+- Enable tracing in the React playground (`VITE_FLARE_URL` override + `configure({ enableTracing: true })`,
+  as the JS playground already does) and call `traceTanStackRouter(router)` at bootstrap, right after
+  `createRouter`.
+- The e2e `react` project gets a Playwright spec asserting an in-app navigation yields a
+  `browser_navigation` envelope at the fake-flare-server whose root name is the parameterized route
+  (e.g. `/products/$id`, `source: route`), and that the pageload root carries the parameterized initial
+  route. Mirrors the roots slice's pageload/navigation/nesting specs.
+
+## Trace model for this slice
+
+- **Pageload**: `configure({ enableTracing: true })` starts the backdated `browser_pageload` root
+  URL-named (`source: url`); the integration renames it to the parameterized initial route
+  (`source: route`) on the router's first resolve, while it is still open. Fetch/XHR spans nest under it
+  unchanged.
+- **Navigation**: each route change → the integration opens one `browser_navigation` root (URL-named on
+  nav start, correct timing) and upgrades its name to the parameterized route (`source: route`) on
+  resolve; the idle controller closes it as today. History-based detection is suppressed, so exactly one
+  root per navigation.
+- **No integration registered**: unchanged from the roots slice (URL-named roots, `source: url`).
+
+## Route name & attributes
+
+- The root span **name** is the parameterized route template as the router emits it (native `$id`
+  syntax), or the raw URL path when no template is resolvable.
+- A **source flag** attribute distinguishes the two: proposed key `flare.route.source` with values
+  `route | url`. Both the key and the broader browser-perf attribute contract are **provisional** —
+  the research doc lists the attribute contract as a backend decision still gated on B5/B9/P4. The raw
+  page URL remains available via the roots' existing `collectBrowserSpanContext`, so the backend can show
+  the concrete URL alongside the template.
+
+## Error handling
+
+Instrumentation must never break the host app or its router:
+
+- `router.subscribe` callbacks are wrapped so a tracing error never escapes into the router's event
+  dispatch, mirroring `browserTracing`'s existing defensive boundaries (the `startRoot` try/catch and the
+  `pushState` wrap guards).
+- Seam operations no-op when there is no active tracing session or no active root; `setActiveRouteName`
+  no-ops if the active root already closed (e.g. a slow initial load past the idle timeout), leaving the
+  URL name rather than throwing.
+- Route-name reads are guarded: empty `fullPath` / pathless routes fall back (`routeId` → keep URL name),
+  and `router.state` shape reads are defensive against router version drift.
+- Registration is idempotent; the returned cleanup is safe to call zero or multiple times.
+
+## Testing (unit + e2e)
+
+- **Unit — js seam** (`packages/js/tests`, alongside `browserTracing.test.ts`): registering a nav source
+  suppresses History navigation detection; `startNavigation()` opens a URL-named `browser_navigation`
+  root and ends the prior one; `setActiveRouteName` renames the open active root (pageload or navigation)
+  and sets its source, and no-ops once it has ended; `unregister` restores default History detection; all
+  operations no-op with no active session.
+- **Unit — TanStack integration** (`packages/react/tests`): with a minimal fake router (exposing
+  `subscribe` + `state.matches`), assert `onBeforeNavigate` → `startNavigation()` then `onResolved` →
+  `setActiveRouteName` with the parameterized name + `source: 'route'`; the initial pageload path
+  (`setActiveRouteName` on the pageload root); empty-`fullPath` fallback to `routeId` / URL; cleanup
+  unsubscribes and unregisters. No React render needed (router-only).
+- **E2e** (`playgrounds/react` + Playwright `react` project): the navigation/pageload assertions above
+  against the fake-flare-server.
+
+The existing pageload/navigation roots unit + e2e coverage must stay green (default URL-named behavior is
+unchanged when no integration registers).
+
+## Items to verify during implementation
+
+- **TanStack initial-pageload signal.** The candidate `fromLocation === undefined` on the first event is
+  not source-verified (research §8.2, open question #2). Confirm against the router's actual event
+  payload; if unreliable, gate the initial `setActiveRouteName` on a "first event seen" latch instead.
+- **Exact TanStack events.** Start the nav root on the navigation-start event (`onBeforeNavigate`) and set
+  the name on `onResolved` (the design decouples these, so matches need not be populated at start).
+  Confirm both events fire for every navigation and that `router.state.matches[last].fullPath` is
+  populated at `onResolved`.
+- **Seam function names** (`registerNavigationSource` / `startNavigation` / `setActiveRouteName`) are
+  provisional; finalize in the plan.
+- **`flare.route.source` attribute key** is provisional pending the backend attribute contract.
+
+## Out of scope / follow-ups
+
+- **Other routers** (React Router v7, Vue Router v4, SvelteKit 2 client) — each a follow-on slice reusing
+  this seam.
+- **SvelteKit server↔client correlation** (inbound `traceparent` in `handle`, SSR trace `<meta>` tags,
+  client-side continuation) — net-new on both ends; its own slice (research §8.4).
+- **Param-syntax canonicalization** across frameworks — deferred to the backend-contract work.
+- **Multi-instance tracing ownership** (the deferred XHR-round Finding 5) — unrelated, still pending.
+- **Backend taxonomy/attribute contract** for route names (B5/B9/P4) — the `flare.route.source` key and
+  the parameterized-name semantics need backend agreement before real-product correlation.

--- a/docs/superpowers/specs/2026-07-07-performance-tracing-framework-router-tanstack-design.md
+++ b/docs/superpowers/specs/2026-07-07-performance-tracing-framework-router-tanstack-design.md
@@ -305,7 +305,13 @@ unchanged when no integration registers, modulo the one deliberate addition of t
 ## Out of scope / follow-ups
 
 - **Other routers** (React Router v7, Vue Router v4, SvelteKit 2 client) — each a follow-on slice reusing
-  this seam.
+  this seam. **Carry-forward (learned during the TanStack build, 2026-07-07):** `startRoot` reads
+  `url.full` / `flare.entry_point.value` from the LIVE `location` via `collectBrowserSpanContext`. That is
+  correct for TanStack (it commits the URL through the History API BEFORE `onBeforeLoad` fires), but Vue
+  Router's `beforeEach` and SvelteKit's `beforeNavigate` fire BEFORE the URL commits — so those slices
+  must thread the destination URL into the root's context (or `setActiveRouteName` must also carry a URL),
+  or their navigation roots will carry the previous page's `url.full`. The seam already accepts an
+  explicit destination `path` for the name for exactly this reason; the URL context needs the same.
 - **SvelteKit server↔client correlation** (inbound `traceparent` in `handle`, SSR trace `<meta>` tags,
   client-side continuation) — net-new on both ends; its own slice (research §8.4).
 - **Param-syntax canonicalization** across frameworks — deferred to the backend-contract work.

--- a/docs/superpowers/specs/2026-07-07-performance-tracing-framework-router-tanstack-design.md
+++ b/docs/superpowers/specs/2026-07-07-performance-tracing-framework-router-tanstack-design.md
@@ -1,6 +1,9 @@
 # Spec: performance tracing — framework router integration, TanStack Router (React)
 
-Status: design approved 2026-07-07. Branch: `research/tracing-framework-routers`.
+Status: design approved 2026-07-07; revised the same day after review (nav-start event switched
+`onBeforeNavigate` → `onBeforeLoad` per TanStack/router#3920, `startNavigation` gained a destination-path
+param, same-path-load policy and registration semantics made explicit, Sentry packaging citation
+corrected). Branch: `research/tracing-framework-routers`.
 
 Scope: the shared framework-agnostic **navigation-source seam** in `@flareapp/js`, plus the **first**
 framework router integration built on it — **TanStack Router v1**, shipped from `@flareapp/react`.
@@ -38,9 +41,13 @@ already uses it, giving us real end-to-end validation with no new fixture.
   updating the name after the match resolves.
 - **Pageload = start-generic-then-enrich.** The generic `browser_pageload` root still starts at
   `configure` time, backdated and URL-named, so early fetch/XHR spans nest correctly. The integration
-  then renames it to the parameterized route (and flips source to `route`) once the router resolves the
-  initial route. Also mirrors Sentry. Navigation and pageload thus share ONE "set the active root's
-  route name" operation.
+  then renames it to the parameterized route (and flips source to `route`) immediately at registration,
+  by resolving the current location through `router.matchRoutes` synchronously, with a one-shot
+  correction on the router's first `onResolved` in case a loader redirect changed the route. Also
+  mirrors Sentry (which names the pageload span from a synchronous `matchRoutes` call and corrects it
+  once on resolve). Enriching at registration rather than waiting for the first resolve closes the
+  window where a slow initial load lets the pageload root idle out still URL-named. Navigation and
+  pageload thus share ONE "set the active root's route name" operation.
 - **Emit the router-native parameterized form; no param-syntax normalization.** TanStack's `$id` form is
   used as-is (span name `/products/$id`), exactly like Sentry. Within an app the router is fixed, so the
   name is internally consistent and the backend groups occurrences fine. Canonicalizing placeholder
@@ -48,7 +55,11 @@ already uses it, giving us real end-to-end validation with no new fixture.
   yet, and is trivial to add centrally in the seam later if the backend ever wants it. Deferred.
 - **Packaging: existing framework package + subpath entry, not a new package.** The integration ships
   from `@flareapp/react` at `@flareapp/react/tanstack-router`, matching the existing `./inject` subpath
-  convention and Sentry's `@sentry/react/tanstackrouter` convention. No new published package.
+  convention. (Correction 2026-07-07: Sentry's React SDK exports `tanstackRouterBrowserTracingIntegration`
+  from the MAIN `@sentry/react` entry — its published exports map has no subpaths; the `/tanstackrouter`
+  subpath convention appears in `@sentry/solid`. The subpath decision stands on the `./inject` precedent
+  and on keeping TanStack-specific code out of the main entry, not on a Sentry React precedent.) No new
+  published package.
 - **No `@flareapp/core` change.** `Span.name` is already a mutable field, so setting a root's route name
   is a guarded field assignment in the seam. The whole slice lives in `@flareapp/js` + `@flareapp/react`.
 - **Automated React e2e coverage is in scope.** Unlike the manual-only XHR slice, this slice adds a
@@ -74,8 +85,15 @@ export type RouteName = { name: string; source: 'route' | 'url' };
 export type NavigationSource = {
     // End the active root (if any) and open a new browser_navigation root, URL-named
     // (source: 'url') with correct timing. This is what onUrlChanged used to do, now
-    // caller-driven. The parameterized name is applied via setActiveRouteName once known.
-    startNavigation(): void;
+    // caller-driven. `path` is the destination pathname as the router reports it
+    // (e.g. TanStack's toLocation.pathname); when omitted it falls back to
+    // location.pathname. Integrations should pass it: several routers fire their
+    // nav-start hook BEFORE the URL updates (Vue Router beforeEach, SvelteKit
+    // beforeNavigate), and TanStack's location masking makes window.location diverge
+    // from the router's real location, so reading location.pathname at start is not
+    // generally safe for the seam's future consumers. The parameterized name is
+    // applied via setActiveRouteName once known.
+    startNavigation(opts?: { path?: string }): void;
     // Rename the currently-active root (pageload OR navigation) to the parameterized route
     // and set its source flag. Used both for the initial-pageload enrichment and to upgrade
     // a navigation root's name when the router resolves. No-op if no root is open / it ended.
@@ -87,25 +105,38 @@ export type NavigationSource = {
 
 Supporting changes in `browserTracing`:
 
-- A module-level flag/reference recording that an external navigation source is registered. While set,
-  `onUrlChanged` early-returns (the History `pushState`/`replaceState`/`popstate` patches may stay
-  installed but do not open navigation roots), so there is exactly one root per navigation.
-  Registration is **order-independent**: registering before `startBrowserTracing` runs makes it skip
-  installing History navigation detection; registering after makes the already-installed handler inert.
+- A module-level reference recording the currently-registered external navigation source. The History
+  `pushState`/`replaceState`/`popstate` patches are ALWAYS installed by `startBrowserTracing`; the
+  registration only gates the handler (`onUrlChanged` opens no root while a source is registered), so
+  there is exactly one root per navigation. This makes registration **order-independent** (register
+  before or after `startBrowserTracing`; only the flag matters) and makes `unregister()` trivially
+  correct: it clears the flag and default detection resumes — nothing needs reinstalling. While
+  suppressed, the handler still keeps `lastPath` current (and `unregister()` resyncs
+  `lastPath = location.pathname` as a belt-and-braces), so post-unregister detection never compares
+  against a stale path.
+- Registration is **last-wins** and handles are **token-guarded**: a second `registerNavigationSource()`
+  call replaces the prior source (debug-logged), and a handle's `unregister()` only clears the
+  registration if that handle is still the active one. A stale handle's cleanup (e.g. an HMR-replaced
+  bootstrap module re-running the wiring) therefore cannot tear down a newer registration. Cleanup stays
+  safe to call zero or multiple times.
 - A module-level reference to the **active tracing flare** (set in `startBrowserTracing`, cleared in
   `stopBrowserTracing`) and to the **current root span**, so `startNavigation` can open a root (reusing
   the existing `startRoot` machinery: end the current `IdleRootController`, create a `browser_navigation`
   root via `flare.startSpan`, wire a fresh `IdleRootController`) and `setActiveRouteName` can rename the
   current root.
-- `startNavigation()` ends the current `IdleRootController` and opens a `browser_navigation` root
-  URL-named (`source: 'url'`) with correct timing.
+- `startNavigation(opts?)` ends the current `IdleRootController` and opens a `browser_navigation` root
+  named after `opts.path ?? location.pathname` (`source: 'url'`) with correct timing.
 - `setActiveRouteName(route)` assigns `root.name = route.name` and sets the source attribute on the
   currently-active root (pageload or navigation) **only while it is open** (guarded via the controller's
   `isEnded`); it no-ops otherwise. `Span.name` is a mutable field, so no core change is needed; the guard
   preserves the "don't mutate an ended span" invariant that `setAttribute`/`setStatus` already enforce.
 
-Default behavior is unchanged when no integration registers: History detection still names roots by URL
-with `source: 'url'`.
+Default behavior when no integration registers is unchanged, with one deliberate addition: every root the
+orchestrator opens (pageload and navigation, integration or not) sets the provisional
+`flare.route.source: 'url'` attribute at open, and `setActiveRouteName` flips it to `'route'`. The
+attribute is therefore uniformly present on browser roots instead of only on integration-touched ones, so
+the backend never has to treat absence as an implicit third state. Existing roots-slice tests gain the
+corresponding assertion.
 
 ### 2. TanStack integration — `@flareapp/react/tanstack-router` (new subpath entry)
 
@@ -120,28 +151,52 @@ const stop = traceTanStackRouter(router); // returns a cleanup fn
 Behavior:
 
 - Calls `registerNavigationSource()` from `@flareapp/js`.
-- Subscribes to the TanStack router: on a navigation start (`onBeforeNavigate`) → `startNavigation()`
-  (opens the URL-named nav root with correct timing); on resolve (`onResolved`) →
-  `setActiveRouteName({ name, source: 'route' })` (upgrades the active root's name to the parameterized
-  route). The initial pageload uses `setActiveRouteName` against the already-running pageload root. Nav
-  end is handled by the idle controller as today; the router supplies nav start + the name.
-- Reads the parameterized route from `router.state.matches[last].fullPath`, falling back to `routeId`,
-  then leaving the URL name with `source: 'url'` when neither is usable (pathless/layout routes can yield
-  an empty `fullPath` — research §8.2, TanStack issue #4892).
-- Distinguishes the initial pageload (upgrade the existing pageload root via `setActiveRouteName`) from a
-  navigation (`startNavigation()` on start, then `setActiveRouteName` on resolve). Candidate initial-load
-  signal: `fromLocation === undefined` on the first event — flagged for source verification (see Items to
-  verify).
+- Subscribes to the TanStack router on **`onBeforeLoad`** (navigation start) and **`onResolved`** (route
+  resolved). NOT `onBeforeNavigate`: TanStack suppresses that event once a loader redirect is pending
+  (`router-core` gates the emit on `!stores.redirect`; TanStack/router#3920), so it does not fire for
+  every navigation — Sentry's integration switched to `onBeforeLoad` for exactly this reason. Nav end is
+  handled by the idle controller as today; the router supplies nav start + the name.
+- **Skip gate** on `onBeforeLoad` (Sentry's, verified in its source): skip when
+  `event.fromLocation === undefined` (the initial pageload — documented TanStack behavior, see below) or
+  when `event.toLocation.state === event.fromLocation.state` (a no-op reload such as
+  `router.invalidate()`, which re-runs `load()` on the same location). Everything else opens a navigation
+  root. Deliberate policy: search-param and hash navigations DO get navigation roots — in TanStack they
+  run loaders and are real navigations — which diverges from the History-based default (that dedupes by
+  pathname and ignores them). The divergence is intentional; recorded here so the e2e work doesn't treat
+  it as a bug.
+- **Redirect chains**: a chain emits one `onBeforeLoad` per hop but a single `onResolved`. The
+  integration keeps an in-flight latch: the first `onBeforeLoad` calls
+  `startNavigation({ path: toLocation.pathname })` plus an immediate `setActiveRouteName` when a route
+  match resolves; subsequent `onBeforeLoad` events while in flight only re-run `setActiveRouteName` for
+  the new hop (no second root); `onResolved` applies the final name and clears the latch.
+- **Route-name resolution** (shared by pageload enrichment, nav start, and resolve): call
+  `router.matchRoutes(toLocation.pathname, toLocation.search, { preload: false, throwOnError: false })`
+  and take the last match. A match list containing only `__root__` means nothing matched — treat it as no
+  match. Name from the match's `fullPath`, falling back to `routeId`, else keep the URL name with
+  `source: 'url'` (pathless/layout routes can yield an empty `fullPath` — research §8.2, TanStack issue
+  #4892). Resolving via `matchRoutes` instead of reading `router.state.matches` works at any point in the
+  lifecycle (no dependency on when router state commits) and matches Sentry.
+- **Initial pageload**: at registration, resolve the current location through `matchRoutes` and call
+  `setActiveRouteName` against the already-running pageload root immediately; subscribe once to
+  `onResolved` to correct the name if a loader redirect changed the route, then drop that listener. The
+  `fromLocation === undefined` initial-load signal is confirmed by TanStack's docs ("fromLocation can be
+  undefined on the initial load") and by Sentry's source (it uses exactly `!fromLocation` to skip the
+  initial load in its navigation subscriber).
 - Returns a cleanup that unsubscribes from the router and calls `NavigationSource.unregister()`
-  (restoring default History detection). Safe to call zero or multiple times.
+  (restoring default History detection; token-guarded, see the seam). Safe to call zero or multiple
+  times.
 - **No-ops safely when tracing is disabled**, and is order-independent relative to
   `configure({ enableTracing: true })`.
 - The integration is actually React-agnostic (it only touches the TanStack router core); it ships from
   `@flareapp/react/tanstack-router` for discoverability. If Vue+TanStack is wanted later, extract; not now.
 
 Dependencies: `@tanstack/react-router` (v1) becomes an **optional** peer dep scoped to this entry via
-`peerDependenciesMeta`, so the main `@flareapp/react` entry is unaffected and apps not using TanStack
-pay nothing. `@flareapp/js` is already a peer dependency of `@flareapp/react`.
+`peerDependenciesMeta`, so the main `@flareapp/react` entry is unaffected and apps not using TanStack pay
+nothing. The supported range needs a floor, not just "v1": Sentry pins `>=1.64.0`; pin ours during
+implementation after checking the APIs we touch (`subscribe` payload flags, the `matchRoutes` signature)
+against that floor. Sentry avoids even a type-level dependency by vendoring structural types for the
+router; do the same if the optional peer dep creates type-checking friction for non-TanStack consumers.
+`@flareapp/js` is already a peer dependency of `@flareapp/react`.
 
 ### 3. React playground wiring + e2e (`playgrounds/react`, `e2e/`)
 
@@ -157,20 +212,24 @@ pay nothing. `@flareapp/js` is already a peer dependency of `@flareapp/react`.
 
 - **Pageload**: `configure({ enableTracing: true })` starts the backdated `browser_pageload` root
   URL-named (`source: url`); the integration renames it to the parameterized initial route
-  (`source: route`) on the router's first resolve, while it is still open. Fetch/XHR spans nest under it
-  unchanged.
-- **Navigation**: each route change → the integration opens one `browser_navigation` root (URL-named on
-  nav start, correct timing) and upgrades its name to the parameterized route (`source: route`) on
-  resolve; the idle controller closes it as today. History-based detection is suppressed, so exactly one
-  root per navigation.
-- **No integration registered**: unchanged from the roots slice (URL-named roots, `source: url`).
+  (`source: route`) immediately at registration, with a one-shot correction on the router's first
+  `onResolved` if a loader redirect changed the route, while it is still open. Fetch/XHR spans nest under
+  it unchanged.
+- **Navigation**: each qualifying `onBeforeLoad` (not skipped by the initial-load / no-op-reload gate) →
+  the integration opens one `browser_navigation` root (named from the event's destination path, correct
+  timing) and upgrades its name to the parameterized route (`source: route`); redirect hops rename the
+  same in-flight root; `onResolved` finalizes; the idle controller closes it as today. History-based
+  detection is suppressed, so exactly one root per navigation.
+- **No integration registered**: unchanged from the roots slice (URL-named roots), except roots now carry
+  `flare.route.source: 'url'` explicitly (see the seam section).
 
 ## Route name & attributes
 
 - The root span **name** is the parameterized route template as the router emits it (native `$id`
   syntax), or the raw URL path when no template is resolvable.
 - A **source flag** attribute distinguishes the two: proposed key `flare.route.source` with values
-  `route | url`. Both the key and the broader browser-perf attribute contract are **provisional** —
+  `route | url`, set on every browser root at open (`url`) and flipped to `route` by
+  `setActiveRouteName`. Both the key and the broader browser-perf attribute contract are **provisional** —
   the research doc lists the attribute contract as a backend decision still gated on B5/B9/P4. The raw
   page URL remains available via the roots' existing `collectBrowserSpanContext`, so the backend can show
   the concrete URL alongside the template.
@@ -185,37 +244,51 @@ Instrumentation must never break the host app or its router:
 - Seam operations no-op when there is no active tracing session or no active root; `setActiveRouteName`
   no-ops if the active root already closed (e.g. a slow initial load past the idle timeout), leaving the
   URL name rather than throwing.
-- Route-name reads are guarded: empty `fullPath` / pathless routes fall back (`routeId` → keep URL name),
-  and `router.state` shape reads are defensive against router version drift.
-- Registration is idempotent; the returned cleanup is safe to call zero or multiple times.
+- Route-name reads are guarded: `matchRoutes` is called with `throwOnError: false` inside a try/catch,
+  `__root__`-only match lists and empty `fullPath` / pathless routes fall back (`routeId` → keep URL
+  name), and router shape reads are defensive against version drift.
+- Registration is last-wins with token-guarded handles (see the seam); the returned cleanup is safe to
+  call zero or multiple times.
 
 ## Testing (unit + e2e)
 
 - **Unit — js seam** (`packages/js/tests`, alongside `browserTracing.test.ts`): registering a nav source
-  suppresses History navigation detection; `startNavigation()` opens a URL-named `browser_navigation`
-  root and ends the prior one; `setActiveRouteName` renames the open active root (pageload or navigation)
-  and sets its source, and no-ops once it has ended; `unregister` restores default History detection; all
-  operations no-op with no active session.
+  suppresses History navigation detection; `startNavigation({ path })` opens a `browser_navigation` root
+  named after the given path (falling back to `location.pathname`) and ends the prior one;
+  `setActiveRouteName` renames the open active root (pageload or navigation) and flips its source
+  attribute, and no-ops once it has ended; roots carry `flare.route.source: 'url'` at open with or
+  without a registered source; a second registration replaces the first and a stale handle's `unregister`
+  is a no-op (token guard); `unregister` restores default History detection with a resynced `lastPath`;
+  all operations no-op with no active session.
 - **Unit — TanStack integration** (`packages/react/tests`): with a minimal fake router (exposing
-  `subscribe` + `state.matches`), assert `onBeforeNavigate` → `startNavigation()` then `onResolved` →
-  `setActiveRouteName` with the parameterized name + `source: 'route'`; the initial pageload path
-  (`setActiveRouteName` on the pageload root); empty-`fullPath` fallback to `routeId` / URL; cleanup
-  unsubscribes and unregisters. No React render needed (router-only).
+  `subscribe` + `matchRoutes`), assert `onBeforeLoad` → `startNavigation({ path })` then `onResolved` →
+  `setActiveRouteName` with the parameterized name + `source: 'route'`; the skip gate (initial load via
+  `fromLocation === undefined`; no-op reload via identical `state`); a redirect chain (two
+  `onBeforeLoad`, one `onResolved`) produces exactly one root, renamed per hop; the initial pageload path
+  (immediate `setActiveRouteName` at registration + one-shot `onResolved` correction); `__root__`-only
+  and empty-`fullPath` fallbacks (`routeId` / URL); cleanup unsubscribes and unregisters. No React render
+  needed (router-only).
 - **E2e** (`playgrounds/react` + Playwright `react` project): the navigation/pageload assertions above
   against the fake-flare-server.
 
 The existing pageload/navigation roots unit + e2e coverage must stay green (default URL-named behavior is
-unchanged when no integration registers).
+unchanged when no integration registers, modulo the one deliberate addition of the always-present
+`flare.route.source` attribute, which those tests gain an assertion for).
 
 ## Items to verify during implementation
 
-- **TanStack initial-pageload signal.** The candidate `fromLocation === undefined` on the first event is
-  not source-verified (research §8.2, open question #2). Confirm against the router's actual event
-  payload; if unreliable, gate the initial `setActiveRouteName` on a "first event seen" latch instead.
-- **Exact TanStack events.** Start the nav root on the navigation-start event (`onBeforeNavigate`) and set
-  the name on `onResolved` (the design decouples these, so matches need not be populated at start).
-  Confirm both events fire for every navigation and that `router.state.matches[last].fullPath` is
-  populated at `onResolved`.
+- **Resolved 2026-07-07 (review):** the initial-pageload signal `fromLocation === undefined` is confirmed
+  by TanStack's docs and Sentry's source — no latch fallback needed (a "first event seen" latch would
+  also misclassify the first real navigation whenever registration happens after the initial load
+  resolved). The events question is likewise answered: `onBeforeNavigate` does NOT fire for every
+  navigation (suppressed after loader redirects, TanStack/router#3920); the design uses `onBeforeLoad` +
+  `onResolved` instead.
+- **Minimum `@tanstack/react-router` version.** Pin the peer-dep floor after checking the `subscribe`
+  payload flags and the `matchRoutes` signature against it (Sentry pins `>=1.64.0`).
+- **No-op-reload gate form.** The spec adopts Sentry's state-identity check
+  (`toLocation.state === fromLocation.state`); the event payload's `hrefChanged` flag is a plausible
+  alternative. Validate the chosen gate against a real router (`invalidate()`, same-URL re-push,
+  hash-only navigation) in the integration unit tests.
 - **Seam function names** (`registerNavigationSource` / `startNavigation` / `setActiveRouteName`) are
   provisional; finalize in the plan.
 - **`flare.route.source` attribute key** is provisional pending the backend attribute contract.
@@ -227,6 +300,8 @@ unchanged when no integration registers).
 - **SvelteKit server↔client correlation** (inbound `traceparent` in `handle`, SSR trace `<meta>` tags,
   client-side continuation) — net-new on both ends; its own slice (research §8.4).
 - **Param-syntax canonicalization** across frameworks — deferred to the backend-contract work.
+- **Route params as span attributes** (Sentry records `url.path.parameter.<name>` per match) — feeds the
+  same backend attribute-contract discussion; not in this slice.
 - **Multi-instance tracing ownership** (the deferred XHR-round Finding 5) — unrelated, still pending.
 - **Backend taxonomy/attribute contract** for route names (B5/B9/P4) — the `flare.route.source` key and
   the parameterized-name semantics need backend agreement before real-product correlation.

--- a/docs/superpowers/specs/2026-07-10-react-component-profiler-design.md
+++ b/docs/superpowers/specs/2026-07-10-react-component-profiler-design.md
@@ -1,0 +1,302 @@
+# React Component Profiler — Design
+
+Status: revised post-review — ready for planning
+Date: 2026-07-10 (revised 2026-07-10 after design review)
+Branch: `feat/react-component-profiler` (off `research/tracing-framework-routers`, tip `10d91ce`)
+Supersedes: the uncommitted POC (`packages/react/src/profiler.ts` + playground wiring), which is a reference only.
+
+Revision (2026-07-10, post-review): closed three timing/sampling gaps found in review. (1) `recordComponentSpan`
+now gates on the live root (`tracer.getActiveSpan()` still matching the reserved `traceId`) and drops the span
+otherwise, so a late / racing / post-idle mount can never seed a fresh `TraceState` and re-sample — the
+no-re-sample invariant now holds by construction. (2) A `hasRecorded` ref guards the mount effect so StrictMode's
+replayed setup cannot buffer a duplicate `spanId`; dev and production both emit one span (the earlier "two spans in
+dev" note is dropped). (3) Suspense is a documented v1 limitation, not engineered around.
+
+## Goal
+
+Give `@flareapp/react` users an opt-in profiler so that each wrapped component records one
+`browser_react_component` span for its mount, nested as a true tree (by `parent_span_id`) under the active
+`browser_pageload` / `browser_navigation` root. The result is a per-navigation mount waterfall of the component
+subtree:
+
+```
+browser_navigation  /product/$id  (312ms)
+ └─ ProductPage            (240ms)
+     ├─ ProductGallery     (180ms)
+     ├─ ProductInfo         (32ms)
+     └─ AddToCartButton     (12ms)
+```
+
+This is the client half only. The flareapp.io backend must officially recognize the `browser_react_component`
+SpanType (map, label, render the component name). That is a hard dependency tracked separately (see
+[Backend dependency](#backend-dependency)); today it exists only as a local uncommitted tweak.
+
+## Scope decisions (locked during brainstorm)
+
+- **What we capture:** mount timing only. Re-render / update / render-lifetime spans (Sentry's `ui.react.update`
+  and `ui.react.render`) are the natural next slice and are out of scope for v1.
+- **How components are instrumented:** manual opt-in. No build-time / Babel plugin. Users wrap the components
+  they care about.
+- **API surface:** a `<FlareProfiler name>` component (the primitive) and a `withFlareProfiler(Component, { name? })`
+  HOC (thin sugar). No `useFlareProfiler` hook in v1.
+- **Nesting:** a true component tree via `parent_span_id`. This deliberately exceeds Sentry, which keeps mount
+  spans flat under the transaction. It is required here because Flare's trace waterfall nests structurally by
+  `parent_span_id` (`resources/js/domain/perf-monitoring/components/sp-agg-traces/helpers.ts`), so a flat model
+  would render as a flat list, not a tree.
+- **Backend:** client-only branch; backend SpanType support is a tracked dependency.
+
+## Why not just copy Sentry
+
+Validated against `getsentry/sentry-javascript` `packages/react/src/profiler.tsx` (verbatim source):
+
+- Sentry's `render()` returns `this.props.children` directly, with no `withActiveSpan` wrap, and creates the mount
+  span in the **constructor** via `startInactiveSpan({ op: 'ui.react.mount', onlyIfParent: true })`. That parents
+  every mount span to whatever is active at render time — always the transaction. So Sentry's component spans are
+  **flat siblings under the transaction**, nested only by time, not structurally. We diverge here on purpose.
+- Sentry has **no StrictMode handling**; its constructor-created span leaks for the discarded StrictMode instance.
+  That is harmless for Sentry because a transaction drops unfinished child spans on close. Flare cannot copy this:
+  `IdleRootController` blocks idle-close on open children, which is exactly the POC's 15006ms `childSpanTimeout`
+  bug. Our record-in-effect model (start and end together) is therefore mandatory, not a nicety.
+- We do adopt Sentry's proven choices: name resolution (`name || displayName || name || Unknown`), root-gating
+  (Sentry's `onlyIfParent`), and mount-first scope with updates as a follow-up.
+
+## Architecture
+
+Three pieces, with the tracer coupling isolated to a single seam module.
+
+### 1. Core: one new field (`packages/core`)
+
+`SpanOptions` gains `spanId?: string`. `Tracer.startSpan` uses `opts.spanId ?? makeSpanId()`. `parent`
+(already accepts `{ traceId, spanId }`), `startTimeUnixNano`, and `.end(endTime)` already exist, so this single
+field is the entire core cost. It is a general manual-stitching primitive, not profiler-specific.
+
+Current shape (`packages/core/src/types.ts`):
+
+```ts
+export type SpanOptions = {
+    parent?: Span | { traceId: string; spanId: string };
+    attributes?: Attributes;
+    startTimeUnixNano?: number;
+    spanType?: string;
+    forceRoot?: boolean;
+    spanId?: string; // NEW: explicit span id for manual stitching
+};
+```
+
+### 2. `@flareapp/js/browser` seam (`packages/js/src/tracing/componentProfiler.ts`)
+
+A side-effect-free module (imported like `registerNavigationSource`) that hides all tracer coupling behind three
+functions bound to the singleton browser tracer:
+
+```ts
+export type ComponentTraceContext = { traceId: string; parentSpanId: string };
+
+// The active pageload/navigation root a top-level component should nest under, read
+// from `tracer.getActiveSpan()` (the holder's active root, which IdleRootController
+// clears on close). Returns null when tracing is off, no root is active, or the root
+// is not recording.
+export function activeComponentRoot(): ComponentTraceContext | null;
+
+// A 16-hex span id a component reserves for itself, so its descendants can reference
+// it as their parent before this component's span is actually recorded.
+export function reserveSpanId(): string;
+
+// Record a completed mount span (spanType 'browser_react_component'). Records ONLY
+// while the reserved root is still the live, recording active root (its traceId still
+// matches `tracer.getActiveSpan()`); otherwise it DROPS the span. That is what makes
+// the "reuse the root's decision, never re-sample per component" guarantee hold: it
+// either records under the live root (whose TraceState still exists, so the decision
+// is reused) or records nothing. No-op when tracing is off.
+export function recordComponentSpan(span: {
+    name: string;
+    spanId: string;
+    parent: ComponentTraceContext;
+    startTimeUnixNano: number;
+    endTimeUnixNano: number;
+    attributes?: Record<string, unknown>;
+}): void;
+```
+
+`recordComponentSpan` first gates on the live root: `const root = tracer.getActiveSpan(); if (!root || root.traceId
+!== parent.traceId || !root.isRecording) return;`. `getActiveSpan()` returns the holder's active root, which
+`IdleRootController.finish` clears to `undefined` on close, so a matching `traceId` proves the reserved root is still
+open (unlike the module-global `currentRoot`, which is not nulled on idle-close). Exposing it means widening the
+`BrowserTracingFlare.tracer` `Pick` to include `getActiveSpan` (the runtime object is a full `Tracer`).
+
+When the gate passes, the root's `TraceState` is still in `traceStates`, so `tracer.startSpan(name, { spanId,
+parent: { traceId, spanId: parentSpanId }, spanType: 'browser_react_component', startTimeUnixNano, attributes
+}).end(endTimeUnixNano)` reuses that state and its recording decision — the plain `{ traceId, spanId }` parent path
+in `resolveTrace` finds existing state and does not re-sample.
+
+When the gate fails — the root idle-closed during a mount gap, or a later navigation replaced it — the span is
+dropped. This is deliberate: without the gate, `startSpan` would find no `TraceState` for the dead trace, seed a
+fresh one, and re-sample it independently via `resolveSampling`, producing a re-sampled, root-detached phantom child
+of an already-shipped root. Dropping keeps the per-component no-re-sample invariant true by construction.
+
+The common case is not dropped: each recorded component span is a start+end pair, and `IdleRootController` re-arms
+the root's idle timer every time a child span ends, so a continuously-mounting subtree keeps its own root alive.
+Only a mount gap longer than `idleTimeout` (typically a Suspense data wait) or a subsequent navigation trips the
+drop path.
+
+### 3. `@flareapp/react/profiler` (`packages/react/src/profiler.ts`)
+
+`createElement`-based (no JSX), importing only `react` and `@flareapp/js/browser` — Electron-safe, matching
+`tanstack-router.ts`.
+
+- `FlareProfilerContext`: a React context carrying `ComponentTraceContext | null`.
+- `<FlareProfiler name>` (function component):
+    - Resolves its parent once into a ref: `resolvedParent = context ?? activeComponentRoot()`, where `context` is
+      the value of `FlareProfilerContext`. A non-null context means a profiled ancestor exists; a null context at
+      the top of a profiled subtree falls back to the active root.
+    - **If `resolvedParent` is null** (no profiled ancestor and no active recording root), the component is fully
+      transparent: it reserves nothing, records nothing, and passes the null context through unchanged so its
+      descendants also no-op. It still renders its children.
+    - **Otherwise** it reserves its own `spanId` (`reserveSpanId()`) and captures `startNano` at first render (both
+      in lazy refs), provides `{ traceId: resolvedParent.traceId, parentSpanId: ownSpanId }` to children, and in a
+      mount `useLayoutEffect` (falling back to `useEffect` under SSR, to match `componentDidMount` timing while
+      preserving bottom-up ordering) records its span exactly once — a `hasRecorded` ref guards the effect body so
+      StrictMode's replayed setup does not buffer a second span under the same reserved id (see
+      [StrictMode](#strictmode-and-leak-safety)) — calling `recordComponentSpan(...)` with `resolvedParent`, its
+      reserved id, `startNano`, and the current time as end.
+- `withFlareProfiler(Component, { name? })`: renders `<FlareProfiler name={resolvedName}>` around `Component`.
+
+## Timing and nesting model (the crux)
+
+- `startNano` is captured at first render (the component begins mounting). `endNano` is captured in the mount
+  effect (the subtree has mounted).
+- React renders top-down (a parent's `startNano` precedes its children's) and fires mount effects bottom-up (a
+  child's `endNano` precedes its parent's). Within a single synchronous commit a parent `[start, end]` therefore
+  encloses every child both by time and by `parent_span_id`, and the waterfall nests correctly. This holds only
+  within a synchronous commit; a `<Suspense>` boundary inside the subtree can break enclosure (see
+  [Suspense](#suspense)).
+- Reserved ids solve the ordering trap: a child records in its own effect _before_ its parent's effect runs, but
+  it already knows the parent's reserved id from render-time context, so the structural link is available even
+  though the parent's span object does not exist yet.
+- Unprofiled intermediate components are transparent: the context passes through unchanged, so a child nests
+  under the nearest _profiled_ ancestor.
+- Orphan degradation: if a profiled ancestor's span is dropped (sampling or `maxSpansPerTrace`), its descendants'
+  `parent_span_id` points at a missing span. Flare's tree builder treats that as an orphan and reparents it to the
+  root (`sp-agg-traces/helpers.ts:74`). Acceptable; covered by a test. Because effects fire bottom-up, an ancestor
+  is recorded after its descendants and so is the more likely victim of a `maxSpansPerTrace` cap; orphaning is the
+  designed-for degradation, not a rare edge.
+- Late-mount drop: a component records only while its reserved root is still the live active root (the seam's
+  live-root gate). A subtree that finishes mounting after the root idle-closed, or whose root a later navigation
+  replaced, records nothing rather than re-sampling and attaching to a dead trace.
+
+## Suspense
+
+`<Suspense>` inside a profiled subtree is a documented v1 limitation, not engineered around. There is no
+Suspense-specific code: the live-root gate already covers the one case that needs handling (a child that resumes
+after its root closed is dropped, not re-sampled). Two behaviors to note in the docs so they are not read as bugs:
+
+- A suspended child's `startNano` is captured before it suspends, so its span covers the suspense wait. Read the
+  duration as "time to mount, including data waits in the subtree."
+- A `<Suspense>` boundary between a profiled parent and child can end the parent span before the child resumes, so
+  the child may render outside its parent in the waterfall, or (if the wait exceeds `idleTimeout`) be dropped.
+
+## StrictMode and leak-safety
+
+Start and end are recorded together in the mount effect, so only committed fibers ever touch the tracer. There is
+no open-span leak. This is mandatory: `IdleRootController` blocks idle-close on open children (the POC's 15006ms
+`childSpanTimeout`), unlike Sentry's transaction which drops unfinished spans.
+
+Record-once guard: under React `<StrictMode>` in development React runs the mount effect twice on the same fiber
+(setup → cleanup → setup) to surface effect bugs. The reserved `spanId` and `startNano` live in refs that persist
+across that replay, so an unguarded effect would buffer the span **twice with the same `spanId`** — a span-id
+collision in the trace, not two distinct spans. A `hasRecorded` ref makes the effect record exactly once per
+committed fiber: the first setup records and sets the flag; the replayed setup no-ops. A genuine unmount/remount is
+a new fiber with a fresh ref and correctly records a new span. Dev and production both emit one span per mount, so
+there is no duplicate dev behavior to document.
+
+## Config, gating, overhead
+
+- Gated on `enableTracing` and an active, recording root: `activeComponentRoot()` returns null otherwise and the
+  component records nothing.
+- Follows the root's sampling decision, never re-sampling per component: a component span is either recorded under
+  the live root (reusing its `TraceState` and decision) or dropped (the seam's live-root gate; see [Timing and
+  nesting model](#timing-and-nesting-model-the-crux)). No code path samples a component independently.
+- No separate `enableReactProfiler` flag or profiler-specific sample rate in v1 (YAGNI). Wrapping a component is
+  the opt-in.
+- Cost when not recording: one context read plus a null check per profiled component; no span work.
+
+## Naming
+
+Resolution order: explicit `name` prop / `options.name` > `Component.displayName` > `Component.name` > `'Unknown'`
+(matches Sentry and the POC). Written to the attribute `flare.react.component` and to `span.name`. The backend
+label falls back to `span.name`, so the component name surfaces even without the attribute.
+
+Production minification can mangle `Component.name`. The docs recommend passing an explicit `name` or setting
+`displayName` for production builds. Build-plugin auto-naming is out of scope.
+
+## Error handling
+
+Every seam call and every effect body is wrapped so instrumentation never throws into the host application (the
+`tanstack-router` discipline). The seam functions additionally no-op internally when tracing is off or no root is
+active.
+
+## Testing
+
+- `packages/react/tests/profiler.test.tsx` (vitest + @testing-library/react + jsdom; already devDependencies):
+    - single component records one span with the correct name, `browser_react_component` type, parent equal to the
+      active root, and a non-negative duration;
+    - nested components: a child's `parent_span_id` equals its parent's reserved span id;
+    - a transparent (unprofiled) middle component: a grandchild nests under the nearest profiled ancestor;
+    - no active root: nothing recorded, children still render;
+    - tracing disabled: nothing recorded;
+    - name precedence (explicit > displayName > name);
+    - never throws when the seam throws (inject a throwing seam);
+    - StrictMode: the record-once guard emits exactly one span per mount in development (not two) with no duplicate
+      `spanId`;
+    - orphan: a child whose profiled parent's span is absent still records with a `parent_span_id` (graceful);
+    - late mount: a component whose reserved root has already ended when its mount effect runs records nothing (no
+      re-sample, no root-detached span);
+    - Suspense boundary: a suspended child records under its profiled ancestor when it resumes within the root
+      window (documents the timing behavior).
+- `packages/js/tests/componentProfiler.test.ts`:
+    - `activeComponentRoot()` returns the root context when a recording root is active; null when tracing is off,
+      no root is active, or the root is not recording;
+    - `recordComponentSpan(...)` buffers a `browser_react_component` span with the right ids, parent, and times, and
+      follows the root's recording decision (no re-sample);
+    - `recordComponentSpan(...)` drops the span (nothing buffered, no re-sample) when `tracer.getActiveSpan()` no
+      longer matches the parent's `traceId` — the root idle-closed or a new navigation root took over.
+- `packages/core`: `startSpan` honors an explicit `spanId`.
+- Playground: wire a handful of components in `playgrounds/react` (for example ProductsPage, ProductPage,
+  ProductGallery, AddToCartButton) to exercise the tree for manual and e2e runs. The local-only `flare.ts` test
+  tweaks (pointing at `flareapp.io.test`) stay out of commits.
+- e2e: one `react` spec asserting that component spans arrive nested under the navigation root via the fake
+  server. This is the largest-effort item; it is included but may be deferred if the plan grows too long.
+
+## File structure
+
+- `packages/core/src/types.ts` — add `spanId?` to `SpanOptions`.
+- `packages/core/src/tracing/Tracer.ts` — `opts.spanId ?? makeSpanId()`.
+- `packages/core/tests/…` — explicit-`spanId` test.
+- `packages/js/src/tracing/componentProfiler.ts` — the seam (new).
+- `packages/js/src/tracing/browserTracing.ts` — widen the `BrowserTracingFlare.tracer` `Pick` to expose
+  `getActiveSpan` for the seam's live-root gate.
+- `packages/js/src/browser.ts` — export the seam.
+- `packages/js/tests/componentProfiler.test.ts` — seam tests (new).
+- `packages/react/src/profiler.ts` — `FlareProfiler` + `withFlareProfiler` + context (rewrites the POC file).
+- `packages/react/tests/profiler.test.tsx` — component tests (new).
+- `packages/react/package.json` — `./profiler` export and build entry are already wired.
+- `playgrounds/react/*` — wiring.
+- README section for `@flareapp/react/profiler`.
+
+## Backend dependency
+
+Handled separately in flareapp.io, not in this branch:
+
+- add a `browser_react_component` case to the monitoring `SpanType` enum;
+- map/label it and render the component name in the trace waterfall (the current local tweak, done properly).
+
+Until this lands, component spans store as `unknown` for other users. The feature is not end-to-end without it.
+
+## Out of scope (v1)
+
+- Automatic build-plugin (Babel/SWC) instrumentation.
+- Update / re-render / render-lifetime spans (Sentry's `ui.react.update` / `ui.react.render`) — the clean next
+  slice.
+- `useFlareProfiler` hook.
+- Per-component enable flag.
+- Suspense-boundary-aware timing. v1 documents the distortion (see [Suspense](#suspense)) instead of resetting or
+  clamping spans across boundaries.

--- a/e2e/specs/react.spec.ts
+++ b/e2e/specs/react.spec.ts
@@ -3,6 +3,24 @@ import { expect, test } from '../fixtures/fake-flare';
 import { logScenariosFor, runLogScenario } from './logShared';
 import { runScenario, scenariosFor } from './shared';
 
+type OtlpSpan = {
+    name: string;
+    spanId: string;
+    parentSpanId: string | null;
+    traceId: string;
+    attributes: Array<{ key: string; value: Record<string, unknown> }>;
+};
+
+const spansOf = (bodyJson: unknown): OtlpSpan[] =>
+    ((bodyJson as { resourceSpans?: Array<{ scopeSpans?: Array<{ spans?: OtlpSpan[] }> }> }).resourceSpans ?? [])
+        .flatMap((r) => r.scopeSpans ?? [])
+        .flatMap((s) => s.spans ?? []);
+
+const attr = (span: OtlpSpan, key: string): unknown => span.attributes.find((a) => a.key === key)?.value;
+
+const hasSpanType = (span: OtlpSpan, type: string): boolean =>
+    JSON.stringify(attr(span, 'flare.span_type') ?? '').includes(type);
+
 test.describe('react playground', () => {
     test('renders product grid', async ({ page }) => {
         await page.goto('/');
@@ -27,6 +45,55 @@ test.describe('react playground', () => {
                 await runScenario(page, fakeFlare, scenario);
             });
         }
+    });
+
+    test('pageload root carries the parameterized route and route source', async ({ page, fakeFlare }) => {
+        await page.goto('/product/p01'); // deep-link the initial load
+        await page.waitForLoadState('networkidle');
+
+        const trace = await fakeFlare.waitForTrace({
+            timeout: 9000,
+            predicate: (r) => {
+                const pl = spansOf(r.bodyJson).find((s) => hasSpanType(s, 'browser_pageload'));
+                return !!pl && JSON.stringify(attr(pl, 'flare.route.source') ?? '').includes('route');
+            },
+        });
+        const pageload = spansOf(trace.bodyJson).find((s) => hasSpanType(s, 'browser_pageload'));
+        expect(pageload && attr(pageload, 'flare.entry_point.handler.identifier')).toEqual({
+            stringValue: '/product/$id',
+        });
+        expect(pageload && attr(pageload, 'flare.route.source')).toEqual({ stringValue: 'route' });
+    });
+
+    test('navigation root carries the parameterized route (not the concrete path)', async ({ page, fakeFlare }) => {
+        await page.goto('/');
+        await page.waitForLoadState('networkidle');
+
+        await page.locator('a[href="/product/p01"]').first().click(); // client nav to the parameterized route
+
+        const trace = await fakeFlare.waitForTrace({
+            timeout: 9000,
+            predicate: (r) => {
+                const nav = spansOf(r.bodyJson).find((s) => hasSpanType(s, 'browser_navigation'));
+                return (
+                    !!nav &&
+                    JSON.stringify(attr(nav, 'flare.entry_point.handler.identifier') ?? '').includes('/product/$id')
+                );
+            },
+        });
+        const nav = spansOf(trace.bodyJson).find((s) => hasSpanType(s, 'browser_navigation'));
+        expect(nav && attr(nav, 'flare.entry_point.handler.identifier')).toEqual({ stringValue: '/product/$id' });
+        expect(nav && attr(nav, 'flare.route.source')).toEqual({ stringValue: 'route' });
+
+        // The no-double-roots invariant: History detection must stay suppressed while the
+        // integration is registered, so this one click produced exactly ONE browser_navigation
+        // root across ALL captured traces. (If suppression broke, the History patch's duplicate
+        // URL-named root opens and ends BEFORE the integration's parameterized one, so by the
+        // time waitForTrace matched above, the duplicate would already have arrived.)
+        const navSpans = (await fakeFlare.traces())
+            .flatMap((t) => spansOf(t.bodyJson))
+            .filter((s) => hasSpanType(s, 'browser_navigation'));
+        expect(navSpans).toHaveLength(1);
     });
 });
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -62,6 +62,7 @@ export {
     buildTracesEnvelope,
     buildTraceparent,
     parseTraceparent,
+    spanId,
 } from './tracing';
 export type { TracerDeps, ActiveSpanHolder } from './tracing';
 

--- a/packages/core/src/tracing/Tracer.ts
+++ b/packages/core/src/tracing/Tracer.ts
@@ -159,7 +159,7 @@ export class Tracer {
 
     startSpan(name: string, opts: SpanOptions = {}): Span {
         const config = this.deps.getConfig();
-        const spanId = makeSpanId();
+        const spanId = opts.spanId ?? makeSpanId();
 
         // The pending continuation (continueFromTraceparent) is a strict one-shot for
         // the NEXT startSpan, whatever that span turns out to be: consumed by a

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -196,6 +196,8 @@ export type SpanOptions = {
      * root opened inside `withSpan(...)` does not become a mid-trace child.
      */
     forceRoot?: boolean;
+    /** Use this exact span id instead of generating one (manual span stitching). */
+    spanId?: string;
 };
 
 export interface Span {

--- a/packages/core/tests/tracer.test.ts
+++ b/packages/core/tests/tracer.test.ts
@@ -261,6 +261,15 @@ describe('Tracer.startSpan', () => {
         });
         expect(child?.traceId).toBe(outerTraceId); // contrast: default nests
     });
+
+    it('uses an explicit spanId from opts instead of generating one', () => {
+        const tracer = makeTracer(config());
+        const root = tracer.startSpan('root');
+        const child = tracer.startSpan('child', { parent: root, spanId: 'abc1230000000000' });
+        expect(child.spanId).toBe('abc1230000000000');
+        expect(child.parentSpanId).toBe(root.spanId);
+        expect(child.traceId).toBe(root.traceId);
+    });
 });
 
 describe('defaultNowNano', () => {

--- a/packages/js/src/browser.ts
+++ b/packages/js/src/browser.ts
@@ -56,3 +56,11 @@ export { collectBrowser } from './browser/context/collectBrowser';
 export { FetchFileReader } from './browser/FetchFileReader';
 export { BrowserFlushScheduler } from './browser/BrowserFlushScheduler';
 export { registerNavigationSource, type NavigationSource, type RouteName } from './tracing/browserTracing';
+export {
+    activeComponentRoot,
+    reserveSpanId,
+    recordComponentSpan,
+    nowNano,
+    type ComponentTraceContext,
+} from './tracing/componentProfiler';
+export { BrowserSpanType } from './tracing/spanTypes';

--- a/packages/js/src/browser.ts
+++ b/packages/js/src/browser.ts
@@ -55,3 +55,4 @@ export { catchWindowErrors } from './browser/catchWindowErrors';
 export { collectBrowser } from './browser/context/collectBrowser';
 export { FetchFileReader } from './browser/FetchFileReader';
 export { BrowserFlushScheduler } from './browser/BrowserFlushScheduler';
+export { registerNavigationSource, type NavigationSource, type RouteName } from './tracing/browserTracing';

--- a/packages/js/src/tracing/IdleRootController.ts
+++ b/packages/js/src/tracing/IdleRootController.ts
@@ -14,6 +14,12 @@ export type IdleRootDeps = {
     setTimeout: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>;
     clearTimeout: (handle: ReturnType<typeof setTimeout>) => void;
     rootStartTime: number; // unix nanos, base for finalTimeout
+    // Floor for a trimmed close: when a root closes with no in-flight children its
+    // end is this floor (read lazily), never `now()`. Navigation passes its start
+    // time (an instant nav trims to ~0); pageload passes the Navigation Timing
+    // load-event end so a childless pageload reports its real load duration instead
+    // of being padded by the whole idleTimeout window.
+    endFloor: () => number;
 };
 
 type Timer = ReturnType<typeof setTimeout> | null;
@@ -53,7 +59,10 @@ export class IdleRootController {
     }
 
     endNow(): void {
-        this.finish(this.deps.now());
+        // Force-ended (route change / pagehide). With no child in flight, trim to the
+        // floor instead of padding to the force-end moment; with an open child use
+        // now() so in-flight work is not cut short before it even started.
+        this.finish(this.openChildren > 0 ? this.deps.now() : this.trimmedEnd());
     }
 
     private onSpanEvent(phase: 'start' | 'end', span: Span): void {
@@ -85,8 +94,18 @@ export class IdleRootController {
         this.clearIdle();
         this.idleTimer = this.deps.setTimeout(() => {
             if (this.openChildren > 0) return;
-            this.finish(this.lastChildEndTime ?? this.deps.now());
+            this.finish(this.trimmedEnd());
         }, this.timeouts.idleTimeout);
+    }
+
+    /**
+     * End time for a trimmed close: the later of the injected floor and the last
+     * child's end, so a root never pads out to `now()`. With no children it is the
+     * floor itself (navigation start, or the pageload load-event end); with children
+     * it stretches to cover the last one.
+     */
+    private trimmedEnd(): number {
+        return Math.max(this.deps.endFloor(), this.lastChildEndTime ?? 0);
     }
 
     private clearIdle(): void {

--- a/packages/js/src/tracing/browserTracing.ts
+++ b/packages/js/src/tracing/browserTracing.ts
@@ -27,15 +27,19 @@ function resolveTimeouts(config: Config): IdleTimeouts {
     };
 }
 
-function startRoot(flare: BrowserTracingFlare, spanType: string, startTimeUnixNano: number): void {
-    const path = location.pathname;
+function startRoot(
+    flare: BrowserTracingFlare,
+    spanType: string,
+    startTimeUnixNano: number,
+    name: string = location.pathname,
+): void {
     let root: Span | undefined;
     try {
-        root = flare.startSpan(path, {
+        root = flare.startSpan(name, {
             spanType,
             startTimeUnixNano,
             forceRoot: true,
-            attributes: collectBrowserSpanContext(flare.config),
+            attributes: { ...collectBrowserSpanContext(flare.config), 'flare.route.source': 'url' },
         });
         controller = new IdleRootController(
             {
@@ -79,7 +83,7 @@ function onUrlChanged(flare: BrowserTracingFlare): void {
             // A failing prior-root teardown must not stop the new root from starting.
         }
     }
-    startRoot(flare, 'browser_navigation', defaultNowNano());
+    startRoot(flare, 'browser_navigation', defaultNowNano(), path);
 }
 
 /**

--- a/packages/js/src/tracing/browserTracing.ts
+++ b/packages/js/src/tracing/browserTracing.ts
@@ -4,12 +4,13 @@ import { collectBrowserSpanContext } from '../browser/context/collectBrowserSpan
 import { fill, unfill } from './fill';
 import { IdleRootController, type IdleTimeouts } from './IdleRootController';
 import { pageloadEndNano, pageloadStartNano, resolvePageloadStartNano } from './navigationTiming';
+import { BrowserSpanType } from './spanTypes';
 
 /** Structural subset of the js Flare this orchestrator needs. */
 export type BrowserTracingFlare = {
     readonly config: Config;
     startSpan(name: string, opts?: SpanOptions): Span;
-    tracer: Pick<Tracer, 'addSpanListener' | 'setActiveRoot' | 'flush'>;
+    tracer: Pick<Tracer, 'addSpanListener' | 'setActiveRoot' | 'flush' | 'getActiveSpan'>;
 };
 
 export type RouteName = { name: string; source: 'route' | 'url' };
@@ -40,7 +41,7 @@ function resolveTimeouts(config: Config): IdleTimeouts {
 
 function startRoot(
     flare: BrowserTracingFlare,
-    spanType: string,
+    spanType: BrowserSpanType,
     startTimeUnixNano: number,
     name: string = location.pathname,
 ): void {
@@ -63,7 +64,7 @@ function startRoot(
                 rootStartTime: startTimeUnixNano,
                 // Childless-close floor: a pageload ends at its real load-event mark,
                 // a navigation at its own start (an instant client nav trims to ~0).
-                endFloor: spanType === 'browser_pageload' ? pageloadEndNano : () => startTimeUnixNano,
+                endFloor: spanType === BrowserSpanType.Pageload ? pageloadEndNano : () => startTimeUnixNano,
             },
             resolveTimeouts(flare.config),
         );
@@ -100,7 +101,7 @@ function onUrlChanged(flare: BrowserTracingFlare): void {
             // A failing prior-root teardown must not stop the new root from starting.
         }
     }
-    startRoot(flare, 'browser_navigation', defaultNowNano(), path);
+    startRoot(flare, BrowserSpanType.Navigation, defaultNowNano(), path);
 }
 
 /**
@@ -124,7 +125,7 @@ export function startBrowserTracing(flare: BrowserTracingFlare): void {
         pageloadTraced,
     );
     pageloadTraced = true;
-    startRoot(flare, 'browser_pageload', pageloadStart);
+    startRoot(flare, BrowserSpanType.Pageload, pageloadStart);
 
     const handle = (): void => {
         // A third party may wrap history.pushState/replaceState on top of ours,
@@ -225,7 +226,7 @@ export function registerNavigationSource(): NavigationSource {
                     // a failing prior-root teardown must not stop the new root
                 }
             }
-            startRoot(activeFlare, 'browser_navigation', defaultNowNano(), path);
+            startRoot(activeFlare, BrowserSpanType.Navigation, defaultNowNano(), path);
         },
         setActiveRouteName(route) {
             if (!active()) return;
@@ -245,4 +246,12 @@ export function registerNavigationSource(): NavigationSource {
             lastPath = here();
         },
     };
+}
+
+/**
+ * Internal accessor for sibling tracing modules (the component-profiler seam) that
+ * need the live tracer. Returns the Flare currently driving browser tracing, or null.
+ */
+export function activeTracingFlare(): BrowserTracingFlare | null {
+    return activeFlare;
 }

--- a/packages/js/src/tracing/browserTracing.ts
+++ b/packages/js/src/tracing/browserTracing.ts
@@ -3,7 +3,7 @@ import { defaultNowNano, type Config, type Span, type SpanOptions, type Tracer }
 import { collectBrowserSpanContext } from '../browser/context/collectBrowserSpanContext';
 import { fill, unfill } from './fill';
 import { IdleRootController, type IdleTimeouts } from './IdleRootController';
-import { pageloadStartNano, resolvePageloadStartNano } from './navigationTiming';
+import { pageloadEndNano, pageloadStartNano, resolvePageloadStartNano } from './navigationTiming';
 
 /** Structural subset of the js Flare this orchestrator needs. */
 export type BrowserTracingFlare = {
@@ -61,6 +61,9 @@ function startRoot(
                 setTimeout: (fn, ms) => setTimeout(fn, ms),
                 clearTimeout: (handle) => clearTimeout(handle),
                 rootStartTime: startTimeUnixNano,
+                // Childless-close floor: a pageload ends at its real load-event mark,
+                // a navigation at its own start (an instant client nav trims to ~0).
+                endFloor: spanType === 'browser_pageload' ? pageloadEndNano : () => startTimeUnixNano,
             },
             resolveTimeouts(flare.config),
         );

--- a/packages/js/src/tracing/browserTracing.ts
+++ b/packages/js/src/tracing/browserTracing.ts
@@ -12,12 +12,23 @@ export type BrowserTracingFlare = {
     tracer: Pick<Tracer, 'addSpanListener' | 'setActiveRoot' | 'flush'>;
 };
 
+export type RouteName = { name: string; source: 'route' | 'url' };
+export type NavigationSource = {
+    startNavigation(opts?: { path?: string }): void;
+    setActiveRouteName(route: RouteName): void;
+    unregister(): void;
+};
+
 let controller: IdleRootController | null = null;
 let uninstall: (() => void) | null = null;
 let lastPath = '';
 // Page-global: a document's real pageload window can only be traced once. Guards
 // against re-enabling after a disable fabricating a second backdated pageload.
 let pageloadTraced = false;
+
+let navSource: object | null = null;
+let activeFlare: BrowserTracingFlare | null = null;
+let currentRoot: Span | null = null;
 
 function resolveTimeouts(config: Config): IdleTimeouts {
     return {
@@ -53,11 +64,13 @@ function startRoot(
             },
             resolveTimeouts(flare.config),
         );
+        currentRoot = root;
     } catch (error) {
         // Instrumentation must never break the app. If root creation or the idle
         // controller fails, undo any partial state (end the orphaned span, clear
         // the active root) and leave tracing inert rather than throwing.
         controller = null;
+        currentRoot = null;
         try {
             root?.end();
         } catch {
@@ -76,6 +89,7 @@ function onUrlChanged(flare: BrowserTracingFlare): void {
     const path = location.pathname;
     if (path === lastPath) return;
     lastPath = path;
+    if (navSource) return; // a framework integration drives navigation; keep lastPath current, open no root
     if (controller && !controller.isEnded) {
         try {
             controller.endNow();
@@ -96,6 +110,7 @@ export function startBrowserTracing(flare: BrowserTracingFlare): void {
     if (typeof window === 'undefined' || typeof history === 'undefined' || typeof location === 'undefined') return;
     if (uninstall) return;
 
+    activeFlare = flare;
     lastPath = location.pathname;
 
     const finalTimeoutNano = resolveTimeouts(flare.config).finalTimeout * 1e6;
@@ -175,5 +190,56 @@ export function stopBrowserTracing(): void {
         uninstall();
         uninstall = null;
     }
+    activeFlare = null;
+    currentRoot = null;
     lastPath = '';
+}
+
+/**
+ * Register the caller as the page's navigation source. While registered, the
+ * built-in History-based navigation detection opens no roots (it still keeps
+ * `lastPath` current); the caller drives navigation via the returned handle.
+ * Last-wins: a second registration replaces the first, and a stale handle's
+ * methods (including `unregister`) no-op — so an HMR-replaced bootstrap cannot
+ * tear down a newer registration.
+ */
+export function registerNavigationSource(): NavigationSource {
+    const token = {};
+    if (navSource && activeFlare?.config.debug) console.debug('Flare: navigation source replaced');
+    navSource = token;
+    const active = (): boolean => navSource === token;
+    const here = (): string => (typeof location !== 'undefined' ? location.pathname : '');
+
+    return {
+        startNavigation(opts) {
+            if (!active() || !activeFlare) return;
+            const path = opts?.path ?? here();
+            lastPath = path;
+            if (controller && !controller.isEnded) {
+                try {
+                    controller.endNow();
+                } catch {
+                    // a failing prior-root teardown must not stop the new root
+                }
+            }
+            startRoot(activeFlare, 'browser_navigation', defaultNowNano(), path);
+        },
+        setActiveRouteName(route) {
+            if (!active()) return;
+            if (currentRoot && controller && !controller.isEnded) {
+                try {
+                    currentRoot.name = route.name;
+                    currentRoot.setAttribute('flare.entry_point.handler.identifier', route.name);
+                    currentRoot.setAttribute('flare.route.source', route.source);
+                } catch {
+                    // instrumentation must never throw into the host app
+                }
+            }
+        },
+        unregister() {
+            if (!active()) return;
+            navSource = null;
+            lastPath = here();
+        },
+    };
 }

--- a/packages/js/src/tracing/componentProfiler.ts
+++ b/packages/js/src/tracing/componentProfiler.ts
@@ -1,0 +1,66 @@
+// Side-effect-free component-profiler seam for @flareapp/react/profiler. Hides all
+// tracer coupling behind four functions bound to the singleton browser tracer, the
+// same discipline as registerNavigationSource. Imported from '@flareapp/js/browser'.
+import { defaultNowNano, spanId as makeSpanId } from '@flareapp/core';
+
+import { activeTracingFlare } from './browserTracing';
+import { BrowserSpanType } from './spanTypes';
+
+export type ComponentTraceContext = { traceId: string; parentSpanId: string };
+
+/** Unix nanos on the same clock the tracer uses for span timestamps. */
+export const nowNano = defaultNowNano;
+
+/** Reserve a 16-hex span id a component uses as its own, so descendants can point at it. */
+export function reserveSpanId(): string {
+    return makeSpanId();
+}
+
+/**
+ * The active pageload/navigation root a top-level component should nest under, read
+ * from the holder's active root (which IdleRootController clears on close). Null when
+ * tracing is off, no root is active, or the root is not recording.
+ */
+export function activeComponentRoot(): ComponentTraceContext | null {
+    try {
+        const root = activeTracingFlare()?.tracer.getActiveSpan();
+        if (!root || !root.isRecording) return null;
+        return { traceId: root.traceId, parentSpanId: root.spanId };
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Record a completed mount span. Records ONLY while the reserved root is still the
+ * live, recording active root (its traceId still matches getActiveSpan()); otherwise
+ * it DROPS the span. Dropping avoids seeding a fresh TraceState for a dead trace
+ * (which would re-sample) and attaching a phantom child to an already-shipped root.
+ * No-op when tracing is off. Never throws into the host.
+ */
+export function recordComponentSpan(span: {
+    name: string;
+    spanId: string;
+    parent: ComponentTraceContext;
+    startTimeUnixNano: number;
+    endTimeUnixNano: number;
+    attributes?: Record<string, unknown>;
+}): void {
+    try {
+        const flare = activeTracingFlare();
+        if (!flare) return;
+        const root = flare.tracer.getActiveSpan();
+        if (!root || root.traceId !== span.parent.traceId || !root.isRecording) return;
+        flare
+            .startSpan(span.name, {
+                spanId: span.spanId,
+                parent: { traceId: span.parent.traceId, spanId: span.parent.parentSpanId },
+                spanType: BrowserSpanType.ReactComponent,
+                startTimeUnixNano: span.startTimeUnixNano,
+                attributes: { ...span.attributes, 'flare.react.component': span.name },
+            })
+            .end(span.endTimeUnixNano);
+    } catch {
+        // instrumentation must never throw into the host app
+    }
+}

--- a/packages/js/src/tracing/index.ts
+++ b/packages/js/src/tracing/index.ts
@@ -5,3 +5,4 @@ export { fill, unfill } from './fill';
 export { isNativeFetch, supportsNativeFetch } from './supportsNativeFetch';
 export { startBrowserTracing, stopBrowserTracing, type BrowserTracingFlare } from './browserTracing';
 export { type HttpTracer } from './httpRequestSpan';
+export { BrowserSpanType } from './spanTypes';

--- a/packages/js/src/tracing/instrumentFetch.ts
+++ b/packages/js/src/tracing/instrumentFetch.ts
@@ -9,6 +9,7 @@ import {
     traceparentFor,
 } from './httpRequestSpan';
 import { type FetchInput, mergeTraceparentHeader } from './propagation';
+import { BrowserSpanType } from './spanTypes';
 import { supportsNativeFetch } from './supportsNativeFetch';
 
 function resolveRequest(input: FetchInput, init: RequestInit | undefined): { method: string; url: string } {
@@ -44,7 +45,7 @@ export function createFetchWrapper(tracer: HttpTracer, original: typeof fetch, o
         const pathname = abs ? abs.pathname : url;
 
         const span = tracer.startSpan(`${method} ${pathname}`, {
-            spanType: 'browser_fetch',
+            spanType: BrowserSpanType.Fetch,
             attributes: requestSpanAttributes(method, abs, url, config),
         });
 

--- a/packages/js/src/tracing/instrumentXHR.ts
+++ b/packages/js/src/tracing/instrumentXHR.ts
@@ -10,6 +10,7 @@ import {
     safeAbsolute,
     traceparentFor,
 } from './httpRequestSpan';
+import { BrowserSpanType } from './spanTypes';
 
 type XhrOpen = XMLHttpRequest['open'];
 type XhrSend = XMLHttpRequest['send'];
@@ -108,7 +109,7 @@ export function createXHRSend(tracer: HttpTracer, original: XhrSend, origin: str
 
         const pathname = abs ? abs.pathname : state.url;
         const span = tracer.startSpan(`${state.method} ${pathname}`, {
-            spanType: 'browser_xhr',
+            spanType: BrowserSpanType.Xhr,
             attributes: requestSpanAttributes(state.method, abs, state.url, config),
         });
         state.span = span;

--- a/packages/js/src/tracing/navigationTiming.ts
+++ b/packages/js/src/tracing/navigationTiming.ts
@@ -35,3 +35,36 @@ export function pageloadStartNano(): number {
     const entry = perf.getEntriesByType('navigation')[0] as PerformanceNavigationTiming | undefined;
     return computePageloadStartNano(perf.timeOrigin, entry?.startTime);
 }
+
+/** Pure math seam (unit-testable): timeOrigin(ms) + load-event-end(ms) → unix nanos; `now` when unset. */
+export function computePageloadEndNano(
+    timeOriginMs: number,
+    loadEventEndMs: number | undefined,
+    domContentLoadedEventEndMs: number | undefined,
+    nowNano: number,
+): number {
+    const endMs = loadEventEndMs || domContentLoadedEventEndMs || 0;
+    if (!endMs) return nowNano;
+    return Math.round((timeOriginMs + endMs) * 1e6);
+}
+
+/**
+ * The pageload root's end time in unix nanoseconds, taken from the Navigation
+ * Timing `loadEventEnd` (the browser's own "page finished loading" mark), falling
+ * back to `domContentLoadedEventEnd`, then the tracer's clock when neither has
+ * fired yet or the API is unavailable. Used as the pageload root's close floor so a
+ * childless pageload reports its real load duration rather than idle-timeout padding.
+ */
+export function pageloadEndNano(): number {
+    const perf = (globalThis as { performance?: Performance }).performance;
+    if (!perf || typeof perf.getEntriesByType !== 'function' || typeof perf.timeOrigin !== 'number') {
+        return defaultNowNano();
+    }
+    const entry = perf.getEntriesByType('navigation')[0] as PerformanceNavigationTiming | undefined;
+    return computePageloadEndNano(
+        perf.timeOrigin,
+        entry?.loadEventEnd,
+        entry?.domContentLoadedEventEnd,
+        defaultNowNano(),
+    );
+}

--- a/packages/js/src/tracing/spanTypes.ts
+++ b/packages/js/src/tracing/spanTypes.ts
@@ -1,0 +1,14 @@
+// Single source of truth for the browser client's span types. Each value is the
+// `flare.span_type` attribute the tracer stamps on a span (see core Tracer). These
+// strings are WIRE FORMAT: the Flare backend keys perf aggregation off them, so the
+// values must never change. Re-exported from '@flareapp/js/browser' so @flareapp/react
+// and the playgrounds reference this set instead of re-typing the literals.
+export const BrowserSpanType = {
+    Pageload: 'browser_pageload',
+    Navigation: 'browser_navigation',
+    Fetch: 'browser_fetch',
+    Xhr: 'browser_xhr',
+    ReactComponent: 'browser_react_component',
+} as const;
+
+export type BrowserSpanType = (typeof BrowserSpanType)[keyof typeof BrowserSpanType];

--- a/packages/js/tests/browserTracing.test.ts
+++ b/packages/js/tests/browserTracing.test.ts
@@ -64,6 +64,7 @@ describe('browserTracing', () => {
         expect(opts.forceRoot).toBe(true); // must not become a child of an ambient active span
         expect(opts.attributes?.['flare.entry_point.type']).toBe('web');
         expect(opts.attributes?.['flare.entry_point.handler.identifier']).toBe('/start');
+        expect(opts.attributes?.['flare.route.source']).toBe('url');
         expect(opts.attributes?.['url.full']).toContain('/start');
         expect('context.route' in (opts.attributes ?? {})).toBe(false);
         expect('context.url' in (opts.attributes ?? {})).toBe(false);

--- a/packages/js/tests/componentProfiler.test.ts
+++ b/packages/js/tests/componentProfiler.test.ts
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+import type { Config, Span, SpanOptions } from '@flareapp/core';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { startBrowserTracing, stopBrowserTracing, type BrowserTracingFlare } from '../src/tracing/browserTracing';
+import { activeComponentRoot, recordComponentSpan, reserveSpanId } from '../src/tracing/componentProfiler';
+
+function rootSpan(over: Partial<Pick<Span, 'traceId' | 'spanId' | 'isRecording'>> = {}): Span {
+    return {
+        traceId: over.traceId ?? 'T',
+        spanId: over.spanId ?? 'root',
+        parentSpanId: null,
+        name: 'root',
+        isRecording: over.isRecording ?? true,
+        endTimeUnixNano: 0,
+        setAttribute: () => rootSpan(),
+        setStatus: () => rootSpan(),
+        addEvent: () => rootSpan(),
+        end: vi.fn(),
+    } as unknown as Span;
+}
+
+// `active` lets a test swap the value tracer.getActiveSpan() returns after startup.
+function fakeFlare(active: () => Span | undefined) {
+    const started: Array<{ name: string; opts?: SpanOptions; end: ReturnType<typeof vi.fn> }> = [];
+    const startSpan = vi.fn((name: string, opts?: SpanOptions) => {
+        const end = vi.fn();
+        started.push({ name, opts, end });
+        return { traceId: 'T', spanId: 'c', name, isRecording: true, end } as unknown as Span;
+    });
+    const flare: BrowserTracingFlare = {
+        config: { idleTimeout: 1000, finalTimeout: 30000, childSpanTimeout: 15000 } as unknown as Config,
+        startSpan,
+        tracer: {
+            addSpanListener: vi.fn(() => () => {}),
+            setActiveRoot: vi.fn(),
+            flush: vi.fn(),
+            getActiveSpan: vi.fn(() => active()),
+        } as unknown as BrowserTracingFlare['tracer'],
+    };
+    return { flare, startSpan, started };
+}
+
+describe('component-profiler seam', () => {
+    afterEach(() => {
+        stopBrowserTracing();
+        vi.useRealTimers();
+        window.history.replaceState({}, '', '/');
+    });
+
+    it('reserveSpanId returns a 16-hex id', () => {
+        expect(reserveSpanId()).toMatch(/^[0-9a-f]{16}$/);
+    });
+
+    it('activeComponentRoot returns the live recording root as parent context', () => {
+        vi.useFakeTimers();
+        const root = rootSpan({ traceId: 'T', spanId: 'root' });
+        const { flare } = fakeFlare(() => root);
+        startBrowserTracing(flare);
+        expect(activeComponentRoot()).toEqual({ traceId: 'T', parentSpanId: 'root' });
+    });
+
+    it('activeComponentRoot is null with no root, a non-recording root, or tracing off', () => {
+        vi.useFakeTimers();
+        let active: Span | undefined;
+        const { flare } = fakeFlare(() => active);
+        startBrowserTracing(flare);
+        expect(activeComponentRoot()).toBeNull(); // no root
+        active = rootSpan({ isRecording: false });
+        expect(activeComponentRoot()).toBeNull(); // root exists but is not recording
+        stopBrowserTracing();
+        expect(activeComponentRoot()).toBeNull(); // no active flare
+    });
+
+    it('recordComponentSpan records under the live root, reusing its trace (no re-sample)', () => {
+        vi.useFakeTimers();
+        const { flare, startSpan } = fakeFlare(() => rootSpan({ traceId: 'T', spanId: 'root' }));
+        startBrowserTracing(flare);
+        startSpan.mockClear();
+
+        recordComponentSpan({
+            name: 'ProductPage',
+            spanId: 'p1',
+            parent: { traceId: 'T', parentSpanId: 'root' },
+            startTimeUnixNano: 10,
+            endTimeUnixNano: 20,
+        });
+
+        expect(startSpan).toHaveBeenCalledWith(
+            'ProductPage',
+            expect.objectContaining({
+                spanId: 'p1',
+                parent: { traceId: 'T', spanId: 'root' },
+                spanType: 'browser_react_component',
+                startTimeUnixNano: 10,
+                attributes: { 'flare.react.component': 'ProductPage' },
+            }),
+        );
+    });
+
+    it('recordComponentSpan drops the span when the active root no longer matches the traceId', () => {
+        vi.useFakeTimers();
+        const { flare, startSpan } = fakeFlare(() => rootSpan({ traceId: 'DIFFERENT', spanId: 'root2' }));
+        startBrowserTracing(flare);
+        startSpan.mockClear();
+
+        recordComponentSpan({
+            name: 'ProductPage',
+            spanId: 'p1',
+            parent: { traceId: 'T', parentSpanId: 'root' },
+            startTimeUnixNano: 10,
+            endTimeUnixNano: 20,
+        });
+
+        expect(startSpan).not.toHaveBeenCalled(); // dropped: root idle-closed or a new nav took over
+    });
+
+    it('never throws into the host', () => {
+        expect(() =>
+            recordComponentSpan({
+                name: 'X',
+                spanId: 'x',
+                parent: { traceId: 'T', parentSpanId: 'root' },
+                startTimeUnixNano: 1,
+                endTimeUnixNano: 2,
+            }),
+        ).not.toThrow(); // no active flare -> no-op
+    });
+});

--- a/packages/js/tests/idleRootController.test.ts
+++ b/packages/js/tests/idleRootController.test.ts
@@ -27,7 +27,7 @@ function fakeSpan(id: string, traceId: string, endTime = 0): Span {
 }
 
 // Controllable harness: manual timers keyed by id (deadline in nanos), manual clock, manual listener.
-function harness(root: Span) {
+function harness(root: Span, endFloor: () => number = () => 0) {
     let listener: ((e: { phase: 'start' | 'end'; span: Span }) => void) | null = null;
     let clock = 0;
     const timers = new Map<number, { fn: () => void; at: number }>();
@@ -53,6 +53,7 @@ function harness(root: Span) {
             timers.delete(h as unknown as number);
         },
         rootStartTime: 0,
+        endFloor,
     };
 
     return {
@@ -89,6 +90,26 @@ describe('IdleRootController', () => {
 
         expect(root.end).toHaveBeenCalledWith(500 * 1e6);
         expect(h.setActiveRoot).toHaveBeenLastCalledWith(undefined);
+    });
+
+    it('a childless root ends at the end floor, not padded to now() (the idle-padding bug)', () => {
+        // A pageload whose window had no fetch/xhr children must close at its real
+        // load-event floor (here 700ms), NOT at start + idleTimeout (1000ms).
+        const root = fakeSpan('root', 'T');
+        const h = harness(root, () => 700 * 1e6);
+        const controller = new IdleRootController(h.deps, TIMEOUTS);
+        expect(controller.isEnded).toBe(false);
+        h.advance(1000); // idleTimeout elapses with no child ever started
+        expect(root.end).toHaveBeenCalledWith(700 * 1e6);
+    });
+
+    it('a childless navigation-style root (floor = start) trims to ~zero, not idleTimeout', () => {
+        const root = fakeSpan('root', 'T');
+        const h = harness(root, () => 0); // navigation floor is the root start
+        const controller = new IdleRootController(h.deps, TIMEOUTS);
+        expect(controller.isEnded).toBe(false);
+        h.advance(1000);
+        expect(root.end).toHaveBeenCalledWith(0);
     });
 
     it('a new child before idle fires cancels the pending close', () => {
@@ -157,15 +178,27 @@ describe('IdleRootController', () => {
         expect(root.end).toHaveBeenCalledTimes(1);
     });
 
-    it('endNow ends immediately and is idempotent', () => {
+    it('endNow with no open children ends at the floor (not now()) and is idempotent', () => {
+        // Force-ended (route change / pagehide) while idle: trim to the floor, don't
+        // pad to the moment of the force-end.
         const root = fakeSpan('root', 'T');
-        const h = harness(root);
-        h.setClock(42);
+        const h = harness(root, () => 300 * 1e6);
+        h.setClock(42 * 1e6);
         const c = new IdleRootController(h.deps, TIMEOUTS);
         c.endNow();
         c.endNow();
         expect(root.end).toHaveBeenCalledTimes(1);
-        expect(root.end).toHaveBeenCalledWith(42);
+        expect(root.end).toHaveBeenCalledWith(300 * 1e6);
         expect(c.isEnded).toBe(true);
+    });
+
+    it('endNow with an open child ends at now() (in-flight work is not cut short)', () => {
+        const root = fakeSpan('root', 'T');
+        const h = harness(root, () => 0);
+        const c = new IdleRootController(h.deps, TIMEOUTS);
+        h.emit('start', fakeSpan('c1', 'T')); // child still in flight
+        h.setClock(900 * 1e6);
+        c.endNow();
+        expect(root.end).toHaveBeenCalledWith(900 * 1e6);
     });
 });

--- a/packages/js/tests/navigationSource.test.ts
+++ b/packages/js/tests/navigationSource.test.ts
@@ -158,6 +158,42 @@ describe('registerNavigationSource', () => {
         expect(startSpan.mock.calls[1]![0]).toBe('/b');
     });
 
+    it('a registered source survives a stop/start tracing toggle and still drives navigation', () => {
+        vi.useFakeTimers();
+        window.history.replaceState({}, '', '/a');
+        const { flare } = fakeFlare();
+        startBrowserTracing(flare);
+        const src = registerNavigationSource();
+
+        // Toggle tracing off then on: stopBrowserTracing deliberately does not
+        // clear navSource, only activeFlare/currentRoot. A brand new Flare session
+        // (fresh startSpan mock) takes over as the active flare.
+        stopBrowserTracing();
+        const { flare: flare2, startSpan: startSpan2, spans: spans2 } = fakeFlare();
+        startBrowserTracing(flare2);
+
+        // The SAME handle still drives navigation, now against the new flare.
+        src.startNavigation({ path: '/b' });
+        expect(startSpan2).toHaveBeenCalledTimes(2); // restarted pageload root + the new nav root
+        const nav = startSpan2.mock.calls[1]!;
+        expect(nav[0]).toBe('/b');
+        expect(nav[1]!.spanType).toBe('browser_navigation');
+        expect(nav[1]!.attributes?.['flare.route.source']).toBe('url');
+
+        // It also renames the now-current root (the '/b' navigation root) on flare2.
+        src.setActiveRouteName({ name: '/x', source: 'route' });
+        expect(spans2[1].span.name).toBe('/x');
+        expect(spans2[1].attrs['flare.entry_point.handler.identifier']).toBe('/x');
+        expect(spans2[1].attrs['flare.route.source']).toBe('route');
+
+        // Built-in History detection is still suppressed after the re-start: a
+        // pushState opens no extra root because navSource survived the toggle.
+        window.history.pushState({}, '', '/c');
+        expect(startSpan2).toHaveBeenCalledTimes(2);
+
+        src.unregister();
+    });
+
     it('operations no-op when tracing is not active', () => {
         const src = registerNavigationSource(); // no startBrowserTracing
         expect(() => {

--- a/packages/js/tests/navigationSource.test.ts
+++ b/packages/js/tests/navigationSource.test.ts
@@ -1,0 +1,169 @@
+// @vitest-environment jsdom
+import type { Config, Span, SpanOptions } from '@flareapp/core';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+    registerNavigationSource,
+    startBrowserTracing,
+    stopBrowserTracing,
+    type BrowserTracingFlare,
+} from '../src/tracing/browserTracing';
+
+function recordingSpan(name: string) {
+    const attrs: Record<string, unknown> = {};
+    const span = {
+        traceId: 'T',
+        spanId: 's_' + name,
+        parentSpanId: null,
+        name,
+        isRecording: true,
+        endTimeUnixNano: 0,
+        setAttribute(k: string, v: unknown) {
+            attrs[k] = v;
+            return span;
+        },
+        setStatus() {
+            return span;
+        },
+        addEvent() {
+            return span;
+        },
+        end: vi.fn(),
+    } as unknown as Span;
+    return { span, attrs };
+}
+
+function fakeFlare() {
+    const spans: Array<{ span: Span; attrs: Record<string, unknown> }> = [];
+    const startSpan = vi.fn((name: string, _o?: SpanOptions) => {
+        const s = recordingSpan(name);
+        spans.push(s);
+        return s.span;
+    });
+    const flare: BrowserTracingFlare = {
+        config: {
+            idleTimeout: 1000,
+            finalTimeout: 30000,
+            childSpanTimeout: 15000,
+            urlDenylist: /(?!)/,
+        } as unknown as Config,
+        startSpan,
+        tracer: {
+            addSpanListener: vi.fn(() => () => {}),
+            setActiveRoot: vi.fn(),
+            flush: vi.fn(),
+        } as unknown as BrowserTracingFlare['tracer'],
+    };
+    return { flare, startSpan, spans };
+}
+
+describe('registerNavigationSource', () => {
+    afterEach(() => {
+        // Force-clear any navigation source leaked by a mid-test assertion failure:
+        // registering a fresh source replaces a leaked one (last-wins), and
+        // unregistering that fresh handle clears the slot.
+        registerNavigationSource().unregister();
+        stopBrowserTracing();
+        vi.useRealTimers();
+        window.history.replaceState({}, '', '/');
+    });
+
+    it('suppresses History-based navigation roots while registered', () => {
+        vi.useFakeTimers();
+        window.history.replaceState({}, '', '/a');
+        const { flare, startSpan } = fakeFlare();
+        startBrowserTracing(flare);
+        const src = registerNavigationSource();
+
+        window.history.pushState({}, '', '/b');
+
+        expect(startSpan).toHaveBeenCalledTimes(1); // only the pageload root
+        src.unregister();
+    });
+
+    it('startNavigation opens a URL-named browser_navigation root and ends the prior root', () => {
+        vi.useFakeTimers();
+        window.history.replaceState({}, '', '/a');
+        const { flare, startSpan, spans } = fakeFlare();
+        startBrowserTracing(flare);
+        const pageloadRoot = spans[0].span as unknown as { end: ReturnType<typeof vi.fn> };
+        const src = registerNavigationSource();
+
+        src.startNavigation({ path: '/product/p01' });
+
+        expect(pageloadRoot.end).toHaveBeenCalled();
+        const nav = startSpan.mock.calls[1];
+        expect(nav[0]).toBe('/product/p01');
+        expect(nav[1]!.spanType).toBe('browser_navigation');
+        expect(nav[1]!.attributes?.['flare.route.source']).toBe('url');
+        src.unregister();
+    });
+
+    it('setActiveRouteName renames the active root and flips the source flag', () => {
+        vi.useFakeTimers();
+        window.history.replaceState({}, '', '/product/p01');
+        const { flare, spans } = fakeFlare();
+        startBrowserTracing(flare);
+        const src = registerNavigationSource();
+
+        src.setActiveRouteName({ name: '/product/$id', source: 'route' });
+
+        expect(spans[0].span.name).toBe('/product/$id');
+        expect(spans[0].attrs['flare.entry_point.handler.identifier']).toBe('/product/$id');
+        expect(spans[0].attrs['flare.route.source']).toBe('route');
+        src.unregister();
+    });
+
+    it('setActiveRouteName no-ops once the active root has ended', () => {
+        vi.useFakeTimers();
+        const { flare, spans } = fakeFlare();
+        startBrowserTracing(flare);
+        const src = registerNavigationSource();
+
+        vi.advanceTimersByTime(1000); // idleTimeout ends the pageload root
+        src.setActiveRouteName({ name: '/x', source: 'route' });
+
+        expect(spans[0].span.name).not.toBe('/x');
+        src.unregister();
+    });
+
+    it('is last-wins: a stale handle cannot drive or tear down a newer registration', () => {
+        vi.useFakeTimers();
+        window.history.replaceState({}, '', '/a');
+        const { flare, startSpan } = fakeFlare();
+        startBrowserTracing(flare);
+        const first = registerNavigationSource();
+        const second = registerNavigationSource(); // replaces first
+
+        first.startNavigation({ path: '/b' }); // stale -> no-op
+        expect(startSpan).toHaveBeenCalledTimes(1);
+        first.unregister(); // stale -> no-op (does not clear `second`)
+        window.history.pushState({}, '', '/c'); // second still registered -> suppressed
+        expect(startSpan).toHaveBeenCalledTimes(1);
+
+        second.unregister();
+    });
+
+    it('unregister restores default History detection', () => {
+        vi.useFakeTimers();
+        window.history.replaceState({}, '', '/a');
+        const { flare, startSpan } = fakeFlare();
+        startBrowserTracing(flare);
+        const src = registerNavigationSource();
+        src.unregister();
+
+        window.history.pushState({}, '', '/b');
+
+        expect(startSpan).toHaveBeenCalledTimes(2); // pageload + nav
+        expect(startSpan.mock.calls[1]![0]).toBe('/b');
+    });
+
+    it('operations no-op when tracing is not active', () => {
+        const src = registerNavigationSource(); // no startBrowserTracing
+        expect(() => {
+            src.startNavigation({ path: '/x' });
+            src.setActiveRouteName({ name: '/x', source: 'route' });
+            src.unregister();
+        }).not.toThrow();
+    });
+});

--- a/packages/js/tests/navigationTiming.test.ts
+++ b/packages/js/tests/navigationTiming.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { computePageloadStartNano, resolvePageloadStartNano } from '../src/tracing/navigationTiming';
+import {
+    computePageloadEndNano,
+    computePageloadStartNano,
+    resolvePageloadStartNano,
+} from '../src/tracing/navigationTiming';
 
 describe('computePageloadStartNano', () => {
     it('returns timeOrigin + entry.startTime in nanoseconds', () => {
@@ -34,5 +38,24 @@ describe('resolvePageloadStartNano', () => {
         const backdated = 1_000 * 1e6;
         const now = backdated + 2_000 * 1e6; // within the cap, but already traced
         expect(resolvePageloadStartNano(backdated, now, FINAL, true)).toBe(now);
+    });
+});
+
+describe('computePageloadEndNano', () => {
+    const NOW = 9_999 * 1e6;
+
+    it('returns timeOrigin + loadEventEnd in nanoseconds', () => {
+        // timeOrigin 1_000 ms, loadEventEnd 488 ms → 1_488 ms → * 1e6 ns
+        expect(computePageloadEndNano(1_000, 488, 300, NOW)).toBe(1_488 * 1e6);
+    });
+
+    it('falls back to domContentLoadedEventEnd when the load event has not fired yet', () => {
+        // loadEventEnd 0 (unset) → use DCL 300 ms
+        expect(computePageloadEndNano(1_000, 0, 300, NOW)).toBe(1_300 * 1e6);
+    });
+
+    it('falls back to now when neither the load nor DCL event has fired', () => {
+        expect(computePageloadEndNano(1_000, 0, 0, NOW)).toBe(NOW);
+        expect(computePageloadEndNano(1_000, undefined, undefined, NOW)).toBe(NOW);
     });
 });

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -84,3 +84,34 @@ at [flareapp.io/docs/react/general/installation](https://flareapp.io/docs/react/
 ## License
 
 The MIT License (MIT). Please see [License File](../../LICENSE.md) for more information.
+
+## Component profiler (`@flareapp/react/profiler`)
+
+Opt-in mount profiling: wrap a component to record a `browser_react_component` span for
+its mount, nested under the active page-load / navigation trace. Requires tracing to be
+enabled (`enableTracing: true`).
+
+```tsx
+import { FlareProfiler, withFlareProfiler } from '@flareapp/react/profiler';
+
+// Wrap at the definition:
+export default withFlareProfiler(ProductPage);
+
+// Or wrap an inline subtree:
+<FlareProfiler name="Gallery">
+    <ProductGallery />
+</FlareProfiler>;
+```
+
+Spans nest into a tree: a profiled child nests under its nearest profiled ancestor;
+unprofiled components in between are transparent. A component with no active trace
+(tracing off, or no page-load/navigation root) records nothing and renders normally.
+
+**Naming:** the span name is `name` (prop or `withFlareProfiler(Component, { name })`),
+then `Component.displayName`, then `Component.name`. Minified production builds can
+mangle `Component.name`, so pass an explicit `name` or set `displayName` for production.
+
+**Suspense (v1 limitation):** a `<Suspense>` boundary inside a profiled subtree can end a
+parent span before a suspended child resumes, so the child may appear outside its parent
+in the waterfall, and its duration includes the data wait. If the wait outlasts the
+trace's idle window the child span is dropped rather than attached to a closed trace.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -61,11 +61,21 @@
                 "types": "./dist/tanstack-router.d.cts",
                 "default": "./dist/tanstack-router.cjs"
             }
+        },
+        "./profiler": {
+            "import": {
+                "types": "./dist/profiler.d.mts",
+                "default": "./dist/profiler.mjs"
+            },
+            "require": {
+                "types": "./dist/profiler.d.cts",
+                "default": "./dist/profiler.cjs"
+            }
         }
     },
     "scripts": {
         "prepublishOnly": "npm run build",
-        "build": "tsdown src/index.ts src/inject.ts src/tanstack-router.ts --format cjs,esm --dts --env.PACKAGE_VERSION=$(node -p \"require('./package.json').version\") --clean",
+        "build": "tsdown src/index.ts src/inject.ts src/tanstack-router.ts src/profiler.ts --format cjs,esm --dts --env.PACKAGE_VERSION=$(node -p \"require('./package.json').version\") --clean",
         "test": "vitest run",
         "typescript": "tsc --noEmit",
         "verify:inject": "node scripts/verify-inject-no-root.mjs",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -51,11 +51,21 @@
                 "types": "./dist/inject.d.cts",
                 "default": "./dist/inject.cjs"
             }
+        },
+        "./tanstack-router": {
+            "import": {
+                "types": "./dist/tanstack-router.d.mts",
+                "default": "./dist/tanstack-router.mjs"
+            },
+            "require": {
+                "types": "./dist/tanstack-router.d.cts",
+                "default": "./dist/tanstack-router.cjs"
+            }
         }
     },
     "scripts": {
         "prepublishOnly": "npm run build",
-        "build": "tsdown src/index.ts src/inject.ts --format cjs,esm --dts --env.PACKAGE_VERSION=$(node -p \"require('./package.json').version\") --clean",
+        "build": "tsdown src/index.ts src/inject.ts src/tanstack-router.ts --format cjs,esm --dts --env.PACKAGE_VERSION=$(node -p \"require('./package.json').version\") --clean",
         "test": "vitest run",
         "typescript": "tsc --noEmit",
         "verify:inject": "node scripts/verify-inject-no-root.mjs",
@@ -80,7 +90,13 @@
     },
     "peerDependencies": {
         "@flareapp/js": "^2.6.0",
-        "react": "^16.0.0||^17.0.0||^18.0.0||^19.0.0"
+        "react": "^16.0.0||^17.0.0||^18.0.0||^19.0.0",
+        "@tanstack/react-router": ">=1.64.0 <2"
+    },
+    "peerDependenciesMeta": {
+        "@tanstack/react-router": {
+            "optional": true
+        }
     },
     "publishConfig": {
         "access": "public"

--- a/packages/react/src/profiler.ts
+++ b/packages/react/src/profiler.ts
@@ -1,0 +1,110 @@
+// @flareapp/react/profiler — opt-in React component-mount tracing.
+//
+// Electron-safe / dependency-free: imports ONLY React and the side-effect-free
+// @flareapp/js/browser seam. NO @flareapp/js root import (same discipline as
+// ./tanstack-router). Each <FlareProfiler> records one `browser_react_component` span
+// for its mount, nested under the nearest profiled ancestor (or the active
+// browser_pageload / browser_navigation root) via React context and reserved span ids.
+import {
+    activeComponentRoot,
+    nowNano,
+    recordComponentSpan,
+    reserveSpanId,
+    type ComponentTraceContext,
+} from '@flareapp/js/browser';
+import {
+    createContext,
+    createElement,
+    useContext,
+    useEffect,
+    useLayoutEffect,
+    useRef,
+    type ComponentType,
+    type ReactNode,
+} from 'react';
+
+// useLayoutEffect matches componentDidMount timing (fires in commit, before paint,
+// bottom-up) but warns during SSR where there is no DOM; fall back to useEffect there.
+const useMountEffect = typeof window === 'undefined' ? useEffect : useLayoutEffect;
+
+const FlareProfilerContext = createContext<ComponentTraceContext | null>(null);
+
+export type FlareProfilerProps = { name: string; children?: ReactNode };
+
+export function FlareProfiler({ name, children }: FlareProfilerProps): ReactNode {
+    const context = useContext(FlareProfilerContext);
+
+    // Resolve the parent once: an ancestor's context if present, else the active root.
+    // `undefined` marks "not yet resolved"; `null` marks "resolved to transparent".
+    const parentRef = useRef<ComponentTraceContext | null | undefined>(undefined);
+    if (parentRef.current === undefined) {
+        try {
+            const live = activeComponentRoot();
+            // Prefer an inherited ancestor context only while it still belongs to the live
+            // trace. A profiled component that persists across navigations (e.g. a layout)
+            // froze its context under the pageload trace; once that root closes and a client
+            // navigation opens a new root, a descendant must re-home to the LIVE root rather
+            // than pin the subtree to the dead trace (which the live-root gate would drop).
+            parentRef.current = context && live && context.traceId === live.traceId ? context : live;
+        } catch {
+            parentRef.current = null; // resolved to transparent; never throw into the host
+        }
+    }
+    const parent = parentRef.current;
+
+    // Reserve this component's own span id and capture its mount start, once, only
+    // when it actually has a parent to nest under.
+    const ownRef = useRef<{ spanId: string; startNano: number } | null>(null);
+    if (parent && ownRef.current === null) {
+        try {
+            ownRef.current = { spanId: reserveSpanId(), startNano: nowNano() };
+        } catch {
+            // leave ownRef null: the mount effect no-ops and this component stays transparent
+        }
+    }
+
+    // Freeze the context handed to descendants: this component's span when profiled,
+    // otherwise pass the (null) context through. A descendant re-resolves against the
+    // root live at ITS mount, so a dead-window ancestor (e.g. a layout mounted between
+    // traces) does not permanently disable profiling for its subtree.
+    const providedRef = useRef<ComponentTraceContext | null | undefined>(undefined);
+    if (providedRef.current === undefined) {
+        providedRef.current =
+            parent && ownRef.current ? { traceId: parent.traceId, parentSpanId: ownRef.current.spanId } : null;
+    }
+
+    // Record exactly once per committed fiber. Under StrictMode React replays the
+    // effect (setup -> cleanup -> setup) on the same fiber, and the refs above persist,
+    // so an unguarded effect would buffer the same reserved spanId twice.
+    const hasRecorded = useRef(false);
+    useMountEffect(() => {
+        const own = ownRef.current;
+        if (!parent || !own || hasRecorded.current) return;
+        hasRecorded.current = true;
+        try {
+            recordComponentSpan({
+                name,
+                spanId: own.spanId,
+                parent,
+                startTimeUnixNano: own.startNano,
+                endTimeUnixNano: nowNano(),
+            });
+        } catch {
+            // instrumentation must never break the host
+        }
+    }, []);
+
+    return createElement(FlareProfilerContext.Provider, { value: providedRef.current ?? null }, children ?? null);
+}
+
+export function withFlareProfiler<P extends object>(
+    Component: ComponentType<P>,
+    options?: { name?: string },
+): ComponentType<P> {
+    // || not ??: an anonymous/minified component can have name '', which must fall
+    // through to 'Unknown' (matches Sentry).
+    const name = options?.name || Component.displayName || Component.name || 'Unknown';
+    const Profiled = (props: P): ReactNode => createElement(FlareProfiler, { name }, createElement(Component, props));
+    Profiled.displayName = `withFlareProfiler(${name})`;
+    return Profiled;
+}

--- a/packages/react/src/tanstack-router.ts
+++ b/packages/react/src/tanstack-router.ts
@@ -1,0 +1,90 @@
+// Electron-safe entry: NO @flareapp/js root import. The navigation-source seam
+// comes from @flareapp/js/browser (side-effect-free). NO runtime dependency on
+// @tanstack/react-router — the router is consumed structurally (see ./vendor).
+import { registerNavigationSource, type RouteName } from '@flareapp/js/browser';
+
+import type { TsrLocation, TsrNavEvent, TsrRouter } from './vendor/tanstackRouterTypes';
+
+/**
+ * Trace a TanStack Router instance: name the `browser_pageload` root from the
+ * initial route and open a parameterized `browser_navigation` root per route
+ * change. Returns a cleanup that unsubscribes and unregisters. Safe to call
+ * before or after tracing is enabled; no-ops when tracing is off.
+ */
+export function traceTanStackRouter(router: TsrRouter): () => void {
+    const nav = registerNavigationSource();
+
+    const routeNameFor = (loc: TsrLocation): RouteName => {
+        try {
+            const matches = router.matchRoutes(loc.pathname, loc.search, { preload: false, throwOnError: false });
+            const last = matches[matches.length - 1];
+            const matched = matches.some((m) => m.routeId !== '__root__');
+            const name = matched ? last?.fullPath || last?.routeId : undefined;
+            if (name) return { name, source: 'route' };
+        } catch {
+            // fall through to the URL name
+        }
+        return { name: loc.pathname, source: 'url' };
+    };
+
+    // A tracing error must never escape into the router's event dispatch.
+    const guard =
+        (fn: (event: TsrNavEvent) => void) =>
+        (event: TsrNavEvent): void => {
+            try {
+                fn(event);
+            } catch {
+                // swallow: instrumentation never breaks the host
+            }
+        };
+
+    // Enrich the pageload root immediately from the current (already-resolved) location.
+    try {
+        nav.setActiveRouteName(routeNameFor(router.state.location));
+    } catch {
+        // never break the host on wiring
+    }
+
+    let inFlight = false;
+
+    const offBeforeLoad = router.subscribe(
+        'onBeforeLoad',
+        guard((e) => {
+            if (e.fromLocation === undefined) return; // initial pageload (handled via onResolved)
+            if (e.toLocation.state === e.fromLocation.state) return; // no-op reload (e.g. router.invalidate())
+            if (!inFlight) {
+                inFlight = true;
+                nav.startNavigation({ path: e.toLocation.pathname });
+            }
+            nav.setActiveRouteName(routeNameFor(e.toLocation)); // set / re-set (redirect hops)
+        }),
+    );
+
+    const offResolved = router.subscribe(
+        'onResolved',
+        guard((e) => {
+            if (e.fromLocation === undefined) {
+                nav.setActiveRouteName(routeNameFor(e.toLocation)); // one-shot pageload correction
+                return;
+            }
+            if (inFlight) {
+                inFlight = false;
+                nav.setActiveRouteName(routeNameFor(e.toLocation)); // finalize the navigation name
+            }
+        }),
+    );
+
+    return () => {
+        try {
+            offBeforeLoad();
+        } catch {
+            // ignore
+        }
+        try {
+            offResolved();
+        } catch {
+            // ignore
+        }
+        nav.unregister();
+    };
+}

--- a/packages/react/src/tanstack-router.ts
+++ b/packages/react/src/tanstack-router.ts
@@ -85,6 +85,10 @@ export function traceTanStackRouter(router: TsrRouter): () => void {
         } catch {
             // ignore
         }
-        nav.unregister();
+        try {
+            nav.unregister();
+        } catch {
+            // ignore
+        }
     };
 }

--- a/packages/react/src/vendor/tanstackRouterTypes.ts
+++ b/packages/react/src/vendor/tanstackRouterTypes.ts
@@ -1,0 +1,14 @@
+// Structural subset of @tanstack/react-router v1 that the tracing integration
+// reads. Vendored (not imported) so this entry needs no runtime dependency on
+// the router and non-TanStack consumers of @flareapp/react type-check cleanly.
+// Verify against the pinned router version if these shapes drift.
+
+export type TsrLocation = { pathname: string; search: unknown; state?: unknown };
+export type TsrNavEvent = { fromLocation?: TsrLocation; toLocation: TsrLocation };
+export type TsrMatch = { routeId?: string; fullPath?: string };
+
+export type TsrRouter = {
+    subscribe(eventType: 'onBeforeLoad' | 'onResolved', cb: (event: TsrNavEvent) => void): () => void;
+    matchRoutes(pathname: string, search: unknown, opts?: { preload?: boolean; throwOnError?: boolean }): TsrMatch[];
+    state: { location: TsrLocation };
+};

--- a/packages/react/tests/profiler.test.tsx
+++ b/packages/react/tests/profiler.test.tsx
@@ -1,0 +1,241 @@
+// @vitest-environment jsdom
+import { cleanup, render } from '@testing-library/react';
+import { StrictMode, Suspense, type ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const seam = vi.hoisted(() => {
+    let counter = 0;
+    return {
+        activeComponentRoot: vi.fn((): { traceId: string; parentSpanId: string } | null => ({
+            traceId: 'T',
+            parentSpanId: 'root',
+        })),
+        reserveSpanId: vi.fn(() => `s${++counter}`),
+        recordComponentSpan: vi.fn(),
+        nowNano: vi.fn(() => 1000),
+        reset: () => {
+            counter = 0;
+        },
+    };
+});
+vi.mock('@flareapp/js/browser', () => ({
+    activeComponentRoot: seam.activeComponentRoot,
+    reserveSpanId: seam.reserveSpanId,
+    recordComponentSpan: seam.recordComponentSpan,
+    nowNano: seam.nowNano,
+}));
+
+import { FlareProfiler, withFlareProfiler } from '../src/profiler';
+
+beforeEach(() => {
+    seam.reset();
+    seam.recordComponentSpan.mockReset();
+    seam.reserveSpanId.mockClear();
+    seam.activeComponentRoot.mockReset().mockReturnValue({ traceId: 'T', parentSpanId: 'root' });
+    seam.nowNano.mockReset().mockReturnValue(1000);
+});
+afterEach(cleanup);
+
+const calls = () =>
+    seam.recordComponentSpan.mock.calls.map(
+        (c) => c[0] as { name: string; spanId: string; parent: { traceId: string; parentSpanId: string } },
+    );
+
+describe('FlareProfiler', () => {
+    it('records one span for a single component, parented to the active root', () => {
+        render(
+            <FlareProfiler name="Solo">
+                <div>content</div>
+            </FlareProfiler>,
+        );
+        expect(seam.recordComponentSpan).toHaveBeenCalledTimes(1);
+        expect(calls()[0]).toMatchObject({
+            name: 'Solo',
+            spanId: 's1',
+            parent: { traceId: 'T', parentSpanId: 'root' },
+            startTimeUnixNano: 1000,
+            endTimeUnixNano: 1000,
+        });
+    });
+
+    it('nests a child span under its profiled parent', () => {
+        render(
+            <FlareProfiler name="Parent">
+                <FlareProfiler name="Child">
+                    <div>x</div>
+                </FlareProfiler>
+            </FlareProfiler>,
+        );
+        // Effects fire bottom-up: Child records first (s2 under parent s1), then Parent (s1 under root).
+        const byName = Object.fromEntries(calls().map((c) => [c.name, c]));
+        expect(byName.Parent).toMatchObject({ spanId: 's1', parent: { parentSpanId: 'root' } });
+        expect(byName.Child).toMatchObject({ spanId: 's2', parent: { parentSpanId: 's1' } });
+    });
+
+    it('is transparent when unprofiled: a grandchild nests under the nearest profiled ancestor', () => {
+        const Passthrough = ({ children }: { children?: ReactNode }) => <div>{children}</div>;
+        render(
+            <FlareProfiler name="Ancestor">
+                <Passthrough>
+                    <FlareProfiler name="Descendant">
+                        <div>x</div>
+                    </FlareProfiler>
+                </Passthrough>
+            </FlareProfiler>,
+        );
+        const byName = Object.fromEntries(calls().map((c) => [c.name, c]));
+        expect(byName.Descendant).toMatchObject({ parent: { parentSpanId: 's1' } }); // under Ancestor, not the plain div
+    });
+
+    it('records nothing but still renders children when there is no active root', () => {
+        seam.activeComponentRoot.mockReturnValue(null);
+        const { getByText } = render(
+            <FlareProfiler name="Solo">
+                <div>still here</div>
+            </FlareProfiler>,
+        );
+        expect(seam.recordComponentSpan).not.toHaveBeenCalled();
+        expect(seam.reserveSpanId).not.toHaveBeenCalled();
+        expect(getByText('still here')).toBeTruthy();
+    });
+
+    it('never throws when the seam throws', () => {
+        seam.recordComponentSpan.mockImplementation(() => {
+            throw new Error('boom');
+        });
+        expect(() =>
+            render(
+                <FlareProfiler name="Solo">
+                    <div>x</div>
+                </FlareProfiler>,
+            ),
+        ).not.toThrow();
+    });
+
+    it('never throws, and still renders children, when activeComponentRoot throws (render phase)', () => {
+        seam.activeComponentRoot.mockImplementation(() => {
+            throw new Error('boom');
+        });
+        let getByText!: ReturnType<typeof render>['getByText'];
+        expect(() => {
+            ({ getByText } = render(
+                <FlareProfiler name="Solo">
+                    <div>still here</div>
+                </FlareProfiler>,
+            ));
+        }).not.toThrow();
+        expect(getByText('still here')).toBeTruthy();
+    });
+
+    it('never throws, still renders children, and skips recording when reserveSpanId throws (render phase)', () => {
+        // mockImplementationOnce, not mockImplementation: reserveSpanId is only
+        // mockClear()'d (not mockReset()'d) in beforeEach, so a persistent throwing
+        // implementation would leak into every later test in this file.
+        seam.reserveSpanId.mockImplementationOnce(() => {
+            throw new Error('boom');
+        });
+        let getByText!: ReturnType<typeof render>['getByText'];
+        expect(() => {
+            ({ getByText } = render(
+                <FlareProfiler name="Solo">
+                    <div>still here</div>
+                </FlareProfiler>,
+            ));
+        }).not.toThrow();
+        expect(getByText('still here')).toBeTruthy();
+        expect(seam.recordComponentSpan).not.toHaveBeenCalled();
+    });
+
+    it('records exactly once under StrictMode (no duplicate spanId)', () => {
+        render(
+            <StrictMode>
+                <FlareProfiler name="Solo">
+                    <div>x</div>
+                </FlareProfiler>
+            </StrictMode>,
+        );
+        expect(seam.recordComponentSpan).toHaveBeenCalledTimes(1);
+    });
+
+    it('records a suspended child under its profiled ancestor once it resolves', async () => {
+        let resolve!: () => void;
+        const gate = new Promise<void>((r) => {
+            resolve = r;
+        });
+        let ready = false;
+        const Suspender = () => {
+            if (!ready) throw gate;
+            return <div>loaded</div>;
+        };
+        render(
+            <FlareProfiler name="Ancestor">
+                <Suspense fallback={<div>loading</div>}>
+                    <FlareProfiler name="Lazy">
+                        <Suspender />
+                    </FlareProfiler>
+                </Suspense>
+            </FlareProfiler>,
+        );
+        ready = true;
+        await vi.waitFor(() => {
+            resolve();
+            const byName = Object.fromEntries(calls().map((c) => [c.name, c]));
+            expect(byName.Lazy).toMatchObject({ parent: { parentSpanId: 's1' } });
+        });
+    });
+
+    it('re-homes a descendant to the live root when the inherited ancestor context is from a dead trace', () => {
+        // Ancestor (a persistent layout) mounts under the initial pageload trace R1.
+        seam.activeComponentRoot.mockReturnValue({ traceId: 'R1', parentSpanId: 'r1root' });
+        const { rerender } = render(<FlareProfiler name="Layout">{null}</FlareProfiler>);
+
+        // Pageload trace R1 closes; a client navigation opens a fresh trace R2. The ancestor
+        // does NOT remount (rerender, same fiber), so its provided context stays frozen at R1.
+        seam.activeComponentRoot.mockReturnValue({ traceId: 'R2', parentSpanId: 'r2root' });
+        rerender(
+            <FlareProfiler name="Layout">
+                <FlareProfiler name="Descendant">
+                    <div>x</div>
+                </FlareProfiler>
+            </FlareProfiler>,
+        );
+
+        const byName = Object.fromEntries(calls().map((c) => [c.name, c]));
+        // Ancestor recorded once, under its own live trace at mount time (R1).
+        expect(byName.Layout).toMatchObject({ parent: { traceId: 'R1', parentSpanId: 'r1root' } });
+        // Descendant inherited the stale R1 context but RE-HOMES to the live R2 root instead of
+        // pinning to the dead trace (which the live-root gate would drop in production).
+        expect(byName.Descendant).toMatchObject({ parent: { traceId: 'R2', parentSpanId: 'r2root' } });
+    });
+});
+
+describe('withFlareProfiler', () => {
+    it('resolves the name from options over displayName over Component.name', () => {
+        function Named() {
+            return <div>n</div>;
+        }
+        const WithName = withFlareProfiler(Named);
+        render(<WithName />);
+        expect(calls()[0]!.name).toBe('Named');
+
+        seam.recordComponentSpan.mockClear();
+        const Displayed = () => <div>d</div>;
+        Displayed.displayName = 'Display';
+        const WithDisplayName = withFlareProfiler(Displayed);
+        render(<WithDisplayName />);
+        expect(calls()[0]!.name).toBe('Display'); // displayName beats Component.name ('Displayed')
+
+        seam.recordComponentSpan.mockClear();
+        const Explicit = withFlareProfiler(Displayed, { name: 'Explicit' });
+        render(<Explicit />);
+        expect(calls()[0]!.name).toBe('Explicit'); // explicit beats displayName
+    });
+
+    it('falls through an empty Component.name to Unknown (|| not ??)', () => {
+        const Anon = () => <div>a</div>;
+        Object.defineProperty(Anon, 'name', { value: '' });
+        const WithAnon = withFlareProfiler(Anon);
+        render(<WithAnon />);
+        expect(calls()[0]!.name).toBe('Unknown'); // '' falls through via ||, not ??
+    });
+});

--- a/packages/react/tests/tanstack-router.entry.test.ts
+++ b/packages/react/tests/tanstack-router.entry.test.ts
@@ -1,0 +1,24 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+describe('@flareapp/react/tanstack-router entry', () => {
+    beforeEach(() => {
+        vi.resetModules();
+        delete (window as unknown as { flare?: unknown }).flare;
+    });
+
+    test('importing the entry does NOT evaluate the @flareapp/js root singleton', async () => {
+        const rootFactory = vi.fn(() => ({ flare: {} }));
+        vi.doMock('@flareapp/js', rootFactory);
+        vi.doMock('@flareapp/js/browser', () => ({ registerNavigationSource: () => ({}) }));
+        await import('../src/tanstack-router');
+        expect(rootFactory).not.toHaveBeenCalled();
+        expect((window as unknown as { flare?: unknown }).flare).toBeUndefined();
+    });
+
+    test('exports traceTanStackRouter', async () => {
+        vi.doMock('@flareapp/js/browser', () => ({ registerNavigationSource: () => ({}) }));
+        const mod = await import('../src/tanstack-router');
+        expect(typeof mod.traceTanStackRouter).toBe('function');
+    });
+});

--- a/packages/react/tests/tanstack-router.test.ts
+++ b/packages/react/tests/tanstack-router.test.ts
@@ -63,7 +63,7 @@ describe('traceTanStackRouter', () => {
         expect(nav.startNavigation).toHaveBeenCalledWith({ path: '/product/p01' });
         expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/product/$id', source: 'route' });
         emit('onResolved', { fromLocation: from, toLocation: to });
-        expect(nav.setActiveRouteName).toHaveBeenCalledTimes(2);
+        expect(nav.setActiveRouteName).toHaveBeenLastCalledWith({ name: '/product/$id', source: 'route' });
     });
 
     it('skips the initial pageload onBeforeLoad', () => {
@@ -138,5 +138,21 @@ describe('traceTanStackRouter', () => {
         expect(unsub.onBeforeLoad).toHaveBeenCalled();
         expect(unsub.onResolved).toHaveBeenCalled();
         expect(nav.unregister).toHaveBeenCalled();
+    });
+
+    it('falls back to the URL name when matchRoutes throws', () => {
+        const { router, emit } = fakeRouter();
+        traceTanStackRouter(router);
+        nav.setActiveRouteName.mockClear();
+        (router.matchRoutes as ReturnType<typeof vi.fn>).mockImplementation(() => {
+            throw new Error('router boom');
+        });
+        expect(() =>
+            emit('onBeforeLoad', {
+                fromLocation: { pathname: '/', search: {}, state: {} },
+                toLocation: { pathname: '/kaboom', search: {}, state: {} },
+            }),
+        ).not.toThrow();
+        expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/kaboom', source: 'url' });
     });
 });

--- a/packages/react/tests/tanstack-router.test.ts
+++ b/packages/react/tests/tanstack-router.test.ts
@@ -1,0 +1,142 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const nav = vi.hoisted(() => ({
+    startNavigation: vi.fn(),
+    setActiveRouteName: vi.fn(),
+    unregister: vi.fn(),
+}));
+vi.mock('@flareapp/js/browser', () => ({ registerNavigationSource: vi.fn(() => nav) }));
+
+import { traceTanStackRouter } from '../src/tanstack-router';
+import type { TsrMatch } from '../src/vendor/tanstackRouterTypes';
+
+const PRODUCT_MATCHES: TsrMatch[] = [{ routeId: '__root__' }, { routeId: '/product/$id', fullPath: '/product/$id' }];
+
+function fakeRouter(opts: { matches?: TsrMatch[]; location?: { pathname: string; search: unknown } } = {}) {
+    const subs: Record<string, (e: unknown) => void> = {};
+    const unsub = { onBeforeLoad: vi.fn(), onResolved: vi.fn() };
+    const router = {
+        state: { location: opts.location ?? { pathname: '/', search: {} } },
+        matchRoutes: vi.fn(() => opts.matches ?? PRODUCT_MATCHES),
+        subscribe: vi.fn((type: 'onBeforeLoad' | 'onResolved', cb: (e: unknown) => void) => {
+            subs[type] = cb;
+            return unsub[type];
+        }),
+    };
+    return { router, unsub, emit: (type: string, e: unknown) => subs[type]?.(e) };
+}
+
+beforeEach(() => {
+    nav.startNavigation.mockClear();
+    nav.setActiveRouteName.mockClear();
+    nav.unregister.mockClear();
+});
+
+describe('traceTanStackRouter', () => {
+    it('enriches the pageload root from the current location at registration', () => {
+        const { router } = fakeRouter({ location: { pathname: '/product/p01', search: {} } });
+        traceTanStackRouter(router);
+        expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/product/$id', source: 'route' });
+    });
+
+    it('corrects the pageload name on the initial onResolved (loader redirect), no nav root', () => {
+        const { router, emit } = fakeRouter();
+        traceTanStackRouter(router);
+        nav.setActiveRouteName.mockClear();
+        (router.matchRoutes as ReturnType<typeof vi.fn>).mockReturnValue([
+            { routeId: '__root__' },
+            { routeId: '/login', fullPath: '/login' },
+        ]);
+        emit('onResolved', { fromLocation: undefined, toLocation: { pathname: '/login', search: {} } });
+        expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/login', source: 'route' });
+        expect(nav.startNavigation).not.toHaveBeenCalled();
+    });
+
+    it('starts one navigation root on a real navigation and finalizes on resolve', () => {
+        const { router, emit } = fakeRouter();
+        traceTanStackRouter(router);
+        nav.setActiveRouteName.mockClear();
+        const from = { pathname: '/', search: {}, state: {} };
+        const to = { pathname: '/product/p01', search: {}, state: {} };
+        emit('onBeforeLoad', { fromLocation: from, toLocation: to });
+        expect(nav.startNavigation).toHaveBeenCalledWith({ path: '/product/p01' });
+        expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/product/$id', source: 'route' });
+        emit('onResolved', { fromLocation: from, toLocation: to });
+        expect(nav.setActiveRouteName).toHaveBeenCalledTimes(2);
+    });
+
+    it('skips the initial pageload onBeforeLoad', () => {
+        const { router, emit } = fakeRouter();
+        traceTanStackRouter(router);
+        emit('onBeforeLoad', { fromLocation: undefined, toLocation: { pathname: '/', search: {} } });
+        expect(nav.startNavigation).not.toHaveBeenCalled();
+    });
+
+    it('skips a no-op reload (identical location state)', () => {
+        const { router, emit } = fakeRouter();
+        traceTanStackRouter(router);
+        const state = {};
+        emit('onBeforeLoad', {
+            fromLocation: { pathname: '/x', search: {}, state },
+            toLocation: { pathname: '/x', search: {}, state },
+        });
+        expect(nav.startNavigation).not.toHaveBeenCalled();
+    });
+
+    it('a redirect chain produces exactly one navigation root, renamed per hop', () => {
+        const { router, emit } = fakeRouter();
+        traceTanStackRouter(router);
+        nav.setActiveRouteName.mockClear();
+        const from = { pathname: '/', search: {}, state: {} };
+        (router.matchRoutes as ReturnType<typeof vi.fn>).mockReturnValue([
+            { routeId: '__root__' },
+            { routeId: '/a', fullPath: '/a' },
+        ]);
+        emit('onBeforeLoad', { fromLocation: from, toLocation: { pathname: '/a', search: {}, state: {} } });
+        (router.matchRoutes as ReturnType<typeof vi.fn>).mockReturnValue([
+            { routeId: '__root__' },
+            { routeId: '/b', fullPath: '/b' },
+        ]);
+        emit('onBeforeLoad', { fromLocation: from, toLocation: { pathname: '/b', search: {}, state: {} } });
+        expect(nav.startNavigation).toHaveBeenCalledTimes(1);
+        emit('onResolved', { fromLocation: from, toLocation: { pathname: '/b', search: {}, state: {} } });
+        expect(nav.setActiveRouteName).toHaveBeenLastCalledWith({ name: '/b', source: 'route' });
+    });
+
+    it('falls back to the URL name when only __root__ matches', () => {
+        const { router, emit } = fakeRouter();
+        traceTanStackRouter(router);
+        nav.setActiveRouteName.mockClear();
+        (router.matchRoutes as ReturnType<typeof vi.fn>).mockReturnValue([{ routeId: '__root__' }]);
+        emit('onBeforeLoad', {
+            fromLocation: { pathname: '/', search: {}, state: {} },
+            toLocation: { pathname: '/nope', search: {}, state: {} },
+        });
+        expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/nope', source: 'url' });
+    });
+
+    it('falls back to routeId when fullPath is empty', () => {
+        const { router, emit } = fakeRouter();
+        traceTanStackRouter(router);
+        nav.setActiveRouteName.mockClear();
+        (router.matchRoutes as ReturnType<typeof vi.fn>).mockReturnValue([
+            { routeId: '__root__' },
+            { routeId: '/layout', fullPath: '' },
+        ]);
+        emit('onBeforeLoad', {
+            fromLocation: { pathname: '/', search: {}, state: {} },
+            toLocation: { pathname: '/layout', search: {}, state: {} },
+        });
+        expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/layout', source: 'route' });
+    });
+
+    it('cleanup unsubscribes and unregisters', () => {
+        const { router, unsub } = fakeRouter();
+        const stop = traceTanStackRouter(router);
+        stop();
+        expect(unsub.onBeforeLoad).toHaveBeenCalled();
+        expect(unsub.onResolved).toHaveBeenCalled();
+        expect(nav.unregister).toHaveBeenCalled();
+    });
+});

--- a/playgrounds/react/src/flare.ts
+++ b/playgrounds/react/src/flare.ts
@@ -8,6 +8,12 @@ export const initFlare = (): void => {
         flare.configure({
             ingestUrl: url,
             logsIngestUrl: url.replace('/api/reports', '/api/logs'),
+            tracesIngestUrl: url.replace('/api/reports', '/api/traces'),
+            // e2e-only timing: keep the pageload/navigation root active long enough for a
+            // prompt Playwright click to land and nest under it, then flush an ended root
+            // fast so arrival assertions don't need to wait out the (5s) production default.
+            idleTimeout: 2000,
+            spanFlushIntervalMs: 500,
         });
     }
 
@@ -17,6 +23,8 @@ export const initFlare = (): void => {
         // and fail like the error reports do). The fake-server logsIngestUrl
         // override above only applies under e2e (VITE_FLARE_URL set).
         enableLogs: true,
+        enableTracing: true,
+        tracesSampleRate: 1,
         beforeEvaluate: (error) => {
             if (error.message === 'hook-drop-report') return null;
             return error;
@@ -33,6 +41,9 @@ export const initFlare = (): void => {
     });
 
     flare.light(key, true);
+
+    // Expose the instance so the e2e suite can drive the tracer directly. Playground-only.
+    (globalThis as { __flare?: typeof flare }).__flare = flare;
 };
 
 export { flare };

--- a/playgrounds/react/src/main.tsx
+++ b/playgrounds/react/src/main.tsx
@@ -1,5 +1,6 @@
 import '@flareapp/playgrounds-shared/styles.css';
 import { FlareErrorBoundary } from '@flareapp/react';
+import { traceTanStackRouter } from '@flareapp/react/tanstack-router';
 import { RouterProvider } from '@tanstack/react-router';
 import { StrictMode, useSyncExternalStore } from 'react';
 import { createRoot } from 'react-dom/client';
@@ -9,6 +10,7 @@ import { initFlare } from './flare';
 import { router } from './router';
 
 initFlare();
+traceTanStackRouter(router);
 
 // Track the router pathname via router.subscribe so the boundary can read it
 // without being mounted inside RouterProvider. The boundary needs to wrap

--- a/playgrounds/react/src/routes/__root.tsx
+++ b/playgrounds/react/src/routes/__root.tsx
@@ -1,7 +1,8 @@
-import { createRootRoute } from '@tanstack/react-router';
+import { withFlareProfiler } from '@flareapp/react/profiler';
+import { createRootRoute, RouteComponent } from '@tanstack/react-router';
 
 import { Layout } from '../components/Layout';
 
 export const rootRoute = createRootRoute({
-    component: Layout,
+    component: withFlareProfiler(Layout, { name: 'Layout' }) as RouteComponent,
 });

--- a/playgrounds/react/src/routes/index.tsx
+++ b/playgrounds/react/src/routes/index.tsx
@@ -1,5 +1,6 @@
 import { products, testIds, unsplashUrl } from '@flareapp/playgrounds-shared';
-import { createRoute, Link } from '@tanstack/react-router';
+import { withFlareProfiler } from '@flareapp/react/profiler';
+import { createRoute, Link, RouteComponent } from '@tanstack/react-router';
 
 import { cart } from '../cart';
 import { rootRoute } from './__root';
@@ -48,5 +49,5 @@ const ProductsPage = () => (
 export const indexRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: '/',
-    component: ProductsPage,
+    component: withFlareProfiler(ProductsPage, { name: 'ProductsPage' }) as RouteComponent,
 });

--- a/playgrounds/react/src/routes/product.$id.tsx
+++ b/playgrounds/react/src/routes/product.$id.tsx
@@ -1,5 +1,6 @@
 import { productById, testIds, unsplashUrl } from '@flareapp/playgrounds-shared';
-import { createRoute } from '@tanstack/react-router';
+import { withFlareProfiler } from '@flareapp/react/profiler';
+import { createRoute, RouteComponent } from '@tanstack/react-router';
 
 import { cart } from '../cart';
 import { flare } from '../flare';
@@ -30,14 +31,7 @@ const ProductPage = () => {
                 <h1 className="text-2xl font-semibold">{product.title}</h1>
                 <p className="text-sm opacity-70">Photograph by {product.photographer}</p>
                 <div className="text-xl font-mono">${(product.priceCents / 100).toFixed(2)}</div>
-                <button
-                    type="button"
-                    data-testid={testIds.addToCart(product.id)}
-                    onClick={() => cart.add(product.id)}
-                    className="rounded-lg bg-brand-ink text-white py-3 hover:opacity-90"
-                >
-                    Add to cart
-                </button>
+                <AddToCartButton testId={testIds.addToCart(product.id)} onClick={() => cart.add(product.id)} />
                 <button
                     type="button"
                     onClick={triggerBroken}
@@ -53,5 +47,19 @@ const ProductPage = () => {
 export const productRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: '/product/$id',
-    component: ProductPage,
+    component: withFlareProfiler(ProductPage, { name: 'ProductPage' }) as RouteComponent,
 });
+
+const AddToCartButton = withFlareProfiler(
+    ({ testId, onClick }: { testId: any; onClick: () => void }) => (
+        <button
+            type="button"
+            data-testid={testId}
+            onClick={onClick}
+            className="rounded-lg bg-brand-ink text-white py-3 hover:opacity-90"
+        >
+            Add to cart
+        </button>
+    ),
+    { name: 'AddToCartButton' },
+);


### PR DESCRIPTION
Parameterized route names for browser performance tracing, driven by the app's router — the first framework router integration in the perf-tracing effort, starting with **TanStack Router (React)**. Tracing stays **opt-in** via `enableTracing` (default off).

Before this, the `browser_pageload` / `browser_navigation` root spans were named by the raw `location.pathname` (e.g. `/product/p01`), which the backend `SpanAggregators` can't group. This slice replaces that with the parameterized route template (`/product/$id`) supplied by the router, plus a `route` vs `url` source flag.

Design spec: `docs/superpowers/specs/2026-07-07-performance-tracing-framework-router-tanstack-design.md`.

---

## What's in it

### 1. Navigation-source seam — `@flareapp/js`

A new `registerNavigationSource()` (exported from `@flareapp/js/browser`) lets a framework integration take over navigation:

```ts
type NavigationSource = {
    startNavigation(opts?: { path?: string }): void;   // open a browser_navigation root (URL-named), ending the prior one
    setActiveRouteName(route: { name: string; source: 'route' | 'url' }): void; // upgrade the active root's name
    unregister(): void;
};
```

- While a source is registered, the built-in History-API navigation detection **opens no root** (it keeps `lastPath` current) — so there's exactly one root per navigation, no double-counting.
- `setActiveRouteName` rewrites the span **name** and the `flare.entry_point.handler.identifier` attribute (the identifier the backend reads) in lockstep, and sets `flare.route.source`. The concrete URL stays in `flare.entry_point.value`.
- Registration is **last-wins + token-guarded**; a stale handle (e.g. HMR) can't tear down a newer one. It survives a tracing enable/disable toggle. No `@flareapp/core` change.
- Every browser root now carries `flare.route.source` (`url` at open, flipped to `route` when a template resolves) — so the backend never has to treat an absent attribute as an implicit third state.

### 2. TanStack integration — `@flareapp/react/tanstack-router` (new subpath entry)

```ts
import { traceTanStackRouter } from '@flareapp/react/tanstack-router';
const stop = traceTanStackRouter(router);
```

- Subscribes to **`onBeforeLoad`** (nav start — not `onBeforeNavigate`, which TanStack suppresses after a loader redirect, TanStack/router#3920) and **`onResolved`** (finalize the name). One nav root per navigation via an in-flight redirect latch; the pageload root is enriched synchronously at registration with a one-shot `onResolved` correction.
- Resolves the parameterized name via `router.matchRoutes(...)` (a `__root__`-only match = no match → URL fallback). Emits the router-native `$id` form (no cross-framework normalization).
- **Electron-safe** (no `@flareapp/js` root import) and uses **vendored structural router types** — no runtime dependency on `@tanstack/react-router` (it's an *optional* peer, `>=1.64.0 <2`). Every router callback is guarded so a tracing error can't escape into the router's dispatch.

### 3. Playground + e2e

- Tracing enabled in the React playground; `traceTanStackRouter(router)` wired at bootstrap.
- New Playwright specs in the `react` project assert the `browser_pageload` (deep-link) and `browser_navigation` (client-nav) roots carry `flare.entry_point.handler.identifier: /product/$id` (parameterized, **not** `/product/p01`) with `flare.route.source: route`.

## Validation

- Unit: the seam (`@flareapp/js`, incl. a toggle-survival regression test) and the integration (`@flareapp/react`, 11 tests covering the skip gate, redirect latch, `__root__`/empty-`fullPath` fallbacks, and a `matchRoutes`-throws fallback).
- e2e: `--project=react` green across 3 runs, no flakiness.
- **Validated against the real TanStack Router (1.170.10)** — every vendored assumption (`matchRoutes` shape, `onBeforeLoad`/`onResolved` payloads, the `__root__` sentinel) held with no integration change.
- Repo-wide: typecheck 0 errors, lint clean (round files), build clean, all workspace unit suites green.

## Out of scope / follow-ups

- **Other routers** (React Router v7, Vue Router v4, SvelteKit 2 client) — each a follow-on slice reusing this seam. Carry-forward recorded in the spec: Vue/SvelteKit hooks fire *before* the URL commits, so those slices must thread the destination URL into the root context (TanStack commits the URL first, so `url.full` is correct here).
- Verify the `matchRoutes` signature at the pinned floor `1.64.0` before the next `@flareapp/react` publish (only 1.170.10 was exercised end-to-end; `routeNameFor` degrades gracefully to a url-source name if it drifts).
- The `flare.route.source` key + parameterized-name semantics need backend agreement (B5/B9/P4) before real-product correlation; `enableTracing` remains opt-in until then.
- Minor cleanups noted in review (shared attribute-key constant; an `endActiveRoot()` helper to dedupe the root-teardown block) — non-blocking.
