### PR TITLE
React component profiler (@flareapp/react/profiler)

### DIFF
--- a/docs/superpowers/specs/2026-07-10-react-component-profiler-design.md
+++ b/docs/superpowers/specs/2026-07-10-react-component-profiler-design.md
@@ -1,0 +1,237 @@
+# React Component Profiler — Design
+
+Status: approved (brainstorm)
+Date: 2026-07-10
+Branch: `feat/react-component-profiler` (off `research/tracing-framework-routers`, tip `10d91ce`)
+Supersedes: the uncommitted POC (`packages/react/src/profiler.ts` + playground wiring), which is a reference only.
+
+## Goal
+
+Give `@flareapp/react` users an opt-in profiler so that each wrapped component records one
+`browser_react_component` span for its mount, nested as a true tree (by `parent_span_id`) under the active
+`browser_pageload` / `browser_navigation` root. The result is a per-navigation mount waterfall of the component
+subtree:
+
+```
+browser_navigation  /product/$id  (312ms)
+ └─ ProductPage            (240ms)
+     ├─ ProductGallery     (180ms)
+     ├─ ProductInfo         (32ms)
+     └─ AddToCartButton     (12ms)
+```
+
+This is the client half only. The flareapp.io backend must officially recognize the `browser_react_component`
+SpanType (map, label, render the component name). That is a hard dependency tracked separately (see
+[Backend dependency](#backend-dependency)); today it exists only as a local uncommitted tweak.
+
+## Scope decisions (locked during brainstorm)
+
+- **What we capture:** mount timing only. Re-render / update / render-lifetime spans (Sentry's `ui.react.update`
+  and `ui.react.render`) are the natural next slice and are out of scope for v1.
+- **How components are instrumented:** manual opt-in. No build-time / Babel plugin. Users wrap the components
+  they care about.
+- **API surface:** a `<FlareProfiler name>` component (the primitive) and a `withFlareProfiler(Component, { name? })`
+  HOC (thin sugar). No `useFlareProfiler` hook in v1.
+- **Nesting:** a true component tree via `parent_span_id`. This deliberately exceeds Sentry, which keeps mount
+  spans flat under the transaction. It is required here because Flare's trace waterfall nests structurally by
+  `parent_span_id` (`resources/js/domain/perf-monitoring/components/sp-agg-traces/helpers.ts`), so a flat model
+  would render as a flat list, not a tree.
+- **Backend:** client-only branch; backend SpanType support is a tracked dependency.
+
+## Why not just copy Sentry
+
+Validated against `getsentry/sentry-javascript` `packages/react/src/profiler.tsx` (verbatim source):
+
+- Sentry's `render()` returns `this.props.children` directly, with no `withActiveSpan` wrap, and creates the mount
+  span in the **constructor** via `startInactiveSpan({ op: 'ui.react.mount', onlyIfParent: true })`. That parents
+  every mount span to whatever is active at render time — always the transaction. So Sentry's component spans are
+  **flat siblings under the transaction**, nested only by time, not structurally. We diverge here on purpose.
+- Sentry has **no StrictMode handling**; its constructor-created span leaks for the discarded StrictMode instance.
+  That is harmless for Sentry because a transaction drops unfinished child spans on close. Flare cannot copy this:
+  `IdleRootController` blocks idle-close on open children, which is exactly the POC's 15006ms `childSpanTimeout`
+  bug. Our record-in-effect model (start and end together) is therefore mandatory, not a nicety.
+- We do adopt Sentry's proven choices: name resolution (`name || displayName || name || Unknown`), root-gating
+  (Sentry's `onlyIfParent`), and mount-first scope with updates as a follow-up.
+
+## Architecture
+
+Three pieces, with the tracer coupling isolated to a single seam module.
+
+### 1. Core: one new field (`packages/core`)
+
+`SpanOptions` gains `spanId?: string`. `Tracer.startSpan` uses `opts.spanId ?? makeSpanId()`. `parent`
+(already accepts `{ traceId, spanId }`), `startTimeUnixNano`, and `.end(endTime)` already exist, so this single
+field is the entire core cost. It is a general manual-stitching primitive, not profiler-specific.
+
+Current shape (`packages/core/src/types.ts`):
+
+```ts
+export type SpanOptions = {
+    parent?: Span | { traceId: string; spanId: string };
+    attributes?: Attributes;
+    startTimeUnixNano?: number;
+    spanType?: string;
+    forceRoot?: boolean;
+    spanId?: string; // NEW: explicit span id for manual stitching
+};
+```
+
+### 2. `@flareapp/js/browser` seam (`packages/js/src/tracing/componentProfiler.ts`)
+
+A side-effect-free module (imported like `registerNavigationSource`) that hides all tracer coupling behind three
+functions bound to the singleton browser tracer:
+
+```ts
+export type ComponentTraceContext = { traceId: string; parentSpanId: string };
+
+// The active pageload/navigation root a top-level component should nest under.
+// Returns null when tracing is off, no root is active, or the root is not recording.
+export function activeComponentRoot(): ComponentTraceContext | null;
+
+// A 16-hex span id a component reserves for itself, so its descendants can reference
+// it as their parent before this component's span is actually recorded.
+export function reserveSpanId(): string;
+
+// Record a completed mount span (spanType 'browser_react_component'). No-op when
+// tracing is off or not recording. Follows the ROOT's sampling decision by reusing the
+// existing trace state (it never re-samples per component).
+export function recordComponentSpan(span: {
+    name: string;
+    spanId: string;
+    parent: ComponentTraceContext;
+    startTimeUnixNano: number;
+    endTimeUnixNano: number;
+    attributes?: Record<string, unknown>;
+}): void;
+```
+
+`recordComponentSpan` is implemented as `tracer.startSpan(name, { spanId, parent: { traceId, spanId: parentSpanId },
+spanType: 'browser_react_component', startTimeUnixNano, attributes }).end(endTimeUnixNano)`. Because the parent is a
+plain `{ traceId, spanId }` whose trace state already exists (seeded by the root), the tracer reuses that state and
+its recording decision rather than re-sampling.
+
+### 3. `@flareapp/react/profiler` (`packages/react/src/profiler.ts`)
+
+`createElement`-based (no JSX), importing only `react` and `@flareapp/js/browser` — Electron-safe, matching
+`tanstack-router.ts`.
+
+- `FlareProfilerContext`: a React context carrying `ComponentTraceContext | null`.
+- `<FlareProfiler name>` (function component):
+    - Resolves its parent once into a ref: `resolvedParent = context ?? activeComponentRoot()`, where `context` is
+      the value of `FlareProfilerContext`. A non-null context means a profiled ancestor exists; a null context at
+      the top of a profiled subtree falls back to the active root.
+    - **If `resolvedParent` is null** (no profiled ancestor and no active recording root), the component is fully
+      transparent: it reserves nothing, records nothing, and passes the null context through unchanged so its
+      descendants also no-op. It still renders its children.
+    - **Otherwise** it reserves its own `spanId` (`reserveSpanId()`) and captures `startNano` at first render (both
+      in lazy refs), provides `{ traceId: resolvedParent.traceId, parentSpanId: ownSpanId }` to children, and in a
+      mount `useLayoutEffect` (falling back to `useEffect` under SSR, to match `componentDidMount` timing while
+      preserving bottom-up ordering) calls `recordComponentSpan(...)` with `resolvedParent`, its reserved id,
+      `startNano`, and the current time as end.
+- `withFlareProfiler(Component, { name? })`: renders `<FlareProfiler name={resolvedName}>` around `Component`.
+
+## Timing and nesting model (the crux)
+
+- `startNano` is captured at first render (the component begins mounting). `endNano` is captured in the mount
+  effect (the subtree has mounted).
+- React renders top-down (a parent's `startNano` precedes its children's) and fires mount effects bottom-up (a
+  child's `endNano` precedes its parent's). So a parent `[start, end]` encloses every child both by time and by
+  `parent_span_id`. Both axes agree; the waterfall nests correctly.
+- Reserved ids solve the ordering trap: a child records in its own effect _before_ its parent's effect runs, but
+  it already knows the parent's reserved id from render-time context, so the structural link is available even
+  though the parent's span object does not exist yet.
+- Unprofiled intermediate components are transparent: the context passes through unchanged, so a child nests
+  under the nearest _profiled_ ancestor.
+- Orphan degradation: if a profiled ancestor's span is dropped (sampling or `maxSpansPerTrace`), its descendants'
+  `parent_span_id` points at a missing span. Flare's tree builder treats that as an orphan and reparents it to the
+  root (`sp-agg-traces/helpers.ts:74`). Acceptable; covered by a test.
+
+## StrictMode and leak-safety
+
+Start and end are recorded together in the mount effect, so only committed fibers ever touch the tracer. There is
+no open-span leak. This is mandatory: `IdleRootController` blocks idle-close on open children (the POC's 15006ms
+`childSpanTimeout`), unlike Sentry's transaction which drops unfinished spans.
+
+Documented runtime consequence: under React `<StrictMode>` in development, mount → unmount → remount produces
+**two** `browser_react_component` spans per component; production produces **one**. This must be called out in the
+docs so the duplicate dev spans are not read as a bug.
+
+## Config, gating, overhead
+
+- Gated on `enableTracing` and an active, recording root: `activeComponentRoot()` returns null otherwise and the
+  component records nothing.
+- Follows the root's sampling decision; no per-component re-sampling.
+- No separate `enableReactProfiler` flag or profiler-specific sample rate in v1 (YAGNI). Wrapping a component is
+  the opt-in.
+- Cost when not recording: one context read plus a null check per profiled component; no span work.
+
+## Naming
+
+Resolution order: explicit `name` prop / `options.name` > `Component.displayName` > `Component.name` > `'Unknown'`
+(matches Sentry and the POC). Written to the attribute `flare.react.component` and to `span.name`. The backend
+label falls back to `span.name`, so the component name surfaces even without the attribute.
+
+Production minification can mangle `Component.name`. The docs recommend passing an explicit `name` or setting
+`displayName` for production builds. Build-plugin auto-naming is out of scope.
+
+## Error handling
+
+Every seam call and every effect body is wrapped so instrumentation never throws into the host application (the
+`tanstack-router` discipline). The seam functions additionally no-op internally when tracing is off or no root is
+active.
+
+## Testing
+
+- `packages/react/tests/profiler.test.tsx` (vitest + @testing-library/react + jsdom; already devDependencies):
+    - single component records one span with the correct name, `browser_react_component` type, parent equal to the
+      active root, and a non-negative duration;
+    - nested components: a child's `parent_span_id` equals its parent's reserved span id;
+    - a transparent (unprofiled) middle component: a grandchild nests under the nearest profiled ancestor;
+    - no active root: nothing recorded, children still render;
+    - tracing disabled: nothing recorded;
+    - name precedence (explicit > displayName > name);
+    - never throws when the seam throws (inject a throwing seam);
+    - StrictMode double-mount: two spans in development (documents the behavior);
+    - orphan: a child whose profiled parent's span is absent still records with a `parent_span_id` (graceful).
+- `packages/js/tests/componentProfiler.test.ts`:
+    - `activeComponentRoot()` returns the root context when a recording root is active; null when tracing is off,
+      no root is active, or the root is not recording;
+    - `recordComponentSpan(...)` buffers a `browser_react_component` span with the right ids, parent, and times, and
+      follows the root's recording decision (no re-sample).
+- `packages/core`: `startSpan` honors an explicit `spanId`.
+- Playground: wire a handful of components in `playgrounds/react` (for example ProductsPage, ProductPage,
+  ProductGallery, AddToCartButton) to exercise the tree for manual and e2e runs. The local-only `flare.ts` test
+  tweaks (pointing at `flareapp.io.test`) stay out of commits.
+- e2e: one `react` spec asserting that component spans arrive nested under the navigation root via the fake
+  server. This is the largest-effort item; it is included but may be deferred if the plan grows too long.
+
+## File structure
+
+- `packages/core/src/types.ts` — add `spanId?` to `SpanOptions`.
+- `packages/core/src/tracing/Tracer.ts` — `opts.spanId ?? makeSpanId()`.
+- `packages/core/tests/…` — explicit-`spanId` test.
+- `packages/js/src/tracing/componentProfiler.ts` — the seam (new).
+- `packages/js/src/browser.ts` — export the seam.
+- `packages/js/tests/componentProfiler.test.ts` — seam tests (new).
+- `packages/react/src/profiler.ts` — `FlareProfiler` + `withFlareProfiler` + context (rewrites the POC file).
+- `packages/react/tests/profiler.test.tsx` — component tests (new).
+- `packages/react/package.json` — `./profiler` export and build entry are already wired.
+- `playgrounds/react/*` — wiring.
+- README section for `@flareapp/react/profiler`.
+
+## Backend dependency
+
+Handled separately in flareapp.io, not in this branch:
+
+- add a `browser_react_component` case to the monitoring `SpanType` enum;
+- map/label it and render the component name in the trace waterfall (the current local tweak, done properly).
+
+Until this lands, component spans store as `unknown` for other users. The feature is not end-to-end without it.
+
+## Out of scope (v1)
+
+- Automatic build-plugin (Babel/SWC) instrumentation.
+- Update / re-render / render-lifetime spans (Sentry's `ui.react.update` / `ui.react.render`) — the clean next
+  slice.
+- `useFlareProfiler` hook.
+- Per-component enable flag.

--- a/docs/superpowers/specs/2026-07-10-react-component-profiler-design.md
+++ b/docs/superpowers/specs/2026-07-10-react-component-profiler-design.md
@@ -1,9 +1,16 @@
 # React Component Profiler — Design
 
-Status: approved (brainstorm)
-Date: 2026-07-10
+Status: revised post-review — ready for planning
+Date: 2026-07-10 (revised 2026-07-10 after design review)
 Branch: `feat/react-component-profiler` (off `research/tracing-framework-routers`, tip `10d91ce`)
 Supersedes: the uncommitted POC (`packages/react/src/profiler.ts` + playground wiring), which is a reference only.
+
+Revision (2026-07-10, post-review): closed three timing/sampling gaps found in review. (1) `recordComponentSpan`
+now gates on the live root (`tracer.getActiveSpan()` still matching the reserved `traceId`) and drops the span
+otherwise, so a late / racing / post-idle mount can never seed a fresh `TraceState` and re-sample — the
+no-re-sample invariant now holds by construction. (2) A `hasRecorded` ref guards the mount effect so StrictMode's
+replayed setup cannot buffer a duplicate `spanId`; dev and production both emit one span (the earlier "two spans in
+dev" note is dropped). (3) Suspense is a documented v1 limitation, not engineered around.
 
 ## Goal
 
@@ -84,17 +91,22 @@ functions bound to the singleton browser tracer:
 ```ts
 export type ComponentTraceContext = { traceId: string; parentSpanId: string };
 
-// The active pageload/navigation root a top-level component should nest under.
-// Returns null when tracing is off, no root is active, or the root is not recording.
+// The active pageload/navigation root a top-level component should nest under, read
+// from `tracer.getActiveSpan()` (the holder's active root, which IdleRootController
+// clears on close). Returns null when tracing is off, no root is active, or the root
+// is not recording.
 export function activeComponentRoot(): ComponentTraceContext | null;
 
 // A 16-hex span id a component reserves for itself, so its descendants can reference
 // it as their parent before this component's span is actually recorded.
 export function reserveSpanId(): string;
 
-// Record a completed mount span (spanType 'browser_react_component'). No-op when
-// tracing is off or not recording. Follows the ROOT's sampling decision by reusing the
-// existing trace state (it never re-samples per component).
+// Record a completed mount span (spanType 'browser_react_component'). Records ONLY
+// while the reserved root is still the live, recording active root (its traceId still
+// matches `tracer.getActiveSpan()`); otherwise it DROPS the span. That is what makes
+// the "reuse the root's decision, never re-sample per component" guarantee hold: it
+// either records under the live root (whose TraceState still exists, so the decision
+// is reused) or records nothing. No-op when tracing is off.
 export function recordComponentSpan(span: {
     name: string;
     spanId: string;
@@ -105,10 +117,26 @@ export function recordComponentSpan(span: {
 }): void;
 ```
 
-`recordComponentSpan` is implemented as `tracer.startSpan(name, { spanId, parent: { traceId, spanId: parentSpanId },
-spanType: 'browser_react_component', startTimeUnixNano, attributes }).end(endTimeUnixNano)`. Because the parent is a
-plain `{ traceId, spanId }` whose trace state already exists (seeded by the root), the tracer reuses that state and
-its recording decision rather than re-sampling.
+`recordComponentSpan` first gates on the live root: `const root = tracer.getActiveSpan(); if (!root || root.traceId
+!== parent.traceId || !root.isRecording) return;`. `getActiveSpan()` returns the holder's active root, which
+`IdleRootController.finish` clears to `undefined` on close, so a matching `traceId` proves the reserved root is still
+open (unlike the module-global `currentRoot`, which is not nulled on idle-close). Exposing it means widening the
+`BrowserTracingFlare.tracer` `Pick` to include `getActiveSpan` (the runtime object is a full `Tracer`).
+
+When the gate passes, the root's `TraceState` is still in `traceStates`, so `tracer.startSpan(name, { spanId,
+parent: { traceId, spanId: parentSpanId }, spanType: 'browser_react_component', startTimeUnixNano, attributes
+}).end(endTimeUnixNano)` reuses that state and its recording decision — the plain `{ traceId, spanId }` parent path
+in `resolveTrace` finds existing state and does not re-sample.
+
+When the gate fails — the root idle-closed during a mount gap, or a later navigation replaced it — the span is
+dropped. This is deliberate: without the gate, `startSpan` would find no `TraceState` for the dead trace, seed a
+fresh one, and re-sample it independently via `resolveSampling`, producing a re-sampled, root-detached phantom child
+of an already-shipped root. Dropping keeps the per-component no-re-sample invariant true by construction.
+
+The common case is not dropped: each recorded component span is a start+end pair, and `IdleRootController` re-arms
+the root's idle timer every time a child span ends, so a continuously-mounting subtree keeps its own root alive.
+Only a mount gap longer than `idleTimeout` (typically a Suspense data wait) or a subsequent navigation trips the
+drop path.
 
 ### 3. `@flareapp/react/profiler` (`packages/react/src/profiler.ts`)
 
@@ -126,8 +154,10 @@ its recording decision rather than re-sampling.
     - **Otherwise** it reserves its own `spanId` (`reserveSpanId()`) and captures `startNano` at first render (both
       in lazy refs), provides `{ traceId: resolvedParent.traceId, parentSpanId: ownSpanId }` to children, and in a
       mount `useLayoutEffect` (falling back to `useEffect` under SSR, to match `componentDidMount` timing while
-      preserving bottom-up ordering) calls `recordComponentSpan(...)` with `resolvedParent`, its reserved id,
-      `startNano`, and the current time as end.
+      preserving bottom-up ordering) records its span exactly once — a `hasRecorded` ref guards the effect body so
+      StrictMode's replayed setup does not buffer a second span under the same reserved id (see
+      [StrictMode](#strictmode-and-leak-safety)) — calling `recordComponentSpan(...)` with `resolvedParent`, its
+      reserved id, `startNano`, and the current time as end.
 - `withFlareProfiler(Component, { name? })`: renders `<FlareProfiler name={resolvedName}>` around `Component`.
 
 ## Timing and nesting model (the crux)
@@ -135,8 +165,10 @@ its recording decision rather than re-sampling.
 - `startNano` is captured at first render (the component begins mounting). `endNano` is captured in the mount
   effect (the subtree has mounted).
 - React renders top-down (a parent's `startNano` precedes its children's) and fires mount effects bottom-up (a
-  child's `endNano` precedes its parent's). So a parent `[start, end]` encloses every child both by time and by
-  `parent_span_id`. Both axes agree; the waterfall nests correctly.
+  child's `endNano` precedes its parent's). Within a single synchronous commit a parent `[start, end]` therefore
+  encloses every child both by time and by `parent_span_id`, and the waterfall nests correctly. This holds only
+  within a synchronous commit; a `<Suspense>` boundary inside the subtree can break enclosure (see
+  [Suspense](#suspense)).
 - Reserved ids solve the ordering trap: a child records in its own effect _before_ its parent's effect runs, but
   it already knows the parent's reserved id from render-time context, so the structural link is available even
   though the parent's span object does not exist yet.
@@ -144,7 +176,23 @@ its recording decision rather than re-sampling.
   under the nearest _profiled_ ancestor.
 - Orphan degradation: if a profiled ancestor's span is dropped (sampling or `maxSpansPerTrace`), its descendants'
   `parent_span_id` points at a missing span. Flare's tree builder treats that as an orphan and reparents it to the
-  root (`sp-agg-traces/helpers.ts:74`). Acceptable; covered by a test.
+  root (`sp-agg-traces/helpers.ts:74`). Acceptable; covered by a test. Because effects fire bottom-up, an ancestor
+  is recorded after its descendants and so is the more likely victim of a `maxSpansPerTrace` cap; orphaning is the
+  designed-for degradation, not a rare edge.
+- Late-mount drop: a component records only while its reserved root is still the live active root (the seam's
+  live-root gate). A subtree that finishes mounting after the root idle-closed, or whose root a later navigation
+  replaced, records nothing rather than re-sampling and attaching to a dead trace.
+
+## Suspense
+
+`<Suspense>` inside a profiled subtree is a documented v1 limitation, not engineered around. There is no
+Suspense-specific code: the live-root gate already covers the one case that needs handling (a child that resumes
+after its root closed is dropped, not re-sampled). Two behaviors to note in the docs so they are not read as bugs:
+
+- A suspended child's `startNano` is captured before it suspends, so its span covers the suspense wait. Read the
+  duration as "time to mount, including data waits in the subtree."
+- A `<Suspense>` boundary between a profiled parent and child can end the parent span before the child resumes, so
+  the child may render outside its parent in the waterfall, or (if the wait exceeds `idleTimeout`) be dropped.
 
 ## StrictMode and leak-safety
 
@@ -152,15 +200,21 @@ Start and end are recorded together in the mount effect, so only committed fiber
 no open-span leak. This is mandatory: `IdleRootController` blocks idle-close on open children (the POC's 15006ms
 `childSpanTimeout`), unlike Sentry's transaction which drops unfinished spans.
 
-Documented runtime consequence: under React `<StrictMode>` in development, mount → unmount → remount produces
-**two** `browser_react_component` spans per component; production produces **one**. This must be called out in the
-docs so the duplicate dev spans are not read as a bug.
+Record-once guard: under React `<StrictMode>` in development React runs the mount effect twice on the same fiber
+(setup → cleanup → setup) to surface effect bugs. The reserved `spanId` and `startNano` live in refs that persist
+across that replay, so an unguarded effect would buffer the span **twice with the same `spanId`** — a span-id
+collision in the trace, not two distinct spans. A `hasRecorded` ref makes the effect record exactly once per
+committed fiber: the first setup records and sets the flag; the replayed setup no-ops. A genuine unmount/remount is
+a new fiber with a fresh ref and correctly records a new span. Dev and production both emit one span per mount, so
+there is no duplicate dev behavior to document.
 
 ## Config, gating, overhead
 
 - Gated on `enableTracing` and an active, recording root: `activeComponentRoot()` returns null otherwise and the
   component records nothing.
-- Follows the root's sampling decision; no per-component re-sampling.
+- Follows the root's sampling decision, never re-sampling per component: a component span is either recorded under
+  the live root (reusing its `TraceState` and decision) or dropped (the seam's live-root gate; see [Timing and
+  nesting model](#timing-and-nesting-model-the-crux)). No code path samples a component independently.
 - No separate `enableReactProfiler` flag or profiler-specific sample rate in v1 (YAGNI). Wrapping a component is
   the opt-in.
 - Cost when not recording: one context read plus a null check per profiled component; no span work.
@@ -191,13 +245,20 @@ active.
     - tracing disabled: nothing recorded;
     - name precedence (explicit > displayName > name);
     - never throws when the seam throws (inject a throwing seam);
-    - StrictMode double-mount: two spans in development (documents the behavior);
-    - orphan: a child whose profiled parent's span is absent still records with a `parent_span_id` (graceful).
+    - StrictMode: the record-once guard emits exactly one span per mount in development (not two) with no duplicate
+      `spanId`;
+    - orphan: a child whose profiled parent's span is absent still records with a `parent_span_id` (graceful);
+    - late mount: a component whose reserved root has already ended when its mount effect runs records nothing (no
+      re-sample, no root-detached span);
+    - Suspense boundary: a suspended child records under its profiled ancestor when it resumes within the root
+      window (documents the timing behavior).
 - `packages/js/tests/componentProfiler.test.ts`:
     - `activeComponentRoot()` returns the root context when a recording root is active; null when tracing is off,
       no root is active, or the root is not recording;
     - `recordComponentSpan(...)` buffers a `browser_react_component` span with the right ids, parent, and times, and
-      follows the root's recording decision (no re-sample).
+      follows the root's recording decision (no re-sample);
+    - `recordComponentSpan(...)` drops the span (nothing buffered, no re-sample) when `tracer.getActiveSpan()` no
+      longer matches the parent's `traceId` — the root idle-closed or a new navigation root took over.
 - `packages/core`: `startSpan` honors an explicit `spanId`.
 - Playground: wire a handful of components in `playgrounds/react` (for example ProductsPage, ProductPage,
   ProductGallery, AddToCartButton) to exercise the tree for manual and e2e runs. The local-only `flare.ts` test
@@ -211,6 +272,8 @@ active.
 - `packages/core/src/tracing/Tracer.ts` — `opts.spanId ?? makeSpanId()`.
 - `packages/core/tests/…` — explicit-`spanId` test.
 - `packages/js/src/tracing/componentProfiler.ts` — the seam (new).
+- `packages/js/src/tracing/browserTracing.ts` — widen the `BrowserTracingFlare.tracer` `Pick` to expose
+  `getActiveSpan` for the seam's live-root gate.
 - `packages/js/src/browser.ts` — export the seam.
 - `packages/js/tests/componentProfiler.test.ts` — seam tests (new).
 - `packages/react/src/profiler.ts` — `FlareProfiler` + `withFlareProfiler` + context (rewrites the POC file).
@@ -235,3 +298,5 @@ Until this lands, component spans store as `unknown` for other users. The featur
   slice.
 - `useFlareProfiler` hook.
 - Per-component enable flag.
+- Suspense-boundary-aware timing. v1 documents the distortion (see [Suspense](#suspense)) instead of resetting or
+  clamping spans across boundaries.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -62,6 +62,7 @@ export {
     buildTracesEnvelope,
     buildTraceparent,
     parseTraceparent,
+    spanId,
 } from './tracing';
 export type { TracerDeps, ActiveSpanHolder } from './tracing';
 

--- a/packages/core/src/tracing/Tracer.ts
+++ b/packages/core/src/tracing/Tracer.ts
@@ -159,7 +159,7 @@ export class Tracer {
 
     startSpan(name: string, opts: SpanOptions = {}): Span {
         const config = this.deps.getConfig();
-        const spanId = makeSpanId();
+        const spanId = opts.spanId ?? makeSpanId();
 
         // The pending continuation (continueFromTraceparent) is a strict one-shot for
         // the NEXT startSpan, whatever that span turns out to be: consumed by a

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -196,6 +196,8 @@ export type SpanOptions = {
      * root opened inside `withSpan(...)` does not become a mid-trace child.
      */
     forceRoot?: boolean;
+    /** Use this exact span id instead of generating one (manual span stitching). */
+    spanId?: string;
 };
 
 export interface Span {

--- a/packages/core/tests/tracer.test.ts
+++ b/packages/core/tests/tracer.test.ts
@@ -261,6 +261,15 @@ describe('Tracer.startSpan', () => {
         });
         expect(child?.traceId).toBe(outerTraceId); // contrast: default nests
     });
+
+    it('uses an explicit spanId from opts instead of generating one', () => {
+        const tracer = makeTracer(config());
+        const root = tracer.startSpan('root');
+        const child = tracer.startSpan('child', { parent: root, spanId: 'abc1230000000000' });
+        expect(child.spanId).toBe('abc1230000000000');
+        expect(child.parentSpanId).toBe(root.spanId);
+        expect(child.traceId).toBe(root.traceId);
+    });
 });
 
 describe('defaultNowNano', () => {

--- a/packages/js/src/browser.ts
+++ b/packages/js/src/browser.ts
@@ -63,3 +63,4 @@ export {
     nowNano,
     type ComponentTraceContext,
 } from './tracing/componentProfiler';
+export { BrowserSpanType } from './tracing/spanTypes';

--- a/packages/js/src/browser.ts
+++ b/packages/js/src/browser.ts
@@ -56,3 +56,10 @@ export { collectBrowser } from './browser/context/collectBrowser';
 export { FetchFileReader } from './browser/FetchFileReader';
 export { BrowserFlushScheduler } from './browser/BrowserFlushScheduler';
 export { registerNavigationSource, type NavigationSource, type RouteName } from './tracing/browserTracing';
+export {
+    activeComponentRoot,
+    reserveSpanId,
+    recordComponentSpan,
+    nowNano,
+    type ComponentTraceContext,
+} from './tracing/componentProfiler';

--- a/packages/js/src/tracing/browserTracing.ts
+++ b/packages/js/src/tracing/browserTracing.ts
@@ -9,7 +9,7 @@ import { pageloadEndNano, pageloadStartNano, resolvePageloadStartNano } from './
 export type BrowserTracingFlare = {
     readonly config: Config;
     startSpan(name: string, opts?: SpanOptions): Span;
-    tracer: Pick<Tracer, 'addSpanListener' | 'setActiveRoot' | 'flush'>;
+    tracer: Pick<Tracer, 'addSpanListener' | 'setActiveRoot' | 'flush' | 'getActiveSpan'>;
 };
 
 export type RouteName = { name: string; source: 'route' | 'url' };
@@ -245,4 +245,12 @@ export function registerNavigationSource(): NavigationSource {
             lastPath = here();
         },
     };
+}
+
+/**
+ * Internal accessor for sibling tracing modules (the component-profiler seam) that
+ * need the live tracer. Returns the Flare currently driving browser tracing, or null.
+ */
+export function activeTracingFlare(): BrowserTracingFlare | null {
+    return activeFlare;
 }

--- a/packages/js/src/tracing/browserTracing.ts
+++ b/packages/js/src/tracing/browserTracing.ts
@@ -4,6 +4,7 @@ import { collectBrowserSpanContext } from '../browser/context/collectBrowserSpan
 import { fill, unfill } from './fill';
 import { IdleRootController, type IdleTimeouts } from './IdleRootController';
 import { pageloadEndNano, pageloadStartNano, resolvePageloadStartNano } from './navigationTiming';
+import { BrowserSpanType } from './spanTypes';
 
 /** Structural subset of the js Flare this orchestrator needs. */
 export type BrowserTracingFlare = {
@@ -40,7 +41,7 @@ function resolveTimeouts(config: Config): IdleTimeouts {
 
 function startRoot(
     flare: BrowserTracingFlare,
-    spanType: string,
+    spanType: BrowserSpanType,
     startTimeUnixNano: number,
     name: string = location.pathname,
 ): void {
@@ -63,7 +64,7 @@ function startRoot(
                 rootStartTime: startTimeUnixNano,
                 // Childless-close floor: a pageload ends at its real load-event mark,
                 // a navigation at its own start (an instant client nav trims to ~0).
-                endFloor: spanType === 'browser_pageload' ? pageloadEndNano : () => startTimeUnixNano,
+                endFloor: spanType === BrowserSpanType.Pageload ? pageloadEndNano : () => startTimeUnixNano,
             },
             resolveTimeouts(flare.config),
         );
@@ -100,7 +101,7 @@ function onUrlChanged(flare: BrowserTracingFlare): void {
             // A failing prior-root teardown must not stop the new root from starting.
         }
     }
-    startRoot(flare, 'browser_navigation', defaultNowNano(), path);
+    startRoot(flare, BrowserSpanType.Navigation, defaultNowNano(), path);
 }
 
 /**
@@ -124,7 +125,7 @@ export function startBrowserTracing(flare: BrowserTracingFlare): void {
         pageloadTraced,
     );
     pageloadTraced = true;
-    startRoot(flare, 'browser_pageload', pageloadStart);
+    startRoot(flare, BrowserSpanType.Pageload, pageloadStart);
 
     const handle = (): void => {
         // A third party may wrap history.pushState/replaceState on top of ours,
@@ -225,7 +226,7 @@ export function registerNavigationSource(): NavigationSource {
                     // a failing prior-root teardown must not stop the new root
                 }
             }
-            startRoot(activeFlare, 'browser_navigation', defaultNowNano(), path);
+            startRoot(activeFlare, BrowserSpanType.Navigation, defaultNowNano(), path);
         },
         setActiveRouteName(route) {
             if (!active()) return;

--- a/packages/js/src/tracing/componentProfiler.ts
+++ b/packages/js/src/tracing/componentProfiler.ts
@@ -4,10 +4,9 @@
 import { defaultNowNano, spanId as makeSpanId } from '@flareapp/core';
 
 import { activeTracingFlare } from './browserTracing';
+import { BrowserSpanType } from './spanTypes';
 
 export type ComponentTraceContext = { traceId: string; parentSpanId: string };
-
-const COMPONENT_SPAN_TYPE = 'browser_react_component';
 
 /** Unix nanos on the same clock the tracer uses for span timestamps. */
 export const nowNano = defaultNowNano;
@@ -56,7 +55,7 @@ export function recordComponentSpan(span: {
             .startSpan(span.name, {
                 spanId: span.spanId,
                 parent: { traceId: span.parent.traceId, spanId: span.parent.parentSpanId },
-                spanType: COMPONENT_SPAN_TYPE,
+                spanType: BrowserSpanType.ReactComponent,
                 startTimeUnixNano: span.startTimeUnixNano,
                 attributes: { ...span.attributes, 'flare.react.component': span.name },
             })

--- a/packages/js/src/tracing/componentProfiler.ts
+++ b/packages/js/src/tracing/componentProfiler.ts
@@ -1,0 +1,67 @@
+// Side-effect-free component-profiler seam for @flareapp/react/profiler. Hides all
+// tracer coupling behind four functions bound to the singleton browser tracer, the
+// same discipline as registerNavigationSource. Imported from '@flareapp/js/browser'.
+import { defaultNowNano, spanId as makeSpanId } from '@flareapp/core';
+
+import { activeTracingFlare } from './browserTracing';
+
+export type ComponentTraceContext = { traceId: string; parentSpanId: string };
+
+const COMPONENT_SPAN_TYPE = 'browser_react_component';
+
+/** Unix nanos on the same clock the tracer uses for span timestamps. */
+export const nowNano = defaultNowNano;
+
+/** Reserve a 16-hex span id a component uses as its own, so descendants can point at it. */
+export function reserveSpanId(): string {
+    return makeSpanId();
+}
+
+/**
+ * The active pageload/navigation root a top-level component should nest under, read
+ * from the holder's active root (which IdleRootController clears on close). Null when
+ * tracing is off, no root is active, or the root is not recording.
+ */
+export function activeComponentRoot(): ComponentTraceContext | null {
+    try {
+        const root = activeTracingFlare()?.tracer.getActiveSpan();
+        if (!root || !root.isRecording) return null;
+        return { traceId: root.traceId, parentSpanId: root.spanId };
+    } catch {
+        return null;
+    }
+}
+
+/**
+ * Record a completed mount span. Records ONLY while the reserved root is still the
+ * live, recording active root (its traceId still matches getActiveSpan()); otherwise
+ * it DROPS the span. Dropping avoids seeding a fresh TraceState for a dead trace
+ * (which would re-sample) and attaching a phantom child to an already-shipped root.
+ * No-op when tracing is off. Never throws into the host.
+ */
+export function recordComponentSpan(span: {
+    name: string;
+    spanId: string;
+    parent: ComponentTraceContext;
+    startTimeUnixNano: number;
+    endTimeUnixNano: number;
+    attributes?: Record<string, unknown>;
+}): void {
+    try {
+        const flare = activeTracingFlare();
+        if (!flare) return;
+        const root = flare.tracer.getActiveSpan();
+        if (!root || root.traceId !== span.parent.traceId || !root.isRecording) return;
+        flare
+            .startSpan(span.name, {
+                spanId: span.spanId,
+                parent: { traceId: span.parent.traceId, spanId: span.parent.parentSpanId },
+                spanType: COMPONENT_SPAN_TYPE,
+                startTimeUnixNano: span.startTimeUnixNano,
+                attributes: { ...span.attributes, 'flare.react.component': span.name },
+            })
+            .end(span.endTimeUnixNano);
+    } catch {
+        // instrumentation must never throw into the host app
+    }
+}

--- a/packages/js/src/tracing/index.ts
+++ b/packages/js/src/tracing/index.ts
@@ -5,3 +5,4 @@ export { fill, unfill } from './fill';
 export { isNativeFetch, supportsNativeFetch } from './supportsNativeFetch';
 export { startBrowserTracing, stopBrowserTracing, type BrowserTracingFlare } from './browserTracing';
 export { type HttpTracer } from './httpRequestSpan';
+export { BrowserSpanType } from './spanTypes';

--- a/packages/js/src/tracing/instrumentFetch.ts
+++ b/packages/js/src/tracing/instrumentFetch.ts
@@ -9,6 +9,7 @@ import {
     traceparentFor,
 } from './httpRequestSpan';
 import { type FetchInput, mergeTraceparentHeader } from './propagation';
+import { BrowserSpanType } from './spanTypes';
 import { supportsNativeFetch } from './supportsNativeFetch';
 
 function resolveRequest(input: FetchInput, init: RequestInit | undefined): { method: string; url: string } {
@@ -44,7 +45,7 @@ export function createFetchWrapper(tracer: HttpTracer, original: typeof fetch, o
         const pathname = abs ? abs.pathname : url;
 
         const span = tracer.startSpan(`${method} ${pathname}`, {
-            spanType: 'browser_fetch',
+            spanType: BrowserSpanType.Fetch,
             attributes: requestSpanAttributes(method, abs, url, config),
         });
 

--- a/packages/js/src/tracing/instrumentXHR.ts
+++ b/packages/js/src/tracing/instrumentXHR.ts
@@ -10,6 +10,7 @@ import {
     safeAbsolute,
     traceparentFor,
 } from './httpRequestSpan';
+import { BrowserSpanType } from './spanTypes';
 
 type XhrOpen = XMLHttpRequest['open'];
 type XhrSend = XMLHttpRequest['send'];
@@ -108,7 +109,7 @@ export function createXHRSend(tracer: HttpTracer, original: XhrSend, origin: str
 
         const pathname = abs ? abs.pathname : state.url;
         const span = tracer.startSpan(`${state.method} ${pathname}`, {
-            spanType: 'browser_xhr',
+            spanType: BrowserSpanType.Xhr,
             attributes: requestSpanAttributes(state.method, abs, state.url, config),
         });
         state.span = span;

--- a/packages/js/src/tracing/spanTypes.ts
+++ b/packages/js/src/tracing/spanTypes.ts
@@ -1,0 +1,14 @@
+// Single source of truth for the browser client's span types. Each value is the
+// `flare.span_type` attribute the tracer stamps on a span (see core Tracer). These
+// strings are WIRE FORMAT: the Flare backend keys perf aggregation off them, so the
+// values must never change. Re-exported from '@flareapp/js/browser' so @flareapp/react
+// and the playgrounds reference this set instead of re-typing the literals.
+export const BrowserSpanType = {
+    Pageload: 'browser_pageload',
+    Navigation: 'browser_navigation',
+    Fetch: 'browser_fetch',
+    Xhr: 'browser_xhr',
+    ReactComponent: 'browser_react_component',
+} as const;
+
+export type BrowserSpanType = (typeof BrowserSpanType)[keyof typeof BrowserSpanType];

--- a/packages/js/tests/componentProfiler.test.ts
+++ b/packages/js/tests/componentProfiler.test.ts
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+import type { Config, Span, SpanOptions } from '@flareapp/core';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { startBrowserTracing, stopBrowserTracing, type BrowserTracingFlare } from '../src/tracing/browserTracing';
+import { activeComponentRoot, recordComponentSpan, reserveSpanId } from '../src/tracing/componentProfiler';
+
+function rootSpan(over: Partial<Pick<Span, 'traceId' | 'spanId' | 'isRecording'>> = {}): Span {
+    return {
+        traceId: over.traceId ?? 'T',
+        spanId: over.spanId ?? 'root',
+        parentSpanId: null,
+        name: 'root',
+        isRecording: over.isRecording ?? true,
+        endTimeUnixNano: 0,
+        setAttribute: () => rootSpan(),
+        setStatus: () => rootSpan(),
+        addEvent: () => rootSpan(),
+        end: vi.fn(),
+    } as unknown as Span;
+}
+
+// `active` lets a test swap the value tracer.getActiveSpan() returns after startup.
+function fakeFlare(active: () => Span | undefined) {
+    const started: Array<{ name: string; opts?: SpanOptions; end: ReturnType<typeof vi.fn> }> = [];
+    const startSpan = vi.fn((name: string, opts?: SpanOptions) => {
+        const end = vi.fn();
+        started.push({ name, opts, end });
+        return { traceId: 'T', spanId: 'c', name, isRecording: true, end } as unknown as Span;
+    });
+    const flare: BrowserTracingFlare = {
+        config: { idleTimeout: 1000, finalTimeout: 30000, childSpanTimeout: 15000 } as unknown as Config,
+        startSpan,
+        tracer: {
+            addSpanListener: vi.fn(() => () => {}),
+            setActiveRoot: vi.fn(),
+            flush: vi.fn(),
+            getActiveSpan: vi.fn(() => active()),
+        } as unknown as BrowserTracingFlare['tracer'],
+    };
+    return { flare, startSpan, started };
+}
+
+describe('component-profiler seam', () => {
+    afterEach(() => {
+        stopBrowserTracing();
+        vi.useRealTimers();
+        window.history.replaceState({}, '', '/');
+    });
+
+    it('reserveSpanId returns a 16-hex id', () => {
+        expect(reserveSpanId()).toMatch(/^[0-9a-f]{16}$/);
+    });
+
+    it('activeComponentRoot returns the live recording root as parent context', () => {
+        vi.useFakeTimers();
+        const root = rootSpan({ traceId: 'T', spanId: 'root' });
+        const { flare } = fakeFlare(() => root);
+        startBrowserTracing(flare);
+        expect(activeComponentRoot()).toEqual({ traceId: 'T', parentSpanId: 'root' });
+    });
+
+    it('activeComponentRoot is null with no root, a non-recording root, or tracing off', () => {
+        vi.useFakeTimers();
+        let active: Span | undefined;
+        const { flare } = fakeFlare(() => active);
+        startBrowserTracing(flare);
+        expect(activeComponentRoot()).toBeNull(); // no root
+        active = rootSpan({ isRecording: false });
+        expect(activeComponentRoot()).toBeNull(); // root exists but is not recording
+        stopBrowserTracing();
+        expect(activeComponentRoot()).toBeNull(); // no active flare
+    });
+
+    it('recordComponentSpan records under the live root, reusing its trace (no re-sample)', () => {
+        vi.useFakeTimers();
+        const { flare, startSpan } = fakeFlare(() => rootSpan({ traceId: 'T', spanId: 'root' }));
+        startBrowserTracing(flare);
+        startSpan.mockClear();
+
+        recordComponentSpan({
+            name: 'ProductPage',
+            spanId: 'p1',
+            parent: { traceId: 'T', parentSpanId: 'root' },
+            startTimeUnixNano: 10,
+            endTimeUnixNano: 20,
+        });
+
+        expect(startSpan).toHaveBeenCalledWith(
+            'ProductPage',
+            expect.objectContaining({
+                spanId: 'p1',
+                parent: { traceId: 'T', spanId: 'root' },
+                spanType: 'browser_react_component',
+                startTimeUnixNano: 10,
+                attributes: { 'flare.react.component': 'ProductPage' },
+            }),
+        );
+    });
+
+    it('recordComponentSpan drops the span when the active root no longer matches the traceId', () => {
+        vi.useFakeTimers();
+        const { flare, startSpan } = fakeFlare(() => rootSpan({ traceId: 'DIFFERENT', spanId: 'root2' }));
+        startBrowserTracing(flare);
+        startSpan.mockClear();
+
+        recordComponentSpan({
+            name: 'ProductPage',
+            spanId: 'p1',
+            parent: { traceId: 'T', parentSpanId: 'root' },
+            startTimeUnixNano: 10,
+            endTimeUnixNano: 20,
+        });
+
+        expect(startSpan).not.toHaveBeenCalled(); // dropped: root idle-closed or a new nav took over
+    });
+
+    it('never throws into the host', () => {
+        expect(() =>
+            recordComponentSpan({
+                name: 'X',
+                spanId: 'x',
+                parent: { traceId: 'T', parentSpanId: 'root' },
+                startTimeUnixNano: 1,
+                endTimeUnixNano: 2,
+            }),
+        ).not.toThrow(); // no active flare -> no-op
+    });
+});

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -84,3 +84,34 @@ at [flareapp.io/docs/react/general/installation](https://flareapp.io/docs/react/
 ## License
 
 The MIT License (MIT). Please see [License File](../../LICENSE.md) for more information.
+
+## Component profiler (`@flareapp/react/profiler`)
+
+Opt-in mount profiling: wrap a component to record a `browser_react_component` span for
+its mount, nested under the active page-load / navigation trace. Requires tracing to be
+enabled (`enableTracing: true`).
+
+```tsx
+import { FlareProfiler, withFlareProfiler } from '@flareapp/react/profiler';
+
+// Wrap at the definition:
+export default withFlareProfiler(ProductPage);
+
+// Or wrap an inline subtree:
+<FlareProfiler name="Gallery">
+    <ProductGallery />
+</FlareProfiler>;
+```
+
+Spans nest into a tree: a profiled child nests under its nearest profiled ancestor;
+unprofiled components in between are transparent. A component with no active trace
+(tracing off, or no page-load/navigation root) records nothing and renders normally.
+
+**Naming:** the span name is `name` (prop or `withFlareProfiler(Component, { name })`),
+then `Component.displayName`, then `Component.name`. Minified production builds can
+mangle `Component.name`, so pass an explicit `name` or set `displayName` for production.
+
+**Suspense (v1 limitation):** a `<Suspense>` boundary inside a profiled subtree can end a
+parent span before a suspended child resumes, so the child may appear outside its parent
+in the waterfall, and its duration includes the data wait. If the wait outlasts the
+trace's idle window the child span is dropped rather than attached to a closed trace.

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -61,11 +61,21 @@
                 "types": "./dist/tanstack-router.d.cts",
                 "default": "./dist/tanstack-router.cjs"
             }
+        },
+        "./profiler": {
+            "import": {
+                "types": "./dist/profiler.d.mts",
+                "default": "./dist/profiler.mjs"
+            },
+            "require": {
+                "types": "./dist/profiler.d.cts",
+                "default": "./dist/profiler.cjs"
+            }
         }
     },
     "scripts": {
         "prepublishOnly": "npm run build",
-        "build": "tsdown src/index.ts src/inject.ts src/tanstack-router.ts --format cjs,esm --dts --env.PACKAGE_VERSION=$(node -p \"require('./package.json').version\") --clean",
+        "build": "tsdown src/index.ts src/inject.ts src/tanstack-router.ts src/profiler.ts --format cjs,esm --dts --env.PACKAGE_VERSION=$(node -p \"require('./package.json').version\") --clean",
         "test": "vitest run",
         "typescript": "tsc --noEmit",
         "verify:inject": "node scripts/verify-inject-no-root.mjs",

--- a/packages/react/src/profiler.ts
+++ b/packages/react/src/profiler.ts
@@ -39,7 +39,13 @@ export function FlareProfiler({ name, children }: FlareProfilerProps): ReactNode
     const parentRef = useRef<ComponentTraceContext | null | undefined>(undefined);
     if (parentRef.current === undefined) {
         try {
-            parentRef.current = context ?? activeComponentRoot();
+            const live = activeComponentRoot();
+            // Prefer an inherited ancestor context only while it still belongs to the live
+            // trace. A profiled component that persists across navigations (e.g. a layout)
+            // froze its context under the pageload trace; once that root closes and a client
+            // navigation opens a new root, a descendant must re-home to the LIVE root rather
+            // than pin the subtree to the dead trace (which the live-root gate would drop).
+            parentRef.current = context && live && context.traceId === live.traceId ? context : live;
         } catch {
             parentRef.current = null; // resolved to transparent; never throw into the host
         }

--- a/packages/react/src/profiler.ts
+++ b/packages/react/src/profiler.ts
@@ -1,0 +1,104 @@
+// @flareapp/react/profiler — opt-in React component-mount tracing.
+//
+// Electron-safe / dependency-free: imports ONLY React and the side-effect-free
+// @flareapp/js/browser seam. NO @flareapp/js root import (same discipline as
+// ./tanstack-router). Each <FlareProfiler> records one `browser_react_component` span
+// for its mount, nested under the nearest profiled ancestor (or the active
+// browser_pageload / browser_navigation root) via React context and reserved span ids.
+import {
+    activeComponentRoot,
+    nowNano,
+    recordComponentSpan,
+    reserveSpanId,
+    type ComponentTraceContext,
+} from '@flareapp/js/browser';
+import {
+    createContext,
+    createElement,
+    useContext,
+    useEffect,
+    useLayoutEffect,
+    useRef,
+    type ComponentType,
+    type ReactNode,
+} from 'react';
+
+// useLayoutEffect matches componentDidMount timing (fires in commit, before paint,
+// bottom-up) but warns during SSR where there is no DOM; fall back to useEffect there.
+const useMountEffect = typeof window === 'undefined' ? useEffect : useLayoutEffect;
+
+const FlareProfilerContext = createContext<ComponentTraceContext | null>(null);
+
+export type FlareProfilerProps = { name: string; children?: ReactNode };
+
+export function FlareProfiler({ name, children }: FlareProfilerProps): ReactNode {
+    const context = useContext(FlareProfilerContext);
+
+    // Resolve the parent once: an ancestor's context if present, else the active root.
+    // `undefined` marks "not yet resolved"; `null` marks "resolved to transparent".
+    const parentRef = useRef<ComponentTraceContext | null | undefined>(undefined);
+    if (parentRef.current === undefined) {
+        try {
+            parentRef.current = context ?? activeComponentRoot();
+        } catch {
+            parentRef.current = null; // resolved to transparent; never throw into the host
+        }
+    }
+    const parent = parentRef.current;
+
+    // Reserve this component's own span id and capture its mount start, once, only
+    // when it actually has a parent to nest under.
+    const ownRef = useRef<{ spanId: string; startNano: number } | null>(null);
+    if (parent && ownRef.current === null) {
+        try {
+            ownRef.current = { spanId: reserveSpanId(), startNano: nowNano() };
+        } catch {
+            // leave ownRef null: the mount effect no-ops and this component stays transparent
+        }
+    }
+
+    // Freeze the context handed to descendants: this component's span when profiled,
+    // otherwise pass the (null) context through. A descendant re-resolves against the
+    // root live at ITS mount, so a dead-window ancestor (e.g. a layout mounted between
+    // traces) does not permanently disable profiling for its subtree.
+    const providedRef = useRef<ComponentTraceContext | null | undefined>(undefined);
+    if (providedRef.current === undefined) {
+        providedRef.current =
+            parent && ownRef.current ? { traceId: parent.traceId, parentSpanId: ownRef.current.spanId } : null;
+    }
+
+    // Record exactly once per committed fiber. Under StrictMode React replays the
+    // effect (setup -> cleanup -> setup) on the same fiber, and the refs above persist,
+    // so an unguarded effect would buffer the same reserved spanId twice.
+    const hasRecorded = useRef(false);
+    useMountEffect(() => {
+        const own = ownRef.current;
+        if (!parent || !own || hasRecorded.current) return;
+        hasRecorded.current = true;
+        try {
+            recordComponentSpan({
+                name,
+                spanId: own.spanId,
+                parent,
+                startTimeUnixNano: own.startNano,
+                endTimeUnixNano: nowNano(),
+            });
+        } catch {
+            // instrumentation must never break the host
+        }
+    }, []);
+
+    return createElement(FlareProfilerContext.Provider, { value: providedRef.current ?? null }, children ?? null);
+}
+
+export function withFlareProfiler<P extends object>(
+    Component: ComponentType<P>,
+    options?: { name?: string },
+): ComponentType<P> {
+    // || not ??: an anonymous/minified component can have name '', which must fall
+    // through to 'Unknown' (matches Sentry).
+    const name = options?.name || Component.displayName || Component.name || 'Unknown';
+    const Profiled = (props: P): ReactNode => createElement(FlareProfiler, { name }, createElement(Component, props));
+    Profiled.displayName = `withFlareProfiler(${name})`;
+    return Profiled;
+}

--- a/packages/react/tests/profiler.test.tsx
+++ b/packages/react/tests/profiler.test.tsx
@@ -183,6 +183,30 @@ describe('FlareProfiler', () => {
             expect(byName.Lazy).toMatchObject({ parent: { parentSpanId: 's1' } });
         });
     });
+
+    it('re-homes a descendant to the live root when the inherited ancestor context is from a dead trace', () => {
+        // Ancestor (a persistent layout) mounts under the initial pageload trace R1.
+        seam.activeComponentRoot.mockReturnValue({ traceId: 'R1', parentSpanId: 'r1root' });
+        const { rerender } = render(<FlareProfiler name="Layout">{null}</FlareProfiler>);
+
+        // Pageload trace R1 closes; a client navigation opens a fresh trace R2. The ancestor
+        // does NOT remount (rerender, same fiber), so its provided context stays frozen at R1.
+        seam.activeComponentRoot.mockReturnValue({ traceId: 'R2', parentSpanId: 'r2root' });
+        rerender(
+            <FlareProfiler name="Layout">
+                <FlareProfiler name="Descendant">
+                    <div>x</div>
+                </FlareProfiler>
+            </FlareProfiler>,
+        );
+
+        const byName = Object.fromEntries(calls().map((c) => [c.name, c]));
+        // Ancestor recorded once, under its own live trace at mount time (R1).
+        expect(byName.Layout).toMatchObject({ parent: { traceId: 'R1', parentSpanId: 'r1root' } });
+        // Descendant inherited the stale R1 context but RE-HOMES to the live R2 root instead of
+        // pinning to the dead trace (which the live-root gate would drop in production).
+        expect(byName.Descendant).toMatchObject({ parent: { traceId: 'R2', parentSpanId: 'r2root' } });
+    });
 });
 
 describe('withFlareProfiler', () => {

--- a/packages/react/tests/profiler.test.tsx
+++ b/packages/react/tests/profiler.test.tsx
@@ -1,0 +1,217 @@
+// @vitest-environment jsdom
+import { cleanup, render } from '@testing-library/react';
+import { StrictMode, Suspense, type ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const seam = vi.hoisted(() => {
+    let counter = 0;
+    return {
+        activeComponentRoot: vi.fn((): { traceId: string; parentSpanId: string } | null => ({
+            traceId: 'T',
+            parentSpanId: 'root',
+        })),
+        reserveSpanId: vi.fn(() => `s${++counter}`),
+        recordComponentSpan: vi.fn(),
+        nowNano: vi.fn(() => 1000),
+        reset: () => {
+            counter = 0;
+        },
+    };
+});
+vi.mock('@flareapp/js/browser', () => ({
+    activeComponentRoot: seam.activeComponentRoot,
+    reserveSpanId: seam.reserveSpanId,
+    recordComponentSpan: seam.recordComponentSpan,
+    nowNano: seam.nowNano,
+}));
+
+import { FlareProfiler, withFlareProfiler } from '../src/profiler';
+
+beforeEach(() => {
+    seam.reset();
+    seam.recordComponentSpan.mockReset();
+    seam.reserveSpanId.mockClear();
+    seam.activeComponentRoot.mockReset().mockReturnValue({ traceId: 'T', parentSpanId: 'root' });
+    seam.nowNano.mockReset().mockReturnValue(1000);
+});
+afterEach(cleanup);
+
+const calls = () =>
+    seam.recordComponentSpan.mock.calls.map(
+        (c) => c[0] as { name: string; spanId: string; parent: { traceId: string; parentSpanId: string } },
+    );
+
+describe('FlareProfiler', () => {
+    it('records one span for a single component, parented to the active root', () => {
+        render(
+            <FlareProfiler name="Solo">
+                <div>content</div>
+            </FlareProfiler>,
+        );
+        expect(seam.recordComponentSpan).toHaveBeenCalledTimes(1);
+        expect(calls()[0]).toMatchObject({
+            name: 'Solo',
+            spanId: 's1',
+            parent: { traceId: 'T', parentSpanId: 'root' },
+            startTimeUnixNano: 1000,
+            endTimeUnixNano: 1000,
+        });
+    });
+
+    it('nests a child span under its profiled parent', () => {
+        render(
+            <FlareProfiler name="Parent">
+                <FlareProfiler name="Child">
+                    <div>x</div>
+                </FlareProfiler>
+            </FlareProfiler>,
+        );
+        // Effects fire bottom-up: Child records first (s2 under parent s1), then Parent (s1 under root).
+        const byName = Object.fromEntries(calls().map((c) => [c.name, c]));
+        expect(byName.Parent).toMatchObject({ spanId: 's1', parent: { parentSpanId: 'root' } });
+        expect(byName.Child).toMatchObject({ spanId: 's2', parent: { parentSpanId: 's1' } });
+    });
+
+    it('is transparent when unprofiled: a grandchild nests under the nearest profiled ancestor', () => {
+        const Passthrough = ({ children }: { children?: ReactNode }) => <div>{children}</div>;
+        render(
+            <FlareProfiler name="Ancestor">
+                <Passthrough>
+                    <FlareProfiler name="Descendant">
+                        <div>x</div>
+                    </FlareProfiler>
+                </Passthrough>
+            </FlareProfiler>,
+        );
+        const byName = Object.fromEntries(calls().map((c) => [c.name, c]));
+        expect(byName.Descendant).toMatchObject({ parent: { parentSpanId: 's1' } }); // under Ancestor, not the plain div
+    });
+
+    it('records nothing but still renders children when there is no active root', () => {
+        seam.activeComponentRoot.mockReturnValue(null);
+        const { getByText } = render(
+            <FlareProfiler name="Solo">
+                <div>still here</div>
+            </FlareProfiler>,
+        );
+        expect(seam.recordComponentSpan).not.toHaveBeenCalled();
+        expect(seam.reserveSpanId).not.toHaveBeenCalled();
+        expect(getByText('still here')).toBeTruthy();
+    });
+
+    it('never throws when the seam throws', () => {
+        seam.recordComponentSpan.mockImplementation(() => {
+            throw new Error('boom');
+        });
+        expect(() =>
+            render(
+                <FlareProfiler name="Solo">
+                    <div>x</div>
+                </FlareProfiler>,
+            ),
+        ).not.toThrow();
+    });
+
+    it('never throws, and still renders children, when activeComponentRoot throws (render phase)', () => {
+        seam.activeComponentRoot.mockImplementation(() => {
+            throw new Error('boom');
+        });
+        let getByText!: ReturnType<typeof render>['getByText'];
+        expect(() => {
+            ({ getByText } = render(
+                <FlareProfiler name="Solo">
+                    <div>still here</div>
+                </FlareProfiler>,
+            ));
+        }).not.toThrow();
+        expect(getByText('still here')).toBeTruthy();
+    });
+
+    it('never throws, still renders children, and skips recording when reserveSpanId throws (render phase)', () => {
+        // mockImplementationOnce, not mockImplementation: reserveSpanId is only
+        // mockClear()'d (not mockReset()'d) in beforeEach, so a persistent throwing
+        // implementation would leak into every later test in this file.
+        seam.reserveSpanId.mockImplementationOnce(() => {
+            throw new Error('boom');
+        });
+        let getByText!: ReturnType<typeof render>['getByText'];
+        expect(() => {
+            ({ getByText } = render(
+                <FlareProfiler name="Solo">
+                    <div>still here</div>
+                </FlareProfiler>,
+            ));
+        }).not.toThrow();
+        expect(getByText('still here')).toBeTruthy();
+        expect(seam.recordComponentSpan).not.toHaveBeenCalled();
+    });
+
+    it('records exactly once under StrictMode (no duplicate spanId)', () => {
+        render(
+            <StrictMode>
+                <FlareProfiler name="Solo">
+                    <div>x</div>
+                </FlareProfiler>
+            </StrictMode>,
+        );
+        expect(seam.recordComponentSpan).toHaveBeenCalledTimes(1);
+    });
+
+    it('records a suspended child under its profiled ancestor once it resolves', async () => {
+        let resolve!: () => void;
+        const gate = new Promise<void>((r) => {
+            resolve = r;
+        });
+        let ready = false;
+        const Suspender = () => {
+            if (!ready) throw gate;
+            return <div>loaded</div>;
+        };
+        render(
+            <FlareProfiler name="Ancestor">
+                <Suspense fallback={<div>loading</div>}>
+                    <FlareProfiler name="Lazy">
+                        <Suspender />
+                    </FlareProfiler>
+                </Suspense>
+            </FlareProfiler>,
+        );
+        ready = true;
+        await vi.waitFor(() => {
+            resolve();
+            const byName = Object.fromEntries(calls().map((c) => [c.name, c]));
+            expect(byName.Lazy).toMatchObject({ parent: { parentSpanId: 's1' } });
+        });
+    });
+});
+
+describe('withFlareProfiler', () => {
+    it('resolves the name from options over displayName over Component.name', () => {
+        function Named() {
+            return <div>n</div>;
+        }
+        const WithName = withFlareProfiler(Named);
+        render(<WithName />);
+        expect(calls()[0]!.name).toBe('Named');
+
+        seam.recordComponentSpan.mockClear();
+        const Displayed = () => <div>d</div>;
+        Displayed.displayName = 'Display';
+        const WithDisplayName = withFlareProfiler(Displayed);
+        render(<WithDisplayName />);
+        expect(calls()[0]!.name).toBe('Display'); // displayName beats Component.name ('Displayed')
+
+        seam.recordComponentSpan.mockClear();
+        const Explicit = withFlareProfiler(Displayed, { name: 'Explicit' });
+        render(<Explicit />);
+        expect(calls()[0]!.name).toBe('Explicit'); // explicit beats displayName
+    });
+
+    it('falls through an empty Component.name to Unknown (|| not ??)', () => {
+        const Anon = () => <div>a</div>;
+        Object.defineProperty(Anon, 'name', { value: '' });
+        const WithAnon = withFlareProfiler(Anon);
+        render(<WithAnon />);
+        expect(calls()[0]!.name).toBe('Unknown'); // '' falls through via ||, not ??
+    });
+});

--- a/playgrounds/react/src/routes/__root.tsx
+++ b/playgrounds/react/src/routes/__root.tsx
@@ -1,7 +1,8 @@
-import { createRootRoute } from '@tanstack/react-router';
+import { withFlareProfiler } from '@flareapp/react/profiler';
+import { createRootRoute, RouteComponent } from '@tanstack/react-router';
 
 import { Layout } from '../components/Layout';
 
 export const rootRoute = createRootRoute({
-    component: Layout,
+    component: withFlareProfiler(Layout, { name: 'Layout' }) as RouteComponent,
 });

--- a/playgrounds/react/src/routes/index.tsx
+++ b/playgrounds/react/src/routes/index.tsx
@@ -1,5 +1,6 @@
 import { products, testIds, unsplashUrl } from '@flareapp/playgrounds-shared';
-import { createRoute, Link } from '@tanstack/react-router';
+import { withFlareProfiler } from '@flareapp/react/profiler';
+import { createRoute, Link, RouteComponent } from '@tanstack/react-router';
 
 import { cart } from '../cart';
 import { rootRoute } from './__root';
@@ -48,5 +49,5 @@ const ProductsPage = () => (
 export const indexRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: '/',
-    component: ProductsPage,
+    component: withFlareProfiler(ProductsPage, { name: 'ProductsPage' }) as RouteComponent,
 });

--- a/playgrounds/react/src/routes/product.$id.tsx
+++ b/playgrounds/react/src/routes/product.$id.tsx
@@ -1,5 +1,6 @@
 import { productById, testIds, unsplashUrl } from '@flareapp/playgrounds-shared';
-import { createRoute } from '@tanstack/react-router';
+import { withFlareProfiler } from '@flareapp/react/profiler';
+import { createRoute, RouteComponent } from '@tanstack/react-router';
 
 import { cart } from '../cart';
 import { flare } from '../flare';
@@ -30,14 +31,7 @@ const ProductPage = () => {
                 <h1 className="text-2xl font-semibold">{product.title}</h1>
                 <p className="text-sm opacity-70">Photograph by {product.photographer}</p>
                 <div className="text-xl font-mono">${(product.priceCents / 100).toFixed(2)}</div>
-                <button
-                    type="button"
-                    data-testid={testIds.addToCart(product.id)}
-                    onClick={() => cart.add(product.id)}
-                    className="rounded-lg bg-brand-ink text-white py-3 hover:opacity-90"
-                >
-                    Add to cart
-                </button>
+                <AddToCartButton testId={testIds.addToCart(product.id)} onClick={() => cart.add(product.id)} />
                 <button
                     type="button"
                     onClick={triggerBroken}
@@ -53,5 +47,19 @@ const ProductPage = () => {
 export const productRoute = createRoute({
     getParentRoute: () => rootRoute,
     path: '/product/$id',
-    component: ProductPage,
+    component: withFlareProfiler(ProductPage, { name: 'ProductPage' }) as RouteComponent,
 });
+
+const AddToCartButton = withFlareProfiler(
+    ({ testId, onClick }: { testId: any; onClick: () => void }) => (
+        <button
+            type="button"
+            data-testid={testId}
+            onClick={onClick}
+            className="rounded-lg bg-brand-ink text-white py-3 hover:opacity-90"
+        >
+            Add to cart
+        </button>
+    ),
+    { name: 'AddToCartButton' },
+);


### PR DESCRIPTION
## What

Adds an opt-in `@flareapp/react` component profiler. Wrapping a component records one `browser_react_component` span for its mount, nested as a true tree (by `parent_span_id`) under the active `browser_pageload` / `browser_navigation` root.

Base branch is `research/tracing-framework-routers` (this stacks on the TanStack-router slice); it is not `main`.

## How it fits together

Three pieces, with all tracer coupling isolated to one seam:

- **`@flareapp/core`** — optional `spanId?` on `SpanOptions`; `Tracer.startSpan` honors it (manual span stitching). `spanId` id-generator re-exported.
- **`@flareapp/js/browser`** — a side-effect-free `componentProfiler` seam (`activeComponentRoot`, `reserveSpanId`, `recordComponentSpan`, `nowNano`). A **live-root gate** records a component span only while the reserved trace is still the live recording root; otherwise it drops it (no re-sample, no attaching to a shipped root).
- **`@flareapp/react/profiler`** — a `<FlareProfiler name>` component and a `withFlareProfiler` HOC. Records once per mount (StrictMode-safe), threads parent linkage via React context and reserved span ids, and never throws into the host. Electron-safe: imports only `react` and `@flareapp/js/browser`, no `@flareapp/js` root import, no JSX in source.

Spans form a tree: a profiled child nests under its nearest profiled ancestor; unprofiled components in between are transparent. A component whose inherited ancestor context belongs to a dead trace (a persistent layout that outlived its pageload root) re-homes to the live navigation root instead of dropping. No trace active → records nothing, renders normally.

Gating is `enableTracing` + an active recording root only — no profiler-specific flag or sample rate.

## Notable design points

- Name resolution: explicit `name` > `Component.displayName` > `Component.name` > `'Unknown'` (`||`, so an anonymous/minified `''` falls through).
- Record exactly once per mount via a `hasRecorded` ref, so StrictMode's replayed setup cannot buffer a duplicate span id.
- Every seam call and mount-effect body is wrapped so instrumentation cannot break the app.

## Testing

- `@flareapp/core`: explicit-`spanId` tracer test.
- `@flareapp/js`: 6 seam tests incl. the live-root drop.
- `@flareapp/react`: 12 profiler tests incl. StrictMode record-once, Suspense nesting, transparent pass-through, never-throws, and a cross-trace re-homing regression test.
- Full repo gate green: typecheck (all workspaces incl. playgrounds), all 14 workspace suites, and build (incl. the `./profiler` entry).

React playground wired as a `Layout → ProductsPage/ProductPage → AddToCartButton` demo tree.

## Follow-ups (not in this PR)

- Backend: the flareapp.io `browser_react_component` `SpanType` (a tracked dependency).
- Release coupling: when `@flareapp/react` ships the profiler, raise its `@flareapp/js` peer range to the first version carrying the seam exports.
- e2e: assert a client navigation emits a `browser_react_component` span parented into the navigation root (spec-sanctioned deferral).
