### PR TITLE
fix(js): end browser trace roots at real activity, not idle-timeout padding

### DIFF
--- a/packages/js/src/tracing/IdleRootController.ts
+++ b/packages/js/src/tracing/IdleRootController.ts
@@ -14,6 +14,12 @@ export type IdleRootDeps = {
     setTimeout: (fn: () => void, ms: number) => ReturnType<typeof setTimeout>;
     clearTimeout: (handle: ReturnType<typeof setTimeout>) => void;
     rootStartTime: number; // unix nanos, base for finalTimeout
+    // Floor for a trimmed close: when a root closes with no in-flight children its
+    // end is this floor (read lazily), never `now()`. Navigation passes its start
+    // time (an instant nav trims to ~0); pageload passes the Navigation Timing
+    // load-event end so a childless pageload reports its real load duration instead
+    // of being padded by the whole idleTimeout window.
+    endFloor: () => number;
 };
 
 type Timer = ReturnType<typeof setTimeout> | null;
@@ -53,7 +59,10 @@ export class IdleRootController {
     }
 
     endNow(): void {
-        this.finish(this.deps.now());
+        // Force-ended (route change / pagehide). With no child in flight, trim to the
+        // floor instead of padding to the force-end moment; with an open child use
+        // now() so in-flight work is not cut short before it even started.
+        this.finish(this.openChildren > 0 ? this.deps.now() : this.trimmedEnd());
     }
 
     private onSpanEvent(phase: 'start' | 'end', span: Span): void {
@@ -85,8 +94,18 @@ export class IdleRootController {
         this.clearIdle();
         this.idleTimer = this.deps.setTimeout(() => {
             if (this.openChildren > 0) return;
-            this.finish(this.lastChildEndTime ?? this.deps.now());
+            this.finish(this.trimmedEnd());
         }, this.timeouts.idleTimeout);
+    }
+
+    /**
+     * End time for a trimmed close: the later of the injected floor and the last
+     * child's end, so a root never pads out to `now()`. With no children it is the
+     * floor itself (navigation start, or the pageload load-event end); with children
+     * it stretches to cover the last one.
+     */
+    private trimmedEnd(): number {
+        return Math.max(this.deps.endFloor(), this.lastChildEndTime ?? 0);
     }
 
     private clearIdle(): void {

--- a/packages/js/src/tracing/browserTracing.ts
+++ b/packages/js/src/tracing/browserTracing.ts
@@ -3,7 +3,7 @@ import { defaultNowNano, type Config, type Span, type SpanOptions, type Tracer }
 import { collectBrowserSpanContext } from '../browser/context/collectBrowserSpanContext';
 import { fill, unfill } from './fill';
 import { IdleRootController, type IdleTimeouts } from './IdleRootController';
-import { pageloadStartNano, resolvePageloadStartNano } from './navigationTiming';
+import { pageloadEndNano, pageloadStartNano, resolvePageloadStartNano } from './navigationTiming';
 
 /** Structural subset of the js Flare this orchestrator needs. */
 export type BrowserTracingFlare = {
@@ -61,6 +61,9 @@ function startRoot(
                 setTimeout: (fn, ms) => setTimeout(fn, ms),
                 clearTimeout: (handle) => clearTimeout(handle),
                 rootStartTime: startTimeUnixNano,
+                // Childless-close floor: a pageload ends at its real load-event mark,
+                // a navigation at its own start (an instant client nav trims to ~0).
+                endFloor: spanType === 'browser_pageload' ? pageloadEndNano : () => startTimeUnixNano,
             },
             resolveTimeouts(flare.config),
         );

--- a/packages/js/src/tracing/navigationTiming.ts
+++ b/packages/js/src/tracing/navigationTiming.ts
@@ -35,3 +35,36 @@ export function pageloadStartNano(): number {
     const entry = perf.getEntriesByType('navigation')[0] as PerformanceNavigationTiming | undefined;
     return computePageloadStartNano(perf.timeOrigin, entry?.startTime);
 }
+
+/** Pure math seam (unit-testable): timeOrigin(ms) + load-event-end(ms) → unix nanos; `now` when unset. */
+export function computePageloadEndNano(
+    timeOriginMs: number,
+    loadEventEndMs: number | undefined,
+    domContentLoadedEventEndMs: number | undefined,
+    nowNano: number,
+): number {
+    const endMs = loadEventEndMs || domContentLoadedEventEndMs || 0;
+    if (!endMs) return nowNano;
+    return Math.round((timeOriginMs + endMs) * 1e6);
+}
+
+/**
+ * The pageload root's end time in unix nanoseconds, taken from the Navigation
+ * Timing `loadEventEnd` (the browser's own "page finished loading" mark), falling
+ * back to `domContentLoadedEventEnd`, then the tracer's clock when neither has
+ * fired yet or the API is unavailable. Used as the pageload root's close floor so a
+ * childless pageload reports its real load duration rather than idle-timeout padding.
+ */
+export function pageloadEndNano(): number {
+    const perf = (globalThis as { performance?: Performance }).performance;
+    if (!perf || typeof perf.getEntriesByType !== 'function' || typeof perf.timeOrigin !== 'number') {
+        return defaultNowNano();
+    }
+    const entry = perf.getEntriesByType('navigation')[0] as PerformanceNavigationTiming | undefined;
+    return computePageloadEndNano(
+        perf.timeOrigin,
+        entry?.loadEventEnd,
+        entry?.domContentLoadedEventEnd,
+        defaultNowNano(),
+    );
+}

--- a/packages/js/tests/idleRootController.test.ts
+++ b/packages/js/tests/idleRootController.test.ts
@@ -27,7 +27,7 @@ function fakeSpan(id: string, traceId: string, endTime = 0): Span {
 }
 
 // Controllable harness: manual timers keyed by id (deadline in nanos), manual clock, manual listener.
-function harness(root: Span) {
+function harness(root: Span, endFloor: () => number = () => 0) {
     let listener: ((e: { phase: 'start' | 'end'; span: Span }) => void) | null = null;
     let clock = 0;
     const timers = new Map<number, { fn: () => void; at: number }>();
@@ -53,6 +53,7 @@ function harness(root: Span) {
             timers.delete(h as unknown as number);
         },
         rootStartTime: 0,
+        endFloor,
     };
 
     return {
@@ -89,6 +90,26 @@ describe('IdleRootController', () => {
 
         expect(root.end).toHaveBeenCalledWith(500 * 1e6);
         expect(h.setActiveRoot).toHaveBeenLastCalledWith(undefined);
+    });
+
+    it('a childless root ends at the end floor, not padded to now() (the idle-padding bug)', () => {
+        // A pageload whose window had no fetch/xhr children must close at its real
+        // load-event floor (here 700ms), NOT at start + idleTimeout (1000ms).
+        const root = fakeSpan('root', 'T');
+        const h = harness(root, () => 700 * 1e6);
+        const controller = new IdleRootController(h.deps, TIMEOUTS);
+        expect(controller.isEnded).toBe(false);
+        h.advance(1000); // idleTimeout elapses with no child ever started
+        expect(root.end).toHaveBeenCalledWith(700 * 1e6);
+    });
+
+    it('a childless navigation-style root (floor = start) trims to ~zero, not idleTimeout', () => {
+        const root = fakeSpan('root', 'T');
+        const h = harness(root, () => 0); // navigation floor is the root start
+        const controller = new IdleRootController(h.deps, TIMEOUTS);
+        expect(controller.isEnded).toBe(false);
+        h.advance(1000);
+        expect(root.end).toHaveBeenCalledWith(0);
     });
 
     it('a new child before idle fires cancels the pending close', () => {
@@ -157,15 +178,27 @@ describe('IdleRootController', () => {
         expect(root.end).toHaveBeenCalledTimes(1);
     });
 
-    it('endNow ends immediately and is idempotent', () => {
+    it('endNow with no open children ends at the floor (not now()) and is idempotent', () => {
+        // Force-ended (route change / pagehide) while idle: trim to the floor, don't
+        // pad to the moment of the force-end.
         const root = fakeSpan('root', 'T');
-        const h = harness(root);
-        h.setClock(42);
+        const h = harness(root, () => 300 * 1e6);
+        h.setClock(42 * 1e6);
         const c = new IdleRootController(h.deps, TIMEOUTS);
         c.endNow();
         c.endNow();
         expect(root.end).toHaveBeenCalledTimes(1);
-        expect(root.end).toHaveBeenCalledWith(42);
+        expect(root.end).toHaveBeenCalledWith(300 * 1e6);
         expect(c.isEnded).toBe(true);
+    });
+
+    it('endNow with an open child ends at now() (in-flight work is not cut short)', () => {
+        const root = fakeSpan('root', 'T');
+        const h = harness(root, () => 0);
+        const c = new IdleRootController(h.deps, TIMEOUTS);
+        h.emit('start', fakeSpan('c1', 'T')); // child still in flight
+        h.setClock(900 * 1e6);
+        c.endNow();
+        expect(root.end).toHaveBeenCalledWith(900 * 1e6);
     });
 });

--- a/packages/js/tests/navigationTiming.test.ts
+++ b/packages/js/tests/navigationTiming.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 
-import { computePageloadStartNano, resolvePageloadStartNano } from '../src/tracing/navigationTiming';
+import {
+    computePageloadEndNano,
+    computePageloadStartNano,
+    resolvePageloadStartNano,
+} from '../src/tracing/navigationTiming';
 
 describe('computePageloadStartNano', () => {
     it('returns timeOrigin + entry.startTime in nanoseconds', () => {
@@ -34,5 +38,24 @@ describe('resolvePageloadStartNano', () => {
         const backdated = 1_000 * 1e6;
         const now = backdated + 2_000 * 1e6; // within the cap, but already traced
         expect(resolvePageloadStartNano(backdated, now, FINAL, true)).toBe(now);
+    });
+});
+
+describe('computePageloadEndNano', () => {
+    const NOW = 9_999 * 1e6;
+
+    it('returns timeOrigin + loadEventEnd in nanoseconds', () => {
+        // timeOrigin 1_000 ms, loadEventEnd 488 ms → 1_488 ms → * 1e6 ns
+        expect(computePageloadEndNano(1_000, 488, 300, NOW)).toBe(1_488 * 1e6);
+    });
+
+    it('falls back to domContentLoadedEventEnd when the load event has not fired yet', () => {
+        // loadEventEnd 0 (unset) → use DCL 300 ms
+        expect(computePageloadEndNano(1_000, 0, 300, NOW)).toBe(1_300 * 1e6);
+    });
+
+    it('falls back to now when neither the load nor DCL event has fired', () => {
+        expect(computePageloadEndNano(1_000, 0, 0, NOW)).toBe(NOW);
+        expect(computePageloadEndNano(1_000, undefined, undefined, NOW)).toBe(NOW);
     });
 });


### PR DESCRIPTION
Stacked on #69 — targets `research/tracing-framework-routers`, so the diff here is just this fix.

## Summary

Browser `pageload` / `navigation` root spans were reporting durations inflated by the whole `idleTimeout`. A **childless** root (no `fetch`/`xhr` children during its window) closed at `now()` = `start + idleTimeout`, so a real ~488ms pageload showed as **2488ms** with `idleTimeout: 2000`.

## Root cause

`IdleRootController` trims a root's end to the last child's end on idle close, but fell back to `now()` when there were no children (`lastChildEndTime ?? now()`), padding the duration by the full idle window. `endNow()` (route change / `pagehide`) had the same `now()` behavior.

## Fix

Roots now trim to an injected **end floor** instead of `now()`:

- **pageload** → Navigation Timing `loadEventEnd` (the browser's "page finished loading" mark; falls back to `domContentLoadedEventEnd`, then `now()`).
- **navigation** → the nav's own start (an instant client-side nav trims to ~0).
- `endNow()` trims the same way, except when a child is still in flight — then it keeps `now()` so in-progress work isn't cut short.

Fetch-heavy roots are unchanged; they already trimmed to the last child.

## Tests

- `IdleRootController`: childless roots trim to the floor (not `now()`); `endNow` trims unless a child is open.
- `navigationTiming`: `computePageloadEndNano` (loadEventEnd → domContentLoadedEventEnd → now fallbacks).
- Full `@flareapp/js` suite green (154), typecheck + lint clean.

Verified in the JS playground against a local Flare: the pageload that read 2488ms now reports its real ~488ms.
