### PR TITLE
feat(playgrounds): React Router v7 (data mode) playground

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,28 +25,29 @@ integrations for React, Vue, and Svelte, and a Vite plugin for sourcemap uploads
 npm workspaces monorepo with 9 published packages, 1 internal package, 4 framework playground apps, a shared fixture
 package, and a Playwright-based e2e suite:
 
-| Package                            | npm name                            | Purpose                                                                                        |
-| ---------------------------------- | ----------------------------------- | ---------------------------------------------------------------------------------------------- |
-| `packages/core`                    | `@flareapp/core`                    | Environment-agnostic Flare core (shared between js + node)                                     |
-| `packages/js`                      | `@flareapp/js`                      | Core client — error capture, stack traces, context, API reporting                              |
-| `packages/react`                   | `@flareapp/react`                   | React `FlareErrorBoundary` error boundary component; `/inject` entry for Electron renderers    |
-| `packages/vue`                     | `@flareapp/vue`                     | Vue error handler plugin (`flareVue()`); `/inject` entry for Electron renderers                |
-| `packages/svelte`                  | `@flareapp/svelte`                  | Svelte 5 `FlareErrorBoundary` with props serialization; `/inject` entry for Electron renderers |
-| `packages/sveltekit`               | `@flareapp/sveltekit`               | SvelteKit error hooks (`handleErrorWithFlare`) + route context                                 |
-| `packages/vite`                    | `@flareapp/vite`                    | Vite build plugin for sourcemap upload with retry logic                                        |
-| `packages/webpack`                 | `@flareapp/webpack`                 | Webpack 5 plugin for sourcemap upload                                                          |
-| `packages/nextjs`                  | `@flareapp/nextjs`                  | Next.js wrapper (`withFlareSourcemaps`) for sourcemap upload                                   |
-| `packages/node`                    | `@flareapp/node`                    | Node.js SDK (process handlers, AsyncLocalStorage scope)                                        |
-| `packages/react-native`            | `@flareapp/react-native`            | React Native SDK (pure-JS, Expo + bare; ErrorUtils + boundary capture)                         |
-| `packages/react-native-sourcemaps` | `@flareapp/react-native-sourcemaps` | RN/Metro sourcemap upload: Babel version inlining + `flare-rn-sourcemaps` upload CLI           |
-| `packages/electron`                | `@flareapp/electron`                | Electron SDK (main + preload + renderer, IPC-unified)                                          |
-| `packages/flare-api`               | `@flareapp/flare-api`               | Shared API client for sourcemap uploads (private, not published)                               |
-| `playgrounds/shared`               | `@flareapp/playgrounds-shared`      | Shared TS fixtures: products, scenarios, testIds, Tailwind tokens                              |
-| `playgrounds/js`                   | `@flareapp/playgrounds-js`          | Vanilla TS + Vite webshop (port 5180)                                                          |
-| `playgrounds/react`                | `@flareapp/playgrounds-react`       | React 19 + TanStack Router webshop (port 5181)                                                 |
-| `playgrounds/vue`                  | `@flareapp/playgrounds-vue`         | Vue 3 + vue-router webshop (port 5182)                                                         |
-| `playgrounds/svelte`               | `@flareapp/playgrounds-svelte`      | SvelteKit (adapter-node) webshop (port 5183)                                                   |
-| `e2e/`                             | (not a workspace)                   | Playwright specs + fake-flare-server fixture                                                   |
+| Package                            | npm name                             | Purpose                                                                                        |
+| ---------------------------------- | ------------------------------------ | ---------------------------------------------------------------------------------------------- |
+| `packages/core`                    | `@flareapp/core`                     | Environment-agnostic Flare core (shared between js + node)                                     |
+| `packages/js`                      | `@flareapp/js`                       | Core client — error capture, stack traces, context, API reporting                              |
+| `packages/react`                   | `@flareapp/react`                    | React `FlareErrorBoundary` error boundary component; `/inject` entry for Electron renderers    |
+| `packages/vue`                     | `@flareapp/vue`                      | Vue error handler plugin (`flareVue()`); `/inject` entry for Electron renderers                |
+| `packages/svelte`                  | `@flareapp/svelte`                   | Svelte 5 `FlareErrorBoundary` with props serialization; `/inject` entry for Electron renderers |
+| `packages/sveltekit`               | `@flareapp/sveltekit`                | SvelteKit error hooks (`handleErrorWithFlare`) + route context                                 |
+| `packages/vite`                    | `@flareapp/vite`                     | Vite build plugin for sourcemap upload with retry logic                                        |
+| `packages/webpack`                 | `@flareapp/webpack`                  | Webpack 5 plugin for sourcemap upload                                                          |
+| `packages/nextjs`                  | `@flareapp/nextjs`                   | Next.js wrapper (`withFlareSourcemaps`) for sourcemap upload                                   |
+| `packages/node`                    | `@flareapp/node`                     | Node.js SDK (process handlers, AsyncLocalStorage scope)                                        |
+| `packages/react-native`            | `@flareapp/react-native`             | React Native SDK (pure-JS, Expo + bare; ErrorUtils + boundary capture)                         |
+| `packages/react-native-sourcemaps` | `@flareapp/react-native-sourcemaps`  | RN/Metro sourcemap upload: Babel version inlining + `flare-rn-sourcemaps` upload CLI           |
+| `packages/electron`                | `@flareapp/electron`                 | Electron SDK (main + preload + renderer, IPC-unified)                                          |
+| `packages/flare-api`               | `@flareapp/flare-api`                | Shared API client for sourcemap uploads (private, not published)                               |
+| `playgrounds/shared`               | `@flareapp/playgrounds-shared`       | Shared TS fixtures: products, scenarios, testIds, Tailwind tokens                              |
+| `playgrounds/js`                   | `@flareapp/playgrounds-js`           | Vanilla TS + Vite webshop (port 5180)                                                          |
+| `playgrounds/react`                | `@flareapp/playgrounds-react`        | React 19 + TanStack Router webshop (port 5181)                                                 |
+| `playgrounds/vue`                  | `@flareapp/playgrounds-vue`          | Vue 3 + vue-router webshop (port 5182)                                                         |
+| `playgrounds/svelte`               | `@flareapp/playgrounds-svelte`       | SvelteKit (adapter-node) webshop (port 5183)                                                   |
+| `playgrounds/react-router`         | `@flareapp/playgrounds-react-router` | React Router v7 (data mode) + `traceReactRouter` webshop (port 5185)                           |
+| `e2e/`                             | (not a workspace)                    | Playwright specs + fake-flare-server fixture                                                   |
 
 ## Tech stack
 
@@ -71,6 +72,7 @@ npm run playgrounds:js     # Boot the vanilla JS playground on http://localhost:
 npm run playgrounds:react  # Boot the React playground on http://localhost:5181
 npm run playgrounds:vue    # Boot the Vue playground on http://localhost:5182
 npm run playgrounds:svelte # Boot the SvelteKit playground on http://localhost:5183
+npm run playgrounds:react-router # Boot the React Router v7 playground on http://localhost:5185
 ```
 
 ## Key source files

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -137,9 +137,10 @@ SDK uniformly across frameworks.
 Playwright config at `playwright.config.ts`, specs at `e2e/specs/*.spec.ts`. One project per framework, single
 worker (the fake server has shared in-memory state), `webServer` boots each playground's `vite dev` automatically.
 
-- `e2e/fake-flare-server/`: standalone node http server (no deps). `POST /api/reports` and `POST /api/sourcemaps`
-  record the body. `GET /__inspect/reports` and `POST /__inspect/reset` are the inspection API used by the test
-  fixture. CORS open. Boots on `FAKE_FLARE_PORT` (default 7765 — avoid 4318, OrbStack squats on it).
+- `e2e/fake-flare-server/`: standalone node http server (no deps). Ingest paths mirror the real Flare ingress:
+  `POST /v1/errors`, `POST /v1/traces`, `POST /v1/logs` (plus `POST /api/sourcemaps`) record the body. `GET
+/__inspect/reports` and `POST /__inspect/reset` are the inspection API used by the test fixture. CORS open. Boots
+  on `FAKE_FLARE_PORT` (default 7765 — avoid 4318, OrbStack squats on it).
 - `e2e/global-setup.ts` / `global-teardown.ts`: boots/stops the fake server around the test run.
 - `e2e/fixtures/fake-flare.ts`: Playwright fixture exposing `reset()`, `reports()`, `waitForReport({ predicate })`,
   `assertNoReports()`. Each test auto-resets the server before running.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,7 @@ integrations for React, Vue, and Svelte, and a Vite plugin for sourcemap uploads
 
 ## Monorepo structure
 
-npm workspaces monorepo with 9 published packages, 1 internal package, 4 framework playground apps, a shared fixture
+npm workspaces monorepo with 9 published packages, 1 internal package, 5 framework playground apps, a shared fixture
 package, and a Playwright-based e2e suite:
 
 | Package                            | npm name                             | Purpose                                                                                        |
@@ -67,7 +67,7 @@ npm run test               # Run vitest across workspaces (after build)
 npm run typescript         # Type-check all packages
 npm run format             # Run oxfmt on all files
 npm run lint               # Run oxlint across all packages
-npm run test:e2e           # Run Playwright suite across all 4 framework playgrounds
+npm run test:e2e           # Run Playwright suite across all 5 framework playgrounds
 npm run playgrounds:js     # Boot the vanilla JS playground on http://localhost:5180
 npm run playgrounds:react  # Boot the React playground on http://localhost:5181
 npm run playgrounds:vue    # Boot the Vue playground on http://localhost:5182

--- a/README.md
+++ b/README.md
@@ -14,29 +14,31 @@ The v1 source lives on the [`1.x`](https://github.com/spatie/flare-client-js/tre
 
 This is an npm workspaces monorepo containing the following packages:
 
-| Package                                                          | npm                                                                              | Description                                                                         |
-| ---------------------------------------------------------------- | -------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
-| [`packages/core`](packages/core)                                 | [`@flareapp/core`](https://www.npmjs.com/package/@flareapp/core)                 | Environment-agnostic Flare core shared between the browser and Node clients         |
-| [`packages/js`](packages/js)                                     | [`@flareapp/js`](https://www.npmjs.com/package/@flareapp/js)                     | Browser client: global error listeners, browser context collection, source fetching |
-| [`packages/react`](packages/react)                               | [`@flareapp/react`](https://www.npmjs.com/package/@flareapp/react)               | React error boundary component and React 19 error handler                           |
-| [`packages/vue`](packages/vue)                                   | [`@flareapp/vue`](https://www.npmjs.com/package/@flareapp/vue)                   | Vue error handler plugin                                                            |
-| [`packages/svelte`](packages/svelte)                             | [`@flareapp/svelte`](https://www.npmjs.com/package/@flareapp/svelte)             | Svelte 5 error boundary component and boundary handler factory                      |
-| [`packages/sveltekit`](packages/sveltekit)                       | [`@flareapp/sveltekit`](https://www.npmjs.com/package/@flareapp/sveltekit)       | SvelteKit client/server error hooks and route context                               |
-| [`packages/node`](packages/node)                                 | [`@flareapp/node`](https://www.npmjs.com/package/@flareapp/node)                 | Node.js SDK with process handlers and AsyncLocalStorage scope                       |
-| [`packages/electron`](packages/electron)                         | [`@flareapp/electron`](https://www.npmjs.com/package/@flareapp/electron)         | Electron SDK (main + preload + renderer)                                            |
-| [`packages/react-native`](packages/react-native)                 | [`@flareapp/react-native`](https://www.npmjs.com/package/@flareapp/react-native) | React Native SDK (pure-JS, Expo + bare; requires RN 0.79+)                          |
-| [`packages/vite`](packages/vite)                                 | [`@flareapp/vite`](https://www.npmjs.com/package/@flareapp/vite)                 | Vite build plugin for sourcemap uploads                                             |
-| [`packages/webpack`](packages/webpack)                           | [`@flareapp/webpack`](https://www.npmjs.com/package/@flareapp/webpack)           | Webpack 5 plugin for sourcemap uploads                                              |
-| [`packages/nextjs`](packages/nextjs)                             | [`@flareapp/nextjs`](https://www.npmjs.com/package/@flareapp/nextjs)             | Next.js wrapper for sourcemap uploads via webpack                                   |
-| [`packages/flare-api`](packages/flare-api)                       | (private)                                                                        | Shared API client for sourcemap uploads (internal)                                  |
-| [`playgrounds/shared`](playgrounds/shared)                       | (private)                                                                        | Shared fixtures: product data, error scenarios, test IDs, Tailwind tokens           |
-| [`playgrounds/js`](playgrounds/js)                               | (private)                                                                        | Vanilla TS + Vite playground (port 5180)                                            |
-| [`playgrounds/react`](playgrounds/react)                         | (private)                                                                        | React 19 + TanStack Router playground (port 5181)                                   |
-| [`playgrounds/vue`](playgrounds/vue)                             | (private)                                                                        | Vue 3 + vue-router playground (port 5182)                                           |
-| [`playgrounds/svelte`](playgrounds/svelte)                       | (private)                                                                        | SvelteKit (adapter-node) playground (port 5183)                                     |
-| [`playgrounds/nextjs`](playgrounds/nextjs)                       | (private)                                                                        | Next.js 15 App Router playground (port 5184)                                        |
-| [`playgrounds/react-native-bare`](playgrounds/react-native-bare) | (private)                                                                        | Bare RN manual smoke-test app for `@flareapp/react-native`                          |
-| [`playgrounds/react-native-expo`](playgrounds/react-native-expo) | (private)                                                                        | Expo manual smoke-test app (incl. Expo device/app context)                          |
+| Package                                                                | npm                                                                                                    | Description                                                                         |
+| ---------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------- |
+| [`packages/core`](packages/core)                                       | [`@flareapp/core`](https://www.npmjs.com/package/@flareapp/core)                                       | Environment-agnostic Flare core shared between the browser and Node clients         |
+| [`packages/js`](packages/js)                                           | [`@flareapp/js`](https://www.npmjs.com/package/@flareapp/js)                                           | Browser client: global error listeners, browser context collection, source fetching |
+| [`packages/react`](packages/react)                                     | [`@flareapp/react`](https://www.npmjs.com/package/@flareapp/react)                                     | React error boundary component and React 19 error handler                           |
+| [`packages/vue`](packages/vue)                                         | [`@flareapp/vue`](https://www.npmjs.com/package/@flareapp/vue)                                         | Vue error handler plugin                                                            |
+| [`packages/svelte`](packages/svelte)                                   | [`@flareapp/svelte`](https://www.npmjs.com/package/@flareapp/svelte)                                   | Svelte 5 error boundary component and boundary handler factory                      |
+| [`packages/sveltekit`](packages/sveltekit)                             | [`@flareapp/sveltekit`](https://www.npmjs.com/package/@flareapp/sveltekit)                             | SvelteKit client/server error hooks and route context                               |
+| [`packages/node`](packages/node)                                       | [`@flareapp/node`](https://www.npmjs.com/package/@flareapp/node)                                       | Node.js SDK with process handlers and AsyncLocalStorage scope                       |
+| [`packages/electron`](packages/electron)                               | [`@flareapp/electron`](https://www.npmjs.com/package/@flareapp/electron)                               | Electron SDK (main + preload + renderer)                                            |
+| [`packages/react-native`](packages/react-native)                       | [`@flareapp/react-native`](https://www.npmjs.com/package/@flareapp/react-native)                       | React Native SDK (pure-JS, Expo + bare; requires RN 0.79+)                          |
+| [`packages/react-native-sourcemaps`](packages/react-native-sourcemaps) | [`@flareapp/react-native-sourcemaps`](https://www.npmjs.com/package/@flareapp/react-native-sourcemaps) | React Native / Metro sourcemap upload (Babel version inlining + upload CLI)         |
+| [`packages/vite`](packages/vite)                                       | [`@flareapp/vite`](https://www.npmjs.com/package/@flareapp/vite)                                       | Vite build plugin for sourcemap uploads                                             |
+| [`packages/webpack`](packages/webpack)                                 | [`@flareapp/webpack`](https://www.npmjs.com/package/@flareapp/webpack)                                 | Webpack 5 plugin for sourcemap uploads                                              |
+| [`packages/nextjs`](packages/nextjs)                                   | [`@flareapp/nextjs`](https://www.npmjs.com/package/@flareapp/nextjs)                                   | Next.js wrapper for sourcemap uploads via webpack                                   |
+| [`packages/flare-api`](packages/flare-api)                             | (private)                                                                                              | Shared API client for sourcemap uploads (internal)                                  |
+| [`playgrounds/shared`](playgrounds/shared)                             | (private)                                                                                              | Shared fixtures: product data, error scenarios, test IDs, Tailwind tokens           |
+| [`playgrounds/js`](playgrounds/js)                                     | (private)                                                                                              | Vanilla TS + Vite playground (port 5180)                                            |
+| [`playgrounds/react`](playgrounds/react)                               | (private)                                                                                              | React 19 + TanStack Router playground (port 5181)                                   |
+| [`playgrounds/vue`](playgrounds/vue)                                   | (private)                                                                                              | Vue 3 + vue-router playground (port 5182)                                           |
+| [`playgrounds/svelte`](playgrounds/svelte)                             | (private)                                                                                              | SvelteKit (adapter-node) playground (port 5183)                                     |
+| [`playgrounds/nextjs`](playgrounds/nextjs)                             | (private)                                                                                              | Next.js 15 App Router playground (port 5184)                                        |
+| [`playgrounds/react-router`](playgrounds/react-router)                 | (private)                                                                                              | React 19 + React Router v7 (data mode) playground (port 5185)                       |
+| [`playgrounds/react-native-bare`](playgrounds/react-native-bare)       | (private)                                                                                              | Bare RN manual smoke-test app for `@flareapp/react-native`                          |
+| [`playgrounds/react-native-expo`](playgrounds/react-native-expo)       | (private)                                                                                              | Expo manual smoke-test app (incl. Expo device/app context)                          |
 
 ## Local development
 
@@ -63,35 +65,37 @@ npm run build
 
 All commands are run from the repository root:
 
-| Command                      | Description                                                                                    |
-| ---------------------------- | ---------------------------------------------------------------------------------------------- |
-| `npm run build`              | Build all packages to their respective `dist` folders                                          |
-| `npm run test`               | Run tests for all packages that have them                                                      |
-| `npm run typescript`         | Type-check all packages                                                                        |
-| `npm run format`             | Run oxfmt across all files                                                                     |
-| `npm run lint`               | Run oxlint across all packages                                                                 |
-| `npm run test:e2e`           | Run the Playwright suite across all four framework playgrounds                                 |
-| `npm run playgrounds:js`     | Build packages, then start the vanilla JS playground (port 5180)                               |
-| `npm run playgrounds:react`  | Build packages, then start the React playground (port 5181)                                    |
-| `npm run playgrounds:vue`    | Build packages, then start the Vue playground (port 5182)                                      |
-| `npm run playgrounds:svelte` | Build packages, then start the SvelteKit playground (port 5183)                                |
-| `npm run playgrounds:nextjs` | Build packages, then start the Next.js playground (port 5184)                                  |
-| `npm run release:all`        | Lockstep-release the 8 public packages; optionally includes core, node, electron, react-native |
+| Command                            | Description                                                                                    |
+| ---------------------------------- | ---------------------------------------------------------------------------------------------- |
+| `npm run build`                    | Build all packages to their respective `dist` folders                                          |
+| `npm run test`                     | Run tests for all packages that have them                                                      |
+| `npm run typescript`               | Type-check all packages                                                                        |
+| `npm run format`                   | Run oxfmt across all files                                                                     |
+| `npm run lint`                     | Run oxlint across all packages                                                                 |
+| `npm run test:e2e`                 | Run the Playwright suite across all five framework playgrounds                                 |
+| `npm run playgrounds:js`           | Build packages, then start the vanilla JS playground (port 5180)                               |
+| `npm run playgrounds:react`        | Build packages, then start the React playground (port 5181)                                    |
+| `npm run playgrounds:vue`          | Build packages, then start the Vue playground (port 5182)                                      |
+| `npm run playgrounds:svelte`       | Build packages, then start the SvelteKit playground (port 5183)                                |
+| `npm run playgrounds:nextjs`       | Build packages, then start the Next.js playground (port 5184)                                  |
+| `npm run playgrounds:react-router` | Build packages, then start the React Router v7 playground (port 5185)                          |
+| `npm run release:all`              | Lockstep-release the 8 public packages; optionally includes core, node, electron, react-native |
 
 ### Playgrounds
 
-There are five parallel playgrounds under `playgrounds/`, one per framework. Each implements the same webshop sample
+There are six parallel playgrounds under `playgrounds/`, one per framework (two are React: TanStack Router and React Router v7). Each implements the same webshop sample
 app (product grid, product detail, cart, checkout, confirmation) plus a `/broken` page that triggers a deterministic
 list of error scenarios. They share fixtures from `@flareapp/playgrounds-shared` so the surface stays identical across
 frameworks.
 
 ```bash
 # Pick the framework you want to explore
-npm run playgrounds:js       # http://localhost:5180
-npm run playgrounds:react    # http://localhost:5181
-npm run playgrounds:vue      # http://localhost:5182
-npm run playgrounds:svelte   # http://localhost:5183
-npm run playgrounds:nextjs   # http://localhost:5184
+npm run playgrounds:js           # http://localhost:5180
+npm run playgrounds:react        # http://localhost:5181
+npm run playgrounds:vue          # http://localhost:5182
+npm run playgrounds:svelte       # http://localhost:5183
+npm run playgrounds:nextjs       # http://localhost:5184
+npm run playgrounds:react-router # http://localhost:5185
 ```
 
 To send reports to a real Flare project (instead of letting them fail), set `VITE_FLARE_URL` and `VITE_FLARE_KEY` for
@@ -100,7 +104,7 @@ nowhere to land.
 
 ### E2E suite
 
-End-to-end tests live in `e2e/` and run all four playgrounds against a local fake Flare server (`e2e/fake-flare-server/`)
+End-to-end tests live in `e2e/` and run all five playgrounds against a local fake Flare server (`e2e/fake-flare-server/`)
 that records report POSTs and exposes inspection endpoints for the tests. Playwright spawns each playground's Vite dev
 server automatically.
 
@@ -108,7 +112,7 @@ server automatically.
 # One-time browser install
 npx playwright install chromium --with-deps
 
-# Run the suite (~25s, 44 tests across js/react/vue/svelte)
+# Run the suite (~90s, 93 tests across js/react/vue/svelte/react-router)
 npm run test:e2e
 
 # One project, one scenario
@@ -136,7 +140,7 @@ GitHub Actions runs on every push:
 
 - **Test**: installs dependencies, builds all packages, runs all tests (Vitest)
 - **TypeScript**: installs dependencies, builds all packages, type-checks all packages
-- **E2E**: installs dependencies, caches Playwright browsers by `@playwright/test` version, builds all packages, and runs the Playwright suite across all four framework playgrounds (Chromium). HTML reports are uploaded as artifacts on every run; traces and screenshots are uploaded only on failure.
+- **E2E**: installs dependencies, caches Playwright browsers by `@playwright/test` version, builds all packages, and runs the Playwright suite across all five framework playgrounds (Chromium). HTML reports are uploaded as artifacts on every run; traces and screenshots are uploaded only on failure.
 
 ## Versioning and releasing
 
@@ -234,6 +238,7 @@ flare-client-js/
 │   ├── shared/      # Shared fixtures (products, scenarios, test IDs, Tailwind tokens)
 │   ├── js/          # Vanilla TS + Vite playground
 │   ├── react/       # React + TanStack Router playground
+│   ├── react-router/ # React + React Router v7 playground
 │   ├── vue/         # Vue + vue-router playground
 │   ├── svelte/      # SvelteKit playground
 │   └── nextjs/      # Next.js playground

--- a/docs/superpowers/specs/2026-07-14-react-router-v7-playground-design.md
+++ b/docs/superpowers/specs/2026-07-14-react-router-v7-playground-design.md
@@ -221,6 +221,15 @@ handles or latches it. Consequences:
   `RootLayout` renders *inside* `RouterProvider`, so `useLocation()` is available
   directly (no `router.subscribe` shim).
 
+**Scope of capture.** Wrapping `<Outlet/>` means this boundary catches child-route
+*render* errors only. Two classes are intentionally out of scope and fall through
+to RR's own default boundary (which latches them in `router.state.errors`): (a) a
+render error thrown by `RootLayout` itself (header / `useCartCount`), and (b)
+loader/action errors — RR routes those to its error path, never a React render
+throw, and no route defines an `errorElement`. No playground scenario exercises
+either, so this is an accepted limitation; a future scenario that throws in the
+layout or a loader would need an explicit `errorElement`/handler to reach Flare.
+
 **Validation-first risk:** the assumption that RR's default root boundary does
 not intercept a child-route render error before the inner `FlareErrorBoundary` is
 the single behavior to confirm first during implementation (via the

--- a/docs/superpowers/specs/2026-07-14-react-router-v7-playground-design.md
+++ b/docs/superpowers/specs/2026-07-14-react-router-v7-playground-design.md
@@ -1,0 +1,334 @@
+# React Router v7 (data mode) playground
+
+Date: 2026-07-14
+Status: Approved (design)
+
+## Problem
+
+The repo ships four parallel webshop playgrounds (`js`, `react`, `vue`, `svelte`),
+one per framework, each implementing the same spec so the Playwright suite can
+exercise the SDK uniformly. The React playground is built on **TanStack Router**
+and exercises `traceTanStackRouter`.
+
+`@flareapp/react` also ships a second router integration —
+`@flareapp/react/react-router`'s `traceReactRouter` — for **React Router v7 data
+mode** (`createBrowserRouter` / `createHashRouter` / `createMemoryRouter` +
+`RouterProvider`). Nothing exercises it end-to-end. It is covered only by vitest
+unit/integration tests against `createMemoryRouter`. There is no playground and no
+Playwright regression coverage for its two navigation branches (held loader roots
+vs. loader-less navigations).
+
+This design adds a fifth playground: a faithful webshop twin of the React
+playground, re-wired onto React Router v7 data mode and traced with
+`traceReactRouter`, plus a Playwright project that exercises it.
+
+## Goals
+
+- A new `@flareapp/playgrounds-react-router` workspace: a faithful twin of the
+  React playground (same header, product grid, detail, cart, checkout,
+  confirmation, broken page; same shared `testIds`, scenarios, and Tailwind
+  styling), built on `createBrowserRouter` + `RouterProvider`.
+- `traceReactRouter(router)` wired in `main.tsx`.
+- A mix of loader and loader-less routes so both `traceReactRouter` navigation
+  branches are exercised: `/product/:id` has an async loader (held nav root),
+  the rest are loader-less.
+- Error/log scenarios reuse the shared spec via `coverageFor('react')` /
+  `logCoverageFor('react')` — no change to the shared `Framework` union.
+- The Flare profiler (`withFlareProfiler`) mirrors the React playground's
+  wrapping, demonstrating profiler component spans nesting under RR data-mode
+  nav roots.
+- A `react-router` Playwright project (port 5185) with a `react-router.spec.ts`
+  mirroring `react.spec.ts`, plus tracing assertions for the pageload root and
+  both navigation branches.
+
+## Non-goals
+
+- No change to any `@flareapp/*` package behavior. This is playground UI + e2e
+  only; `traceReactRouter` is consumed as-is.
+- No change to the shared `Framework` union or `coverageFor`/`logCoverageFor`
+  exclusion maps. The RR playground is React and reuses the `'react'` coverage.
+- No `reactInvariant` route. That route exists only for the prod-build minified
+  error-decode suite (`react-prod.spec.ts`); the RR playground runs dev-mode e2e
+  only, so it is omitted. (A prod suite for RR is a later, separate change.)
+- No RR **framework mode** (formerly Remix, file-based + SSR) and no
+  **declarative mode** (`<BrowserRouter>` + `<Routes>`). `traceReactRouter`
+  targets **data-mode** routers only (it needs `router.subscribe` / `router.state`).
+- No hash-router variant. `createBrowserRouter` only. (`traceReactRouter` has a
+  documented hash-fragment url limitation that is out of scope here.)
+
+## Package layout
+
+New workspace `playgrounds/react-router/` (picked up by the existing
+`playgrounds/*` glob in the root `package.json` workspaces).
+
+```
+playgrounds/react-router/
+  package.json          # @flareapp/playgrounds-react-router, dep react-router@^7.6.0
+  index.html            # verbatim from react playground (title updated)
+  env.d.ts              # verbatim
+  vite.config.ts        # port 5185 (server + preview), sourcemap: true
+  tsconfig.json         # verbatim
+  tsconfig.node.json    # verbatim
+  .env.example          # verbatim
+  src/
+    main.tsx            # initFlare(); traceReactRouter(router); render RouterProvider
+    router.tsx          # createBrowserRouter([rootRoute])
+    flare.ts            # copied; default key 'test-key-react-router'
+    cart.ts             # verbatim (framework-agnostic useSyncExternalStore store)
+    components/
+      Fallback.tsx      # verbatim
+    routes/
+      root.tsx          # RootLayout (header/nav + FlareErrorBoundary>Outlet) + rootRoute
+      products.tsx      # ProductsPage (index route)
+      product.tsx       # ProductPage + async loader
+      cart.tsx          # CartPage
+      checkout.tsx      # CheckoutPage
+      confirmation.tsx  # ConfirmationPage
+      broken.tsx        # BrokenPage (error + log scenario buttons)
+```
+
+- **npm name:** `@flareapp/playgrounds-react-router`
+- **port:** 5185 (5180 js, 5181 react, 5182 vue, 5183 svelte, 5184 nextjs are taken)
+- **deps:** `@flareapp/js: *`, `@flareapp/react: *`, `@flareapp/playgrounds-shared: *`,
+  `react-router: ^7.6.0` (unified v7 package; `createBrowserRouter`, `RouterProvider`,
+  `useLoaderData`, `Link`, `Outlet`, `useNavigate`, `useLocation` all export from it),
+  `react`/`react-dom: ^19`.
+- **devDeps:** `@tailwindcss/vite`, `@vitejs/plugin-react`, `@types/react`,
+  `@types/react-dom`, `tailwindcss`, `typescript`, `vite` (same set as react playground,
+  minus TanStack).
+
+## Router & tracing wiring
+
+`src/router.tsx` builds a data router from per-file `RouteObject` modules, using
+`Component` + `loader` (not `element`):
+
+```ts
+export const router = createBrowserRouter([rootRoute]);
+```
+
+where `rootRoute` (in `routes/root.tsx`) is:
+
+```ts
+export const rootRoute: RouteObject = {
+    path: '/',
+    Component: RootLayout,
+    children: [
+        { index: true, Component: ProductsPage },
+        { path: 'product/:id', Component: ProductPage, loader: productLoader },
+        { path: 'cart', Component: CartPage },
+        { path: 'checkout', Component: CheckoutPage },
+        { path: 'confirmation', Component: ConfirmationPage },
+        { path: 'broken', Component: BrokenPage },
+    ],
+};
+```
+
+`src/main.tsx`:
+
+```tsx
+initFlare();
+traceReactRouter(router); // subscribes once, outside React
+
+createRoot(container).render(
+    <StrictMode>
+        <RouterProvider router={router} />
+    </StrictMode>,
+);
+```
+
+`traceReactRouter` is called before render; it reads the router's
+synchronously-resolved initial matches to name the `browser_pageload` root and
+subscribes for subsequent navigations. StrictMode's double-invocation does not
+affect it (the subscription lives outside React, and the profiler's record-once
+ref already handles StrictMode).
+
+`src/flare.ts` is copied from the react playground unchanged except the default
+key (`'test-key-react-router'`): same `idleTimeout: 2000` / `spanFlushIntervalMs: 500`
+e2e timing, `enableLogs`, `enableTracing`, `tracesSampleRate: 1`,
+`beforeEvaluate` (drops `hook-drop-report`), `beforeSubmit` (mutates
+`hook-mutate-report`), and the `__flare` global for the e2e suite.
+
+## Loaders (both tracing branches)
+
+- **`/product/:id`** gets an async loader:
+
+  ```ts
+  const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+  export async function productLoader({ params }) {
+      await sleep(150);            // deterministic loading window, no network
+      return { product: productById(params.id) };
+  }
+  ```
+
+  `ProductPage` reads it via `useLoaderData()`. The loading window makes RR
+  publish a non-idle `navigation.state` before the URL commits, so
+  `traceReactRouter` opens a **held** `browser_navigation` root and names it at
+  settle from the committed matches (`/product/:id`).
+
+- **`/`, `/cart`, `/checkout`, `/confirmation`, `/broken`** are loader-less. RR
+  short-circuits to a single idle fire with the committed location, so
+  `traceReactRouter` takes its **loader-less** branch (open + settle in one fire,
+  no hold).
+
+The `sleep(150)` is a fixed delay with no network dependency, keeping the e2e
+deterministic. (A real fetch inside the loader to demonstrate fetch spans nesting
+under the nav root is a possible later enhancement, not part of this cut.)
+
+## Error handling in RR data mode
+
+This is the one non-trivial difference from the React (TanStack) playground.
+
+In RR data mode, RR intercepts a route's render error via its own error-boundary
+machinery **before** any React error boundary mounted *above* `RouterProvider`
+sees it, and it **latches** the error in `router.state.errors` (which would break
+a naive rethrow-to-outer-boundary reset). The TanStack playground's approach
+(wrap `RouterProvider` from outside + disable the router catch) does not port
+cleanly.
+
+Instead, the **root route element wraps `<Outlet/>` in `FlareErrorBoundary`**:
+
+```tsx
+function RootLayout() {
+    const pathname = useLocation().pathname;
+    return (
+        <div /* header + nav, same markup as react Layout */>
+            ...
+            <main>
+                <FlareErrorBoundary fallback={Fallback} resetKeys={[pathname]}>
+                    <Outlet />
+                </FlareErrorBoundary>
+            </main>
+        </div>
+    );
+}
+```
+
+Because **no route defines an `errorElement`/`ErrorBoundary`**, RR inserts no
+per-route error boundary. A child-route render error therefore propagates up the
+React tree to this `FlareErrorBoundary` (a descendant of RR's default root
+boundary, an ancestor of the route component), which catches it first. RR never
+handles or latches it. Consequences:
+
+- `render-error`: reported with React component-stack context (via
+  `FlareErrorBoundary`'s `componentDidCatch`), Fallback shown.
+- `boundary-reset`: `resetErrorBoundary()` re-renders the Outlet subtree, which
+  remounts `BrokenPage` with fresh local state (`renderTrigger = null`), so it
+  does not re-throw and the Fallback hides — identical recovery semantics to the
+  other playgrounds, with no RR error state to clear.
+- Navigating to a different route changes `useLocation().pathname`, so
+  `resetKeys` auto-resets the boundary on navigation (matching the react
+  playground's `resetKeys={[pathname]}` behavior). Unlike the TanStack playground,
+  `RootLayout` renders *inside* `RouterProvider`, so `useLocation()` is available
+  directly (no `router.subscribe` shim).
+
+**Validation-first risk:** the assumption that RR's default root boundary does
+not intercept a child-route render error before the inner `FlareErrorBoundary` is
+the single behavior to confirm first during implementation (via the
+`render-error` / `boundary-reset` e2e). If it turns out RR's default boundary
+wins, the fallback is: set the root route's `ErrorBoundary` to
+`() => { throw useRouteError(); }` (bubbling above `RouterProvider` to an outer
+`FlareErrorBoundary`) and drive reset by navigating to clear the latched error.
+The inner-wrap approach is expected to work and is cleaner, so it is the primary
+design.
+
+Event/manual scenarios (`sync-throw`, `async-throw`, `unhandled-rejection`,
+`manual-report`, `glow-then-throw`, `hook-drop-report`, `hook-mutate-report`)
+need no boundary: they route through `@flareapp/js` window listeners (set up on
+import) or `flare.report`, identical to the react playground. `BrokenPage` reuses
+the react playground's `eventTriggers` map and `MaybeThrowing` / `renderTrigger`
+render-error pattern verbatim.
+
+## Profiler
+
+Mirror the react playground's `withFlareProfiler` usage for parity:
+`RootLayout`, `ProductsPage`, `ProductPage`, and the `AddToCartButton` are
+wrapped. This exercises profiler component spans under RR data-mode roots,
+including the persistent-layout case (a profiled root layout that stays mounted
+across navigations), which the profiler re-homes to the live root.
+
+## Shared spec reuse
+
+- `coverageFor('react')` drives `BrokenPage`'s error buttons; `logCoverageFor('react')`
+  drives the log buttons. The `'react'` coverage excludes `sourcemap-mapped` and
+  `sveltekit-server-throw` (both irrelevant here) and includes `render-error` /
+  `boundary-reset` (handled by the root `FlareErrorBoundary` above).
+- No new `testIds`, scenarios, or `Framework` values. The e2e project name is
+  `react-router`, but the spec passes `'react'` to the shared coverage helpers.
+
+## e2e integration
+
+### `playwright.config.ts`
+
+Add to `devProjects`:
+
+```ts
+{
+    name: 'react-router',
+    testMatch: /react-router\.spec\.ts$/,
+    use: { baseURL: 'http://localhost:5185', browserName: 'chromium' },
+},
+```
+
+Add to `devWebServers`:
+
+```ts
+{
+    command: 'npm run dev --workspace=@flareapp/playgrounds-react-router',
+    url: 'http://localhost:5185',
+    reuseExistingServer: !process.env.CI,
+    timeout: 60_000,
+    env: { ...sharedEnv, VITE_FLARE_KEY: 'test-key-react-router' },
+},
+```
+
+The prod suite (`prodProjects`/`prodWebServers`) is untouched.
+
+### `e2e/specs/react-router.spec.ts`
+
+Mirrors `react.spec.ts`, reusing `runScenario` / `scenariosFor('react')`,
+`runLogScenario` / `logScenariosFor('react')`, and the same OTLP span helpers:
+
+- `renders product grid`
+- `checkout happy path reports no errors` (add to cart -> cart -> checkout ->
+  submit -> confirmation; `assertNoReports`)
+- `error scenarios` — `runScenario` per `scenariosFor('react')`
+- `log scenarios` — `runLogScenario` per `logScenariosFor('react')`
+- `pageload root carries the parameterized route and route source` — deep-link
+  `/product/p01`, `waitForTrace` for a `browser_pageload` span whose
+  `flare.route.source` is `route` and whose name is `/product/:id`
+- `loader navigation opens a parameterized browser_navigation root` — from `/`,
+  click a product link, `waitForTrace` for a `browser_navigation` span named
+  `/product/:id` with `route` source (exercises the **held loader** branch)
+- `loader-less navigation opens a parameterized browser_navigation root` — click
+  the Cart link, `waitForTrace` for a `browser_navigation` span named `/cart`
+  (exercises the **loader-less** branch)
+
+Each nav test uses `page.waitForLoadState('networkidle')` after the initial
+`goto` before clicking, matching the existing specs.
+
+## Root scripts & docs
+
+- Root `package.json`: add
+  `"playgrounds:react-router": "npm run build --workspaces --if-present && npm run dev --workspace=@flareapp/playgrounds-react-router"`
+  (same shape as the other `playgrounds:*` scripts).
+- `CLAUDE.md`: add a `playgrounds/react-router` row to the Monorepo structure
+  table and a `playgrounds:react-router` line to the Commands block.
+
+## Testing strategy
+
+- **Primary:** the `react-router` Playwright project. The playground app has no
+  standalone unit tests (consistent with the other playgrounds); its behavior is
+  asserted by e2e.
+- **TDD order:** wire the playground enough to boot, then make the e2e spec pass
+  scenario-group by scenario-group, validating the `render-error` /
+  `boundary-reset` error-boundary behavior first (the one design risk), then the
+  tracing assertions (pageload, loader nav, loader-less nav).
+- **Manual:** `npm run playgrounds:react-router` -> `http://localhost:5185` for
+  exploration (reports fail to send without a fake server, as with the others).
+
+## Rollout
+
+Single PR on the current `react-router-v7-integration` branch (or a follow-on
+branch), independent of the pending `@flareapp/js` version bump / react peer-floor
+raise tracked for the `traceReactRouter` feature itself — the playground consumes
+the workspace `*` versions and does not gate the publish.

--- a/e2e/fake-flare-server/server.ts
+++ b/e2e/fake-flare-server/server.ts
@@ -3,10 +3,13 @@ import type { AddressInfo } from 'node:net';
 
 import type { FakeFlareEndpoint, FakeFlareRecord, FakeFlareServer, WaitForOptions } from './types';
 
-const REPORTS_PATH = '/api/reports';
+// Ingress paths mirror the real Flare ingress (routes/ingress.php): errors, traces, and logs are
+// served under /v1. Sourcemap upload keeps the real /api/sourcemaps endpoint. The internal endpoint
+// buckets (reports/logs/traces) are unchanged.
+const REPORTS_PATH = '/v1/errors';
 const SOURCEMAPS_PATH = '/api/sourcemaps';
-const LOGS_PATH = '/api/logs';
-const TRACES_PATH = '/api/traces';
+const LOGS_PATH = '/v1/logs';
+const TRACES_PATH = '/v1/traces';
 const INSPECT_REPORTS = '/__inspect/reports';
 const INSPECT_RESET = '/__inspect/reset';
 

--- a/e2e/node-frameworks/helpers.ts
+++ b/e2e/node-frameworks/helpers.ts
@@ -62,7 +62,7 @@ export const close = (server: Server): Promise<void> =>
  * handlers so a framework-caught error never exits the test process.
  */
 export const setupFlare = (): void => {
-    flare.configure({ ingestUrl: `${fakeBaseUrl()}/api/reports` });
+    flare.configure({ ingestUrl: `${fakeBaseUrl()}/v1/errors` });
     flare.configureNode({ uncaughtExceptionMode: 'off', unhandledRejectionMode: 'off' });
     // Synthetic key on purpose: reports go to the fake server, not real Flare. Do not wire an env key here.
     flare.light('node-frameworks-test');

--- a/e2e/specs/otlp.ts
+++ b/e2e/specs/otlp.ts
@@ -1,0 +1,19 @@
+// Shared OTLP trace-span parsing helpers for the tracing e2e specs (react, react-router).
+
+export type OtlpSpan = {
+    name: string;
+    spanId: string;
+    parentSpanId: string | null;
+    traceId: string;
+    attributes: Array<{ key: string; value: Record<string, unknown> }>;
+};
+
+export const spansOf = (bodyJson: unknown): OtlpSpan[] =>
+    ((bodyJson as { resourceSpans?: Array<{ scopeSpans?: Array<{ spans?: OtlpSpan[] }> }> }).resourceSpans ?? [])
+        .flatMap((r) => r.scopeSpans ?? [])
+        .flatMap((s) => s.spans ?? []);
+
+export const attr = (span: OtlpSpan, key: string): unknown => span.attributes.find((a) => a.key === key)?.value;
+
+export const hasSpanType = (span: OtlpSpan, type: string): boolean =>
+    JSON.stringify(attr(span, 'flare.span_type') ?? '').includes(type);

--- a/e2e/specs/react-router.spec.ts
+++ b/e2e/specs/react-router.spec.ts
@@ -1,25 +1,8 @@
 import { testIds } from '../../playgrounds/shared/src';
 import { expect, test } from '../fixtures/fake-flare';
 import { logScenariosFor, runLogScenario } from './logShared';
+import { attr, hasSpanType, spansOf } from './otlp';
 import { runScenario, scenariosFor } from './shared';
-
-type OtlpSpan = {
-    name: string;
-    spanId: string;
-    parentSpanId: string | null;
-    traceId: string;
-    attributes: Array<{ key: string; value: Record<string, unknown> }>;
-};
-
-const spansOf = (bodyJson: unknown): OtlpSpan[] =>
-    ((bodyJson as { resourceSpans?: Array<{ scopeSpans?: Array<{ spans?: OtlpSpan[] }> }> }).resourceSpans ?? [])
-        .flatMap((r) => r.scopeSpans ?? [])
-        .flatMap((s) => s.spans ?? []);
-
-const attr = (span: OtlpSpan, key: string): unknown => span.attributes.find((a) => a.key === key)?.value;
-
-const hasSpanType = (span: OtlpSpan, type: string): boolean =>
-    JSON.stringify(attr(span, 'flare.span_type') ?? '').includes(type);
 
 test.describe('react-router playground', () => {
     test('renders product grid', async ({ page }) => {

--- a/e2e/specs/react-router.spec.ts
+++ b/e2e/specs/react-router.spec.ts
@@ -1,0 +1,131 @@
+import { testIds } from '../../playgrounds/shared/src';
+import { expect, test } from '../fixtures/fake-flare';
+import { logScenariosFor, runLogScenario } from './logShared';
+import { runScenario, scenariosFor } from './shared';
+
+type OtlpSpan = {
+    name: string;
+    spanId: string;
+    parentSpanId: string | null;
+    traceId: string;
+    attributes: Array<{ key: string; value: Record<string, unknown> }>;
+};
+
+const spansOf = (bodyJson: unknown): OtlpSpan[] =>
+    ((bodyJson as { resourceSpans?: Array<{ scopeSpans?: Array<{ spans?: OtlpSpan[] }> }> }).resourceSpans ?? [])
+        .flatMap((r) => r.scopeSpans ?? [])
+        .flatMap((s) => s.spans ?? []);
+
+const attr = (span: OtlpSpan, key: string): unknown => span.attributes.find((a) => a.key === key)?.value;
+
+const hasSpanType = (span: OtlpSpan, type: string): boolean =>
+    JSON.stringify(attr(span, 'flare.span_type') ?? '').includes(type);
+
+test.describe('react-router playground', () => {
+    test('renders product grid', async ({ page }) => {
+        await page.goto('/');
+        await expect(page.getByTestId(testIds.productGrid)).toBeVisible();
+    });
+
+    test('checkout happy path reports no errors', async ({ page, fakeFlare }) => {
+        await page.goto('/');
+        await page.getByTestId(testIds.addToCart('p01')).click();
+        await page.getByRole('link', { name: 'Cart' }).click();
+        await expect(page.getByTestId(testIds.cartItem('p01'))).toBeVisible();
+        await page.getByRole('link', { name: 'Checkout' }).click();
+        await page.getByTestId(testIds.checkoutSubmit).click();
+        await expect(page.getByTestId(testIds.confirmation)).toBeVisible();
+        await fakeFlare.assertNoReports();
+    });
+
+    test.describe('error scenarios', () => {
+        for (const scenario of scenariosFor('react')) {
+            test(scenario.id, async ({ page, fakeFlare }) => {
+                await page.goto('/broken');
+                await page.waitForLoadState('networkidle');
+                await runScenario(page, fakeFlare, scenario);
+            });
+        }
+    });
+
+    test('pageload root carries the parameterized route and route source', async ({ page, fakeFlare }) => {
+        await page.goto('/product/p01'); // deep-link the initial load (loader route)
+        await page.waitForLoadState('networkidle');
+
+        const trace = await fakeFlare.waitForTrace({
+            timeout: 9000,
+            predicate: (r) => {
+                const pl = spansOf(r.bodyJson).find((s) => hasSpanType(s, 'browser_pageload'));
+                return !!pl && JSON.stringify(attr(pl, 'flare.route.source') ?? '').includes('route');
+            },
+        });
+        const pageload = spansOf(trace.bodyJson).find((s) => hasSpanType(s, 'browser_pageload'));
+        expect(pageload && attr(pageload, 'flare.entry_point.handler.identifier')).toEqual({
+            stringValue: '/product/:id',
+        });
+        expect(pageload && attr(pageload, 'flare.route.source')).toEqual({ stringValue: 'route' });
+    });
+
+    test('loader navigation opens a parameterized browser_navigation root', async ({ page, fakeFlare }) => {
+        await page.goto('/');
+        await page.waitForLoadState('networkidle');
+
+        await page.locator('a[href="/product/p01"]').first().click(); // loader route -> held nav root
+
+        const trace = await fakeFlare.waitForTrace({
+            timeout: 9000,
+            predicate: (r) => {
+                const nav = spansOf(r.bodyJson).find((s) => hasSpanType(s, 'browser_navigation'));
+                return (
+                    !!nav &&
+                    JSON.stringify(attr(nav, 'flare.entry_point.handler.identifier') ?? '').includes('/product/:id')
+                );
+            },
+        });
+        const nav = spansOf(trace.bodyJson).find((s) => hasSpanType(s, 'browser_navigation'));
+        expect(nav && attr(nav, 'flare.entry_point.handler.identifier')).toEqual({ stringValue: '/product/:id' });
+        expect(nav && attr(nav, 'flare.route.source')).toEqual({ stringValue: 'route' });
+
+        // No-double-roots invariant: registerNavigationSource suppresses the History-based root,
+        // so this one click produced exactly ONE browser_navigation root across all traces.
+        const navSpans = (await fakeFlare.traces())
+            .flatMap((t) => spansOf(t.bodyJson))
+            .filter((s) => hasSpanType(s, 'browser_navigation'));
+        expect(navSpans).toHaveLength(1);
+    });
+
+    test('loader-less navigation opens a parameterized browser_navigation root', async ({ page, fakeFlare }) => {
+        await page.goto('/');
+        await page.waitForLoadState('networkidle');
+
+        await page.locator('a[href="/cart"]').first().click(); // no loader -> loader-less nav root
+
+        const trace = await fakeFlare.waitForTrace({
+            timeout: 9000,
+            predicate: (r) => {
+                const nav = spansOf(r.bodyJson).find((s) => hasSpanType(s, 'browser_navigation'));
+                return (
+                    !!nav && JSON.stringify(attr(nav, 'flare.entry_point.handler.identifier') ?? '').includes('/cart')
+                );
+            },
+        });
+        const nav = spansOf(trace.bodyJson).find((s) => hasSpanType(s, 'browser_navigation'));
+        expect(nav && attr(nav, 'flare.entry_point.handler.identifier')).toEqual({ stringValue: '/cart' });
+        expect(nav && attr(nav, 'flare.route.source')).toEqual({ stringValue: 'route' });
+
+        const navSpans = (await fakeFlare.traces())
+            .flatMap((t) => spansOf(t.bodyJson))
+            .filter((s) => hasSpanType(s, 'browser_navigation'));
+        expect(navSpans).toHaveLength(1);
+    });
+});
+
+test.describe('react-router logging', () => {
+    for (const scenario of logScenariosFor('react').filter((s) => s.flushOnTrigger)) {
+        test(scenario.id, async ({ page, fakeFlare }) => {
+            await page.goto('/broken');
+            await page.waitForLoadState('networkidle');
+            await runLogScenario(page, fakeFlare, scenario);
+        });
+    }
+});

--- a/e2e/specs/react.spec.ts
+++ b/e2e/specs/react.spec.ts
@@ -1,25 +1,8 @@
 import { testIds } from '../../playgrounds/shared/src';
 import { expect, test } from '../fixtures/fake-flare';
 import { logScenariosFor, runLogScenario } from './logShared';
+import { attr, hasSpanType, spansOf } from './otlp';
 import { runScenario, scenariosFor } from './shared';
-
-type OtlpSpan = {
-    name: string;
-    spanId: string;
-    parentSpanId: string | null;
-    traceId: string;
-    attributes: Array<{ key: string; value: Record<string, unknown> }>;
-};
-
-const spansOf = (bodyJson: unknown): OtlpSpan[] =>
-    ((bodyJson as { resourceSpans?: Array<{ scopeSpans?: Array<{ spans?: OtlpSpan[] }> }> }).resourceSpans ?? [])
-        .flatMap((r) => r.scopeSpans ?? [])
-        .flatMap((s) => s.spans ?? []);
-
-const attr = (span: OtlpSpan, key: string): unknown => span.attributes.find((a) => a.key === key)?.value;
-
-const hasSpanType = (span: OtlpSpan, type: string): boolean =>
-    JSON.stringify(attr(span, 'flare.span_type') ?? '').includes(type);
 
 test.describe('react playground', () => {
     test('renders product grid', async ({ page }) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1643,6 +1643,10 @@
             "resolved": "playgrounds/react",
             "link": true
         },
+        "node_modules/@flareapp/playgrounds-react-router": {
+            "resolved": "playgrounds/react-router",
+            "link": true
+        },
         "node_modules/@flareapp/playgrounds-shared": {
             "resolved": "playgrounds/shared",
             "link": true
@@ -8195,7 +8199,6 @@
             "version": "0.7.2",
             "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
             "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
-            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": ">= 0.6"
@@ -14134,7 +14137,6 @@
             "version": "7.18.1",
             "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.1.tgz",
             "integrity": "sha512-GDLgg3i3uM0aeJO3Fm+TCS+sDQ7gu12T6x0qdTEzcwqEfleci7JwugVNIF3U//0FWKnJT7ptG+20B2jfDqnZAg==",
-            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "cookie": "^1.0.1",
@@ -14905,7 +14907,6 @@
             "version": "2.7.2",
             "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
             "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
-            "dev": true,
             "license": "MIT"
         },
         "node_modules/setprototypeof": {
@@ -18260,6 +18261,26 @@
                 "@tanstack/react-router": "^1.95.0",
                 "react": "^19.0.0",
                 "react-dom": "^19.0.0"
+            },
+            "devDependencies": {
+                "@tailwindcss/vite": "^4.0.0",
+                "@types/react": "^19.0.0",
+                "@types/react-dom": "^19.0.0",
+                "@vitejs/plugin-react": "^4.3.0",
+                "tailwindcss": "^4.0.0",
+                "typescript": "^5.7.0",
+                "vite": "^6.0.0"
+            }
+        },
+        "playgrounds/react-router": {
+            "name": "@flareapp/playgrounds-react-router",
+            "dependencies": {
+                "@flareapp/js": "*",
+                "@flareapp/playgrounds-shared": "*",
+                "@flareapp/react": "*",
+                "react": "^19.0.0",
+                "react-dom": "^19.0.0",
+                "react-router": "^7.6.0"
             },
             "devDependencies": {
                 "@tailwindcss/vite": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
         "playgrounds:vue": "npm run build --workspaces --if-present && npm run dev --workspace=@flareapp/playgrounds-vue",
         "playgrounds:svelte": "npm run build --workspaces --if-present && npm run dev --workspace=@flareapp/playgrounds-svelte",
         "playgrounds:nextjs": "npm run build --workspaces --if-present && npm run dev --workspace=@flareapp/playgrounds-nextjs",
+        "playgrounds:react-router": "npm run build --workspaces --if-present && npm run dev --workspace=@flareapp/playgrounds-react-router",
         "format": "oxfmt .",
         "lint": "oxlint",
         "prepare": "husky",

--- a/packages/node/tests/integration.test.ts
+++ b/packages/node/tests/integration.test.ts
@@ -20,7 +20,7 @@ describe('Node SDK integration', () => {
         const { flare } = await import('../src');
         flare.removeProcessListeners();
         flare.configureNode({ uncaughtExceptionMode: 'off', unhandledRejectionMode: 'off' });
-        flare.configure({ ingestUrl: `${fakeFlareServer.url}/api/reports` });
+        flare.configure({ ingestUrl: `${fakeFlareServer.url}/v1/errors` });
         flare.light('test-key');
 
         fakeFlareServer.reset();

--- a/playgrounds/js/src/flare.ts
+++ b/playgrounds/js/src/flare.ts
@@ -7,8 +7,8 @@ export const initFlare = (): void => {
     if (url) {
         flare.configure({
             ingestUrl: url,
-            logsIngestUrl: url.replace('/api/reports', '/api/logs'),
-            tracesIngestUrl: url.replace('/api/reports', '/api/traces'),
+            logsIngestUrl: url.replace('/v1/errors', '/v1/logs'),
+            tracesIngestUrl: url.replace('/v1/errors', '/v1/traces'),
             // e2e-only timing: keep the pageload/navigation root active long enough for a
             // prompt Playwright click to land and nest under it, then flush an ended root
             // fast so arrival assertions don't need to wait out the (5s) production default.

--- a/playgrounds/react-router/.env.example
+++ b/playgrounds/react-router/.env.example
@@ -1,0 +1,7 @@
+# Flare project API key. Get one at https://flareapp.io.
+VITE_FLARE_KEY=your-flare-project-key
+
+# Optional: full Flare ingest URL. Leave unset to use the default
+# (https://ingress.flareapp.io/v1/errors). Override only for staging or
+# for pointing at the e2e fake-flare-server.
+# VITE_FLARE_URL=https://ingress.flareapp.io/v1/errors

--- a/playgrounds/react-router/env.d.ts
+++ b/playgrounds/react-router/env.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+    readonly VITE_FLARE_KEY?: string;
+    readonly VITE_FLARE_URL?: string;
+}
+
+interface ImportMeta {
+    readonly env: ImportMetaEnv;
+}

--- a/playgrounds/react-router/index.html
+++ b/playgrounds/react-router/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Flare React Router v7 playground</title>
+    </head>
+    <body class="bg-surface-muted font-sans text-brand-ink">
+        <div id="root"></div>
+        <script type="module" src="/src/main.tsx"></script>
+    </body>
+</html>

--- a/playgrounds/react-router/package.json
+++ b/playgrounds/react-router/package.json
@@ -1,0 +1,28 @@
+{
+    "name": "@flareapp/playgrounds-react-router",
+    "private": true,
+    "type": "module",
+    "scripts": {
+        "dev": "vite",
+        "build": "vite build",
+        "preview": "vite preview",
+        "typescript": "tsc --noEmit"
+    },
+    "dependencies": {
+        "@flareapp/js": "*",
+        "@flareapp/react": "*",
+        "@flareapp/playgrounds-shared": "*",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "react-router": "^7.6.0"
+    },
+    "devDependencies": {
+        "@tailwindcss/vite": "^4.0.0",
+        "@types/react": "^19.0.0",
+        "@types/react-dom": "^19.0.0",
+        "@vitejs/plugin-react": "^4.3.0",
+        "tailwindcss": "^4.0.0",
+        "typescript": "^5.7.0",
+        "vite": "^6.0.0"
+    }
+}

--- a/playgrounds/react-router/src/cart.ts
+++ b/playgrounds/react-router/src/cart.ts
@@ -1,0 +1,70 @@
+import { useSyncExternalStore } from 'react';
+
+const KEY = 'flare-playground-cart';
+
+export type CartLine = { productId: string; quantity: number };
+
+type Listener = () => void;
+const listeners = new Set<Listener>();
+
+const read = (): CartLine[] => {
+    try {
+        const raw = localStorage.getItem(KEY);
+        if (!raw) return [];
+        const parsed = JSON.parse(raw);
+        return Array.isArray(parsed) ? parsed : [];
+    } catch {
+        return [];
+    }
+};
+
+// Cache snapshots so useSyncExternalStore receives a stable reference between
+// notifications. Reading on every getSnapshot would return a fresh array each
+// time and trigger React's infinite loop guard.
+let linesSnapshot: CartLine[] = read();
+let countSnapshot: number = linesSnapshot.reduce((sum, line) => sum + line.quantity, 0);
+
+const write = (lines: CartLine[]): void => {
+    localStorage.setItem(KEY, JSON.stringify(lines));
+    linesSnapshot = lines;
+    countSnapshot = lines.reduce((sum, line) => sum + line.quantity, 0);
+    for (const listener of [...listeners]) listener();
+};
+
+const subscribe = (listener: Listener): (() => void) => {
+    listeners.add(listener);
+    return () => {
+        listeners.delete(listener);
+    };
+};
+
+export const cart = {
+    lines: (): CartLine[] => linesSnapshot,
+    add: (productId: string): void => {
+        const lines = [...linesSnapshot];
+        const existing = lines.find((line) => line.productId === productId);
+        if (existing) existing.quantity += 1;
+        else lines.push({ productId, quantity: 1 });
+        write(lines);
+    },
+    remove: (productId: string): void => {
+        write(linesSnapshot.filter((line) => line.productId !== productId));
+    },
+    clear: (): void => write([]),
+    count: (): number => countSnapshot,
+    subscribe,
+};
+
+export const useCart = (): CartLine[] =>
+    useSyncExternalStore(
+        subscribe,
+        () => linesSnapshot,
+        () => linesSnapshot,
+    );
+
+export const useCartCount = (): number =>
+    useSyncExternalStore(
+        subscribe,
+        () => countSnapshot,
+        () => countSnapshot,
+    );

--- a/playgrounds/react-router/src/components/Fallback.tsx
+++ b/playgrounds/react-router/src/components/Fallback.tsx
@@ -1,0 +1,16 @@
+import { testIds } from '@flareapp/playgrounds-shared';
+import type { FlareErrorBoundaryFallbackProps } from '@flareapp/react';
+
+export const Fallback = ({ error, resetErrorBoundary }: FlareErrorBoundaryFallbackProps) => (
+    <div data-testid={testIds.boundaryFallback} className="p-8 text-center">
+        <h2 className="text-lg font-semibold mb-2">Something broke.</h2>
+        <p className="text-sm opacity-70 mb-4">{error.message}</p>
+        <button
+            data-testid={testIds.boundaryReset}
+            onClick={resetErrorBoundary}
+            className="rounded-lg bg-brand-ink text-white px-4 py-2 text-sm"
+        >
+            Reset
+        </button>
+    </div>
+);

--- a/playgrounds/react-router/src/flare.ts
+++ b/playgrounds/react-router/src/flare.ts
@@ -7,8 +7,8 @@ export const initFlare = (): void => {
     if (url) {
         flare.configure({
             ingestUrl: url,
-            logsIngestUrl: url.replace('/api/reports', '/api/logs'),
-            tracesIngestUrl: url.replace('/api/reports', '/api/traces'),
+            logsIngestUrl: url.replace('/v1/errors', '/v1/logs'),
+            tracesIngestUrl: url.replace('/v1/errors', '/v1/traces'),
             // e2e-only timing: keep the pageload/navigation root active long enough for a
             // prompt Playwright click to land and nest under it, then flush an ended root
             // fast so arrival assertions don't need to wait out the (5s) production default.

--- a/playgrounds/react-router/src/flare.ts
+++ b/playgrounds/react-router/src/flare.ts
@@ -1,0 +1,49 @@
+import { flare } from '@flareapp/js';
+
+export const initFlare = (): void => {
+    const url = import.meta.env.VITE_FLARE_URL;
+    const key = import.meta.env.VITE_FLARE_KEY ?? 'test-key-react-router';
+
+    if (url) {
+        flare.configure({
+            ingestUrl: url,
+            logsIngestUrl: url.replace('/api/reports', '/api/logs'),
+            tracesIngestUrl: url.replace('/api/reports', '/api/traces'),
+            // e2e-only timing: keep the pageload/navigation root active long enough for a
+            // prompt Playwright click to land and nest under it, then flush an ended root
+            // fast so arrival assertions don't need to wait out the (5s) production default.
+            idleTimeout: 2000,
+            spanFlushIntervalMs: 500,
+        });
+    }
+
+    flare.configure({
+        // Logging is always on in the playground so the log buttons exercise the
+        // SDK even without a fake server (manual runs POST to the default ingest
+        // and fail like the error reports do). The fake-server logsIngestUrl
+        // override above only applies under e2e (VITE_FLARE_URL set).
+        enableLogs: true,
+        enableTracing: true,
+        tracesSampleRate: 1,
+        beforeEvaluate: (error) => {
+            if (error.message === 'hook-drop-report') return null;
+            return error;
+        },
+        beforeSubmit: (report) => {
+            if (report.message === 'hook-mutate-report') {
+                report.attributes = {
+                    ...report.attributes,
+                    'context.custom_hook': { injectedBy: 'beforeSubmit' },
+                };
+            }
+            return report;
+        },
+    });
+
+    flare.light(key, true);
+
+    // Expose the instance so the e2e suite can drive the tracer directly. Playground-only.
+    (globalThis as { __flare?: typeof flare }).__flare = flare;
+};
+
+export { flare };

--- a/playgrounds/react-router/src/main.tsx
+++ b/playgrounds/react-router/src/main.tsx
@@ -1,0 +1,20 @@
+import '@flareapp/playgrounds-shared/styles.css';
+import { traceReactRouter } from '@flareapp/react/react-router';
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { RouterProvider } from 'react-router';
+
+import { initFlare } from './flare';
+import { router } from './router';
+
+initFlare();
+traceReactRouter(router as unknown as Parameters<typeof traceReactRouter>[0]);
+
+const container = document.getElementById('root');
+if (!container) throw new Error('No #root element');
+
+createRoot(container).render(
+    <StrictMode>
+        <RouterProvider router={router} />
+    </StrictMode>,
+);

--- a/playgrounds/react-router/src/router.tsx
+++ b/playgrounds/react-router/src/router.tsx
@@ -1,0 +1,5 @@
+import { createBrowserRouter } from 'react-router';
+
+import { rootRoute } from './routes/root';
+
+export const router = createBrowserRouter([rootRoute]);

--- a/playgrounds/react-router/src/routes/broken.tsx
+++ b/playgrounds/react-router/src/routes/broken.tsx
@@ -1,0 +1,108 @@
+import { coverageFor, fireLogScenario, logCoverageFor, testIds } from '@flareapp/playgrounds-shared';
+import { useState } from 'react';
+import type { RouteObject } from 'react-router';
+
+import { flare } from '../flare';
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+type RenderTrigger = 'render-error' | 'boundary-reset' | null;
+
+const MaybeThrowing = ({ trigger }: { trigger: RenderTrigger }) => {
+    if (trigger === 'render-error' || trigger === 'boundary-reset') {
+        throw new Error(trigger);
+    }
+    return null;
+};
+
+const eventTriggers: Record<string, () => void | Promise<void>> = {
+    'sync-throw': () => {
+        throw new Error('sync-throw');
+    },
+    'async-throw': async () => {
+        await sleep(20);
+        throw new Error('async-throw');
+    },
+    'unhandled-rejection': () => {
+        void Promise.reject(new Error('unhandled-rejection'));
+    },
+    'manual-report': () => {
+        void flare.report(new Error('manual-report'), {
+            'context.scenario': { source: 'manual-report', userId: 'usr_42' },
+        });
+    },
+    'glow-then-throw': () => {
+        flare.glow('clicked checkout', 'info', { step: 1 });
+        flare.glow('validated cart', 'info', { step: 2 });
+        flare.glow('called payment', 'warning', { step: 3 });
+        throw new Error('glow-then-throw');
+    },
+    'hook-drop-report': () => {
+        void flare.report(new Error('hook-drop-report'));
+    },
+    'hook-mutate-report': () => {
+        void flare.report(new Error('hook-mutate-report'));
+    },
+    'sourcemap-mapped': () => {
+        throw new Error('sourcemap-mapped');
+    },
+};
+
+const BrokenPage = () => {
+    const scenarios = coverageFor('react');
+    const logScenarios = logCoverageFor('react');
+    const [renderTrigger, setRenderTrigger] = useState<RenderTrigger>(null);
+
+    const onClick = (id: string) => {
+        if (id === 'render-error' || id === 'boundary-reset') {
+            setRenderTrigger(id);
+            return;
+        }
+        const trigger = eventTriggers[id];
+        if (!trigger) return;
+        void trigger();
+    };
+
+    return (
+        <section>
+            <h1 className="text-xl font-semibold mb-2">Error playground</h1>
+            <p className="text-sm opacity-70 mb-6">Each button triggers a deterministic error scenario.</p>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                {scenarios.map((scenario) => (
+                    <button
+                        key={scenario.id}
+                        type="button"
+                        data-testid={testIds.brokenTrigger(scenario.id)}
+                        onClick={() => onClick(scenario.id)}
+                        className="rounded-lg border border-surface-border bg-surface px-4 py-3 text-left text-sm hover:border-brand"
+                    >
+                        <div className="font-medium">{scenario.label}</div>
+                        <div className="text-xs opacity-60 font-mono">{scenario.id}</div>
+                    </button>
+                ))}
+            </div>
+            <h2 className="text-lg font-semibold mt-8 mb-2">Logging</h2>
+            <p className="text-sm opacity-70 mb-4">Each button records one or more structured logs.</p>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                {logScenarios.map((scenario) => (
+                    <button
+                        key={scenario.id}
+                        type="button"
+                        data-testid={testIds.logTrigger(scenario.id)}
+                        onClick={() => fireLogScenario(flare, scenario)}
+                        className="rounded-lg border border-surface-border bg-surface px-4 py-3 text-left text-sm hover:border-brand"
+                    >
+                        <div className="font-medium">{scenario.label}</div>
+                        <div className="text-xs opacity-60 font-mono">{scenario.id}</div>
+                    </button>
+                ))}
+            </div>
+            <MaybeThrowing trigger={renderTrigger} />
+        </section>
+    );
+};
+
+export const brokenRoute: RouteObject = {
+    path: 'broken',
+    Component: BrokenPage,
+};

--- a/playgrounds/react-router/src/routes/cart.tsx
+++ b/playgrounds/react-router/src/routes/cart.tsx
@@ -1,0 +1,79 @@
+import { productById, testIds } from '@flareapp/playgrounds-shared';
+import type { RouteObject } from 'react-router';
+import { Link } from 'react-router';
+
+import { cart, useCart } from '../cart';
+
+const CartPage = () => {
+    const lines = useCart();
+
+    if (lines.length === 0) {
+        return (
+            <section>
+                <h1 className="text-xl font-semibold mb-6">Cart</h1>
+                <p className="text-sm opacity-70">Cart is empty.</p>
+            </section>
+        );
+    }
+
+    const total = lines.reduce((sum, line) => {
+        const product = productById(line.productId);
+        return product ? sum + product.priceCents * line.quantity : sum;
+    }, 0);
+
+    return (
+        <section>
+            <h1 className="text-xl font-semibold mb-6">Cart</h1>
+            <table className="w-full text-left">
+                <thead className="text-xs uppercase opacity-60">
+                    <tr>
+                        <th className="py-2">Item</th>
+                        <th className="py-2">Qty</th>
+                        <th className="py-2">Subtotal</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {lines.map((line) => {
+                        const product = productById(line.productId);
+                        if (!product) return null;
+                        const subtotal = (product.priceCents * line.quantity) / 100;
+                        return (
+                            <tr
+                                key={product.id}
+                                data-testid={testIds.cartItem(product.id)}
+                                className="border-b border-surface-border"
+                            >
+                                <td className="py-3">{product.title}</td>
+                                <td className="py-3 font-mono text-sm">{line.quantity}</td>
+                                <td className="py-3 font-mono text-sm">${subtotal.toFixed(2)}</td>
+                                <td className="py-3 text-right">
+                                    <button
+                                        type="button"
+                                        onClick={() => cart.remove(product.id)}
+                                        className="text-xs text-brand hover:underline"
+                                    >
+                                        Remove
+                                    </button>
+                                </td>
+                            </tr>
+                        );
+                    })}
+                </tbody>
+            </table>
+            <div className="mt-6 flex items-center justify-between">
+                <div className="text-sm">
+                    Total: <span className="font-mono">${(total / 100).toFixed(2)}</span>
+                </div>
+                <Link to="/checkout" className="rounded-lg bg-brand-ink text-white px-4 py-2 text-sm">
+                    Checkout
+                </Link>
+            </div>
+        </section>
+    );
+};
+
+export const cartRoute: RouteObject = {
+    path: 'cart',
+    Component: CartPage,
+};

--- a/playgrounds/react-router/src/routes/checkout.tsx
+++ b/playgrounds/react-router/src/routes/checkout.tsx
@@ -1,0 +1,64 @@
+import { testIds } from '@flareapp/playgrounds-shared';
+import type { FormEvent } from 'react';
+import type { RouteObject } from 'react-router';
+import { useNavigate } from 'react-router';
+
+import { cart } from '../cart';
+
+const CheckoutPage = () => {
+    const navigate = useNavigate();
+
+    const onSubmit = (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        cart.clear();
+        void navigate('/confirmation');
+    };
+
+    return (
+        <section className="max-w-md mx-auto">
+            <h1 className="text-xl font-semibold mb-6">Checkout</h1>
+            <form onSubmit={onSubmit} className="flex flex-col gap-4">
+                <label className="flex flex-col gap-1 text-sm">
+                    Name
+                    <input
+                        name="name"
+                        required
+                        defaultValue="Test User"
+                        className="rounded border border-surface-border px-3 py-2"
+                    />
+                </label>
+                <label className="flex flex-col gap-1 text-sm">
+                    Email
+                    <input
+                        name="email"
+                        type="email"
+                        required
+                        defaultValue="test@example.com"
+                        className="rounded border border-surface-border px-3 py-2"
+                    />
+                </label>
+                <label className="flex flex-col gap-1 text-sm">
+                    Card number
+                    <input
+                        name="card"
+                        required
+                        defaultValue="4242 4242 4242 4242"
+                        className="rounded border border-surface-border px-3 py-2 font-mono"
+                    />
+                </label>
+                <button
+                    type="submit"
+                    data-testid={testIds.checkoutSubmit}
+                    className="rounded-lg bg-brand-ink text-white py-2 text-sm"
+                >
+                    Pay
+                </button>
+            </form>
+        </section>
+    );
+};
+
+export const checkoutRoute: RouteObject = {
+    path: 'checkout',
+    Component: CheckoutPage,
+};

--- a/playgrounds/react-router/src/routes/confirmation.tsx
+++ b/playgrounds/react-router/src/routes/confirmation.tsx
@@ -1,0 +1,18 @@
+import { testIds } from '@flareapp/playgrounds-shared';
+import type { RouteObject } from 'react-router';
+import { Link } from 'react-router';
+
+const ConfirmationPage = () => (
+    <section data-testid={testIds.confirmation} className="text-center py-16">
+        <h1 className="text-2xl font-semibold mb-2">Order confirmed</h1>
+        <p className="text-sm opacity-70 mb-6">A receipt was sent to your inbox.</p>
+        <Link to="/" className="text-sm text-brand hover:underline">
+            Continue shopping
+        </Link>
+    </section>
+);
+
+export const confirmationRoute: RouteObject = {
+    path: 'confirmation',
+    Component: ConfirmationPage,
+};

--- a/playgrounds/react-router/src/routes/product.tsx
+++ b/playgrounds/react-router/src/routes/product.tsx
@@ -1,0 +1,75 @@
+import { productById, testIds, unsplashUrl, type Product } from '@flareapp/playgrounds-shared';
+import { withFlareProfiler } from '@flareapp/react/profiler';
+import type { LoaderFunctionArgs, RouteObject } from 'react-router';
+import { useLoaderData } from 'react-router';
+
+import { cart } from '../cart';
+import { flare } from '../flare';
+
+const sleep = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms));
+
+type ProductLoaderData = { product: Product | undefined };
+
+export async function productLoader({ params }: LoaderFunctionArgs): Promise<ProductLoaderData> {
+    // Artificial loading window so the client navigation opens a held browser_navigation root
+    // (traceReactRouter's loader branch). No network dependency keeps the e2e deterministic.
+    await sleep(150);
+    return { product: productById(params.id ?? '') };
+}
+
+const AddToCartButton = withFlareProfiler(
+    ({ testId, onClick }: { testId: string; onClick: () => void }) => (
+        <button
+            type="button"
+            data-testid={testId}
+            onClick={onClick}
+            className="rounded-lg bg-brand-ink text-white py-3 hover:opacity-90"
+        >
+            Add to cart
+        </button>
+    ),
+    { name: 'AddToCartButton' },
+);
+
+const ProductPage = () => {
+    const { product } = useLoaderData() as ProductLoaderData;
+
+    if (!product) {
+        return <p>Product not found.</p>;
+    }
+
+    const triggerBroken = () => {
+        void flare.report(new Error(`broken-solution:${product.id}`), {
+            'context.product': { id: product.id, title: product.title },
+        });
+    };
+
+    return (
+        <article className="grid md:grid-cols-2 gap-8">
+            <img
+                src={unsplashUrl(product.unsplashId, 800, 800)}
+                alt={product.title}
+                className="aspect-square w-full object-cover rounded-2xl"
+            />
+            <div className="flex flex-col gap-4">
+                <h1 className="text-2xl font-semibold">{product.title}</h1>
+                <p className="text-sm opacity-70">Photograph by {product.photographer}</p>
+                <div className="text-xl font-mono">${(product.priceCents / 100).toFixed(2)}</div>
+                <AddToCartButton testId={testIds.addToCart(product.id)} onClick={() => cart.add(product.id)} />
+                <button
+                    type="button"
+                    onClick={triggerBroken}
+                    className="rounded-lg border border-brand text-brand py-3 hover:bg-brand-soft"
+                >
+                    Trigger broken solution
+                </button>
+            </div>
+        </article>
+    );
+};
+
+export const productRoute: RouteObject = {
+    path: 'product/:id',
+    loader: productLoader,
+    Component: withFlareProfiler(ProductPage, { name: 'ProductPage' }),
+};

--- a/playgrounds/react-router/src/routes/products.tsx
+++ b/playgrounds/react-router/src/routes/products.tsx
@@ -1,0 +1,52 @@
+import { products, testIds, unsplashUrl } from '@flareapp/playgrounds-shared';
+import { withFlareProfiler } from '@flareapp/react/profiler';
+import type { RouteObject } from 'react-router';
+import { Link } from 'react-router';
+
+import { cart } from '../cart';
+
+const ProductsPage = () => (
+    <section data-testid={testIds.productGrid}>
+        <h1 className="text-xl font-semibold mb-6">Photographs</h1>
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-6">
+            {products.map((product) => (
+                <article
+                    key={product.id}
+                    data-testid={testIds.productCard(product.id)}
+                    className="group rounded-2xl bg-surface border border-surface-border overflow-hidden"
+                >
+                    <Link to={`/product/${product.id}`} className="block">
+                        <img
+                            src={unsplashUrl(product.unsplashId, 400, 400)}
+                            alt={product.title}
+                            loading="lazy"
+                            className="aspect-square w-full object-cover"
+                        />
+                    </Link>
+                    <div className="p-4 flex items-center justify-between gap-3">
+                        <div>
+                            <h2 className="text-sm font-semibold">{product.title}</h2>
+                            <p className="text-xs opacity-70">{product.photographer}</p>
+                        </div>
+                        <div className="text-sm font-mono">${(product.priceCents / 100).toFixed(2)}</div>
+                    </div>
+                    <div className="px-4 pb-4">
+                        <button
+                            type="button"
+                            data-testid={testIds.addToCart(product.id)}
+                            onClick={() => cart.add(product.id)}
+                            className="w-full rounded-lg bg-brand-ink text-white text-sm py-2 hover:opacity-90"
+                        >
+                            Add to cart
+                        </button>
+                    </div>
+                </article>
+            ))}
+        </div>
+    </section>
+);
+
+export const productsRoute: RouteObject = {
+    index: true,
+    Component: withFlareProfiler(ProductsPage, { name: 'ProductsPage' }),
+};

--- a/playgrounds/react-router/src/routes/root.tsx
+++ b/playgrounds/react-router/src/routes/root.tsx
@@ -1,0 +1,60 @@
+import { testIds } from '@flareapp/playgrounds-shared';
+import { FlareErrorBoundary } from '@flareapp/react';
+import { withFlareProfiler } from '@flareapp/react/profiler';
+import type { RouteObject } from 'react-router';
+import { Link, Outlet, useLocation } from 'react-router';
+
+import { useCartCount } from '../cart';
+import { Fallback } from '../components/Fallback';
+import { brokenRoute } from './broken';
+import { cartRoute } from './cart';
+import { checkoutRoute } from './checkout';
+import { confirmationRoute } from './confirmation';
+import { productRoute } from './product';
+import { productsRoute } from './products';
+
+const RootLayout = () => {
+    const count = useCartCount();
+    const pathname = useLocation().pathname;
+
+    return (
+        <div className="min-h-screen flex flex-col">
+            <header className="border-b border-surface-border bg-surface">
+                <div className="mx-auto max-w-5xl px-6 py-4 flex items-center justify-between">
+                    <Link to="/" className="text-lg font-semibold tracking-tight">
+                        Flare Pix
+                    </Link>
+                    <nav className="flex items-center gap-6">
+                        <Link to="/" className="text-sm font-medium hover:text-brand">
+                            Shop
+                        </Link>
+                        <Link to="/cart" className="text-sm font-medium hover:text-brand">
+                            Cart
+                        </Link>
+                        <Link to="/broken" className="text-sm font-medium hover:text-brand">
+                            Broken
+                        </Link>
+                        <Link
+                            to="/cart"
+                            data-testid={testIds.cartCount}
+                            className="rounded-full bg-brand px-3 py-1 text-xs font-semibold text-white"
+                        >
+                            {count}
+                        </Link>
+                    </nav>
+                </div>
+            </header>
+            <main className="flex-1 mx-auto max-w-5xl w-full px-6 py-8">
+                <FlareErrorBoundary fallback={Fallback} resetKeys={[pathname]}>
+                    <Outlet />
+                </FlareErrorBoundary>
+            </main>
+        </div>
+    );
+};
+
+export const rootRoute: RouteObject = {
+    path: '/',
+    Component: withFlareProfiler(RootLayout, { name: 'Layout' }),
+    children: [productsRoute, productRoute, cartRoute, checkoutRoute, confirmationRoute, brokenRoute],
+};

--- a/playgrounds/react-router/tsconfig.json
+++ b/playgrounds/react-router/tsconfig.json
@@ -1,0 +1,8 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "jsx": "react-jsx",
+        "types": ["vite/client"]
+    },
+    "include": ["src/**/*", "env.d.ts"]
+}

--- a/playgrounds/react-router/tsconfig.node.json
+++ b/playgrounds/react-router/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "types": ["node"],
+        "moduleResolution": "bundler",
+        "allowSyntheticDefaultImports": true
+    },
+    "include": ["vite.config.ts"]
+}

--- a/playgrounds/react-router/vite.config.ts
+++ b/playgrounds/react-router/vite.config.ts
@@ -1,0 +1,18 @@
+import tailwindcss from '@tailwindcss/vite';
+import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+    plugins: [react(), tailwindcss()],
+    server: {
+        port: 5185,
+        strictPort: true,
+    },
+    preview: {
+        port: 5185,
+        strictPort: true,
+    },
+    build: {
+        sourcemap: true,
+    },
+});

--- a/playgrounds/react/src/flare.ts
+++ b/playgrounds/react/src/flare.ts
@@ -7,8 +7,8 @@ export const initFlare = (): void => {
     if (url) {
         flare.configure({
             ingestUrl: url,
-            logsIngestUrl: url.replace('/api/reports', '/api/logs'),
-            tracesIngestUrl: url.replace('/api/reports', '/api/traces'),
+            logsIngestUrl: url.replace('/v1/errors', '/v1/logs'),
+            tracesIngestUrl: url.replace('/v1/errors', '/v1/traces'),
             // e2e-only timing: keep the pageload/navigation root active long enough for a
             // prompt Playwright click to land and nest under it, then flush an ended root
             // fast so arrival assertions don't need to wait out the (5s) production default.

--- a/playgrounds/svelte/src/lib/flare.client.ts
+++ b/playgrounds/svelte/src/lib/flare.client.ts
@@ -7,7 +7,7 @@ export const initFlareClient = (): void => {
     if (url) {
         flare.configure({
             ingestUrl: url,
-            logsIngestUrl: url.replace('/api/reports', '/api/logs'),
+            logsIngestUrl: url.replace('/v1/errors', '/v1/logs'),
         });
     }
 

--- a/playgrounds/vue/src/flare.ts
+++ b/playgrounds/vue/src/flare.ts
@@ -7,7 +7,7 @@ export const initFlare = (): void => {
     if (url) {
         flare.configure({
             ingestUrl: url,
-            logsIngestUrl: url.replace('/api/reports', '/api/logs'),
+            logsIngestUrl: url.replace('/v1/errors', '/v1/logs'),
         });
     }
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from '@playwright/test';
 
 const FAKE_FLARE_PORT = process.env.FAKE_FLARE_PORT ?? '7765';
-const FAKE_FLARE_INGEST_URL = `http://127.0.0.1:${FAKE_FLARE_PORT}/api/reports`;
+const FAKE_FLARE_INGEST_URL = `http://127.0.0.1:${FAKE_FLARE_PORT}/v1/errors`;
 
 const sharedEnv = {
     VITE_FLARE_URL: FAKE_FLARE_INGEST_URL,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -38,6 +38,11 @@ const devProjects = [
         testMatch: /svelte\.spec\.ts$/,
         use: { baseURL: 'http://localhost:5183', browserName: 'chromium' as const },
     },
+    {
+        name: 'react-router',
+        testMatch: /react-router\.spec\.ts$/,
+        use: { baseURL: 'http://localhost:5185', browserName: 'chromium' as const },
+    },
 ];
 
 const prodProjects = [
@@ -76,6 +81,13 @@ const devWebServers = [
         reuseExistingServer: !process.env.CI,
         timeout: 90_000,
         env: { ...sharedEnv, VITE_FLARE_KEY: 'test-key-svelte' },
+    },
+    {
+        command: 'npm run dev --workspace=@flareapp/playgrounds-react-router',
+        url: 'http://localhost:5185',
+        reuseExistingServer: !process.env.CI,
+        timeout: 60_000,
+        env: { ...sharedEnv, VITE_FLARE_KEY: 'test-key-react-router' },
     },
 ];
 


### PR DESCRIPTION
## What

Adds a fifth webshop playground, `@flareapp/playgrounds-react-router` (port 5185), built on **React Router v7 data mode** (`createBrowserRouter` + `RouterProvider`) and traced with `@flareapp/react/react-router`'s `traceReactRouter`. Nothing exercised that entry end-to-end before; the React playground uses TanStack Router. This fills the gap and adds Playwright regression coverage for both of `traceReactRouter`'s navigation branches.

It is a faithful twin of the existing React (TanStack) playground: same product grid / detail / cart / checkout / confirmation / broken pages, same shared `testIds`, error, and log scenarios (reused via `coverageFor('react')` / `logCoverageFor('react')` — no change to the shared `Framework` union).

## Key design points

- **Data-mode router** with per-file `RouteObject` modules; `traceReactRouter` wired once in `main.tsx`.
- **Mixed loaders:** `/product/:id` has an async loader (150 ms) so its navigation exercises `traceReactRouter`'s **held** navigation-root branch; the other routes are loader-less (single idle-fire branch).
- **Error handling adapted for RR data mode:** `FlareErrorBoundary` is mounted *inside* the root route element wrapping `<Outlet/>` (not around `RouterProvider`). Because no route defines an `errorElement`, a child-route render error reaches this boundary before RR's default boundary, so RR never latches it — `render-error` reports with component-stack context and `boundary-reset` recovers cleanly. Scope: this captures child-route *render* errors only (documented in the spec; layout-render and loader/action errors fall through to RR's default boundary).
- **Parameterized route names use colon syntax** (`/product/:id`), matching `routeNameFromMatches`.
- **Profiler parity:** `withFlareProfiler` wraps the same components as the React playground.

## Tests

- New `react-router` Playwright project + `e2e/specs/react-router.spec.ts`: grid render, checkout-happy-path (`assertNoReports`), all error scenarios, log scenarios, and tracing assertions for the pageload root, the loader navigation root (`/product/:id`), and the loader-less navigation root (`/cart`), including the single-nav-root invariant.
- `npx playwright test --project=react-router`: **19/19**. Full `npm run test:e2e`: **93/93** across all five projects, no regressions.

## Notes

- No `@flareapp/*` package source changes. The workspace is `private: true` and consumes `@flareapp/*` at `*`, so it does not gate any publish.
- Follow-ups (non-blocking, out of scope here): extract the duplicated OTLP trace-parsing helpers shared by `react.spec.ts` and `react-router.spec.ts` into an `e2e/specs/` helper.
