### PR TITLE
feat(vue): Vue Router performance tracing

### DIFF
--- a/docs/superpowers/specs/2026-07-14-performance-tracing-framework-router-vue-router-design.md
+++ b/docs/superpowers/specs/2026-07-14-performance-tracing-framework-router-vue-router-design.md
@@ -43,8 +43,13 @@ Flare's seam and conventions.
    to `to.path` → `{ source: 'url' }`. Matches the React/TanStack slices exactly and the backend's
    cross-framework parameterized-route aggregation. No `routeLabel: 'name' | 'path'` toggle and no
    named-route (`custom`) source for v1 — route names are optional and would fragment aggregation.
-4. **Zero `@flareapp/js` change.** The nav seam already has `hold` + `url` + `settleNavigation`. This
-   slice touches only `@flareapp/vue`, the Vue playground, and the e2e suite.
+4. **One additive `@flareapp/js` change: shared instrumentation guards.** No nav-seam behavior
+   changes (`hold` + `url` + `settleNavigation` already exist). The slice does add two pure helpers
+   (`insulate`, `safeInvoke`) to the side-effect-free `@flareapp/js/browser` barrel and converts the
+   existing React integrations onto them, collapsing three near-duplicate try/catch wrappers into one
+   definition (see Component 0). Land that as a small standalone step first; the vue slice then
+   consumes it. Beyond that, this slice touches only `@flareapp/vue`, the Vue playground, and the e2e
+   suite.
 
 ## vue-router lifecycle facts (verified against source)
 
@@ -71,6 +76,48 @@ Verified against `vuejs/router` `packages/router/src/router.ts` + `errors.ts` an
 - `beforeEach` / `afterEach` / `onError` each return an unregister function.
 
 ## Components
+
+### 0. `packages/js/src/tracing/instrumentationGuard.ts` (new — prerequisite refactor)
+
+Two pure, environment-agnostic helpers, exported from the side-effect-free `@flareapp/js/browser`
+barrel (so the Electron-safety / entry-test guarantees are unaffected). They replace three
+near-duplicate copies of the same "instrumentation must never throw into the host" idea: the generic
+`guard` HOF this slice would otherwise define locally, the monomorphic `guard` in
+`@flareapp/react/tanstack-router`, and the inline `try/catch` in `@flareapp/react/react-router`.
+
+```ts
+/** Wrap a host-invoked callback (router guard / store subscriber) so a tracing throw can never escape
+ *  into the host's dispatch. A thrown callback resolves to `undefined`. */
+export function insulate<A extends unknown[]>(fn: (...a: A) => void): (...a: A) => void {
+    return (...a: A): void => {
+        try {
+            fn(...a);
+        } catch {
+            // instrumentation never breaks the host
+        }
+    };
+}
+
+/** Invoke a teardown fn now (if present), swallowing any throw. For cleanup chains. */
+export function safeInvoke(fn: (() => void) | null | undefined): void {
+    try {
+        fn?.();
+    } catch {
+        // ignore
+    }
+}
+```
+
+Land this as a small standalone step (js barrel + the two React call sites) **before** the vue slice,
+so the vue integration consumes it rather than introducing a fourth copy. Conversion notes:
+
+- `react-router` converges cleanly: `router.subscribe(insulate(onState))` — `onState` is already a
+  named, typed function, so no annotation is needed.
+- `tanstack-router` costs two explicit `(e: TsrNavEvent)` param annotations: the generic helper can't
+  infer the event type from `router.subscribe`'s context, where the discarded monomorphic local `guard`
+  typed it for free.
+- All cleanup blocks collapse to `safeInvoke(off)` calls; `safeInvoke(() => nav.unregister())` wraps the
+  seam call in an arrow so the method keeps its binding (no detached-`this` reliance).
 
 ### 1. `packages/vue/src/vendor/vueRouterTypes.ts` (new)
 
@@ -101,26 +148,34 @@ export type VueRouterLike = {
 
 ### 2. `packages/vue/src/traceVueRouter.ts` (new, internal)
 
-The whole integration. Imports **only** `registerNavigationSource` + `RouteName` from
-`@flareapp/js/browser` (side-effect-free → Electron-safe; `flareVue.ts` already imports from that barrel
-via `resolveFlare`). **Not exported** from `index.ts` / `inject.ts` — the only public surface is the
-plugin option. Accepts `unknown` and narrows defensively (checks `beforeEach`/`afterEach` are functions),
+The whole integration. Imports `registerNavigationSource` + `RouteName` and the shared `insulate` /
+`safeInvoke` guards (Component 0) from `@flareapp/js/browser` (side-effect-free → Electron-safe;
+`flareVue.ts` already imports from that barrel via `resolveFlare`). **Not exported** from `index.ts` /
+`inject.ts` — the only public surface is the plugin option. Accepts `unknown` and narrows defensively (checks `beforeEach`/`afterEach` are functions),
 returning a no-op cleanup if the shape is wrong, so a shimmed/absent router never throws.
 
 Numeric failure-type constants are defined locally (`NAVIGATION_CANCELLED = 8`) rather than imported, to
 avoid a runtime `vue-router` dependency.
 
 ```ts
-import { registerNavigationSource, type RouteName } from '@flareapp/js/browser';
+import { insulate, registerNavigationSource, safeInvoke, type RouteName } from '@flareapp/js/browser';
 import type { NavigationFailureLike, VueRouteLocationLike, VueRouterLike } from './vendor/vueRouterTypes';
 
 const NAVIGATION_CANCELLED = 8; // ErrorTypes.NAVIGATION_CANCELLED — a newer nav superseded this one
+
+// Dedup re-instrumentation of the same router. Vite HMR re-runs plugin install against a persistent
+// router; without this each cycle appends another guard triple that is never removed (inert, since the
+// superseded nav source no-ops, but an unbounded accumulation on a long-lived router). Keyed on the
+// router object, so a genuinely new router is unaffected.
+const instrumented = new WeakMap<object, () => void>();
 
 export function traceVueRouter(router: unknown): () => void {
     const r = router as Partial<VueRouterLike> | null;
     if (!r || typeof r.beforeEach !== 'function' || typeof r.afterEach !== 'function') {
         return () => {}; // wrong shape → inert
     }
+
+    instrumented.get(r)?.(); // HMR: tear down any prior instrumentation of this same router first
 
     const nav = registerNavigationSource();
 
@@ -158,26 +213,20 @@ export function traceVueRouter(router: unknown): () => void {
         // never break the host on wiring
     }
 
-    const guard =
-        <A extends unknown[]>(fn: (...a: A) => void) =>
-        (...a: A): void => {
-            try {
-                fn(...a);
-            } catch {
-                // instrumentation never breaks the host's navigation dispatch
-            }
-        };
-
     const offBefore = r.beforeEach(
-        guard((to: VueRouteLocationLike, from: VueRouteLocationLike) => {
+        insulate((to: VueRouteLocationLike, from: VueRouteLocationLike) => {
             // Initial navigation first: START_LOCATION.fullPath is '/', so an app whose initial route is
-            // '/' would otherwise be swallowed by the no-op skip below.
+            // '/' would otherwise be swallowed by the same-location skip below.
             if (!sawInitial && isInitial(from)) {
                 nav.setActiveRouteName(routeNameFor(to)); // name the pageload root; open no nav root
                 return;
             }
 
-            if (to.fullPath && from?.fullPath && to.fullPath === from.fullPath) return; // no-op / duplicated nav
+            // Only a `force: true` re-navigation reaches beforeEach with to.fullPath === from.fullPath: a
+            // plain duplicated nav is short-circuited before guards run and surfaces solely as an afterEach
+            // failure (type 16, dropped by the !inFlight guard there). Skip it so a same-URL refresh opens
+            // no navigation root.
+            if (to.fullPath && from?.fullPath && to.fullPath === from.fullPath) return;
 
             if (!inFlight) {
                 inFlight = true;
@@ -188,7 +237,7 @@ export function traceVueRouter(router: unknown): () => void {
     );
 
     const offAfter = r.afterEach(
-        guard((to: VueRouteLocationLike, from: VueRouteLocationLike, failure?: NavigationFailureLike) => {
+        insulate((to: VueRouteLocationLike, from: VueRouteLocationLike, failure?: NavigationFailureLike) => {
             if (!sawInitial && isInitial(from)) {
                 if (!failure) {
                     sawInitial = true;
@@ -218,7 +267,7 @@ export function traceVueRouter(router: unknown): () => void {
     const offError =
         typeof r.onError === 'function'
             ? r.onError(
-                  guard(() => {
+                  insulate(() => {
                       if (!inFlight) return;
                       inFlight = false;
                       const current = r.currentRoute?.value;
@@ -227,28 +276,15 @@ export function traceVueRouter(router: unknown): () => void {
               )
             : undefined;
 
-    return () => {
-        try {
-            offBefore?.();
-        } catch {
-            // ignore
-        }
-        try {
-            offAfter?.();
-        } catch {
-            // ignore
-        }
-        try {
-            offError?.();
-        } catch {
-            // ignore
-        }
-        try {
-            nav.unregister();
-        } catch {
-            // ignore
-        }
+    const cleanup = (): void => {
+        safeInvoke(offBefore);
+        safeInvoke(offAfter);
+        safeInvoke(offError);
+        safeInvoke(() => nav.unregister());
+        instrumented.delete(r);
     };
+    instrumented.set(r, cleanup);
+    return cleanup;
 }
 ```
 
@@ -269,8 +305,12 @@ export function traceVueRouter(router: unknown): () => void {
     ```
 
     Install is already idempotent per app (`installedApps` WeakSet), so router tracing is wired at most
-    once per app. The returned cleanup is not stored — Vue has no plugin-uninstall hook, and the nav source
-    is last-wins (an HMR re-init or a second app supersedes the prior registration cleanly).
+    once per app. `flareVue` still discards the returned cleanup (Vue has no plugin-uninstall hook), but
+    `traceVueRouter` self-dedups per router instance (module-level `WeakMap`, Component 2): an HMR re-init
+    against a persistent router tears down the prior guard triple before re-registering, so guards can't
+    accumulate. The nav source stays last-wins as a second line of defense. (The dedup is effective when
+    the cached `@flareapp/vue` module survives the HMR update, as Vite's pre-bundled deps normally do; a
+    full module re-eval resets the map, which is harmless.)
 
 ## Trace model for this slice
 
@@ -281,6 +321,13 @@ export function traceVueRouter(router: unknown): () => void {
   `url.full` from the destination `to.fullPath`), settled in `afterEach`. Nested `browser_fetch` /
   `browser_xhr` spans from guard-based or component-mount data loading attach to the held root; the idle
   lifecycle closes it after the last child settles.
+- **Blocked / aborted navigations still emit a short navigation span.** `beforeEach` is vue-router's
+  earliest hook and cannot know a later guard will abort, so the held root — and the `endNow()` of the
+  prior root — is committed before any abort is known. An aborted navigation therefore ends the prior
+  root and emits a brief `browser_navigation` span named after `from` (where the user stayed). This is
+  inherent to a `beforeEach`-timed integration and matches `@sentry/vue`; accepted rather than worked
+  around, since opening the root only in `afterEach` would lose navigation-start timing and drop in-guard
+  fetches. Aborting guards are uncommon (mostly "unsaved changes" prompts), so the noise is bounded.
 
 ## Route name & attributes
 
@@ -292,8 +339,9 @@ given the codebase's redaction posture).
 
 ## Error handling
 
-- Every guard body is wrapped so a tracing error is swallowed and never escapes into vue-router's
-  navigation dispatch (a thrown guard would otherwise abort the user's navigation).
+- Every guard body is wrapped with the shared `insulate` helper (Component 0) so a tracing error is
+  swallowed and never escapes into vue-router's navigation dispatch (a thrown guard would otherwise
+  abort the user's navigation).
 - `router.onError` releases the hold so a guard exception mid-navigation cannot strand a held root.
 - A wrong-shaped / absent router makes `traceVueRouter` inert (no-op cleanup), never a throw.
 - `traceVueRouter` is invoked inside a try/catch in `flareVue` install, so wiring can never break the
@@ -312,11 +360,19 @@ Mirror the React `*.integration.test.ts` / `*.entry.test.ts` split.
     - client nav → one `startNavigation({ hold: true })` with `url` = origin + `to.fullPath`; `settleNavigation`
       with `{ name: '/product/:id', source: 'route' }`.
     - unmatched route (`matched: []`) → `{ source: 'url' }`, name = `to.path`.
-    - no-op nav (`to.fullPath === from.fullPath`) → no `startNavigation`.
-    - redirect hops (two `beforeEach`, one with a redirect, single successful `afterEach`) → one
+    - force same-location re-nav (`beforeEach` fires with `to.fullPath === from.fullPath`) → skipped: no
+      `startNavigation`, no span.
+    - plain duplicated nav (no `beforeEach`; `afterEach` with `failure.type === 16`) → dropped by the
+      `!inFlight` guard: no span. (Distinct from the force case above — a non-force duplicate never runs
+      guards.)
+    - guard-returned redirect (two `beforeEach`: original + target, one successful `afterEach`) → one
       `startNavigation`, one `settleNavigation` named the final target.
+    - route-config redirect (one `beforeEach`: target only, since vue-router short-circuits before guards
+      for the original; one successful `afterEach`) → one `startNavigation`, one `settleNavigation` named
+      the final target.
     - `cancelled` (type 8) afterEach → held root kept; the superseding nav's success settles it.
-    - `aborted` (type 4) afterEach → `settleNavigation(from)` (release).
+    - `aborted` (type 4) afterEach → `settleNavigation(from)` (release); the prior root was already ended
+      by the `beforeEach` `startNavigation`, and a short `from`-named nav span is emitted (see Trace model).
     - `onError` mid-nav → `settleNavigation` (release).
     - install after `router.isReady()` (resolved `currentRoute`) → pageload named immediately, first
       `beforeEach` treated as a client nav.
@@ -324,6 +380,9 @@ Mirror the React `*.integration.test.ts` / `*.entry.test.ts` split.
 - `packages/vue/tests/vue-router.entry.test.ts` — assert `traceVueRouter` (and `flareVue` with a
   `router` option) does not import the `@flareapp/js` root (Electron-safety), matching the React entry
   test discipline and the existing `verify:inject` guard.
+- `packages/js/tests/instrumentationGuard.test.ts` — unit-test the extracted helpers (Component 0):
+  `insulate` swallows a throw and yields `undefined`; `safeInvoke` tolerates a nullish fn and swallows a
+  throw. Lands with the prerequisite refactor, not the vue slice.
 
 ## Playground
 
@@ -340,10 +399,25 @@ Mirror the React `*.integration.test.ts` / `*.entry.test.ts` split.
 - `FlareVueOptions['router']` typed as `unknown` accepts a real `vue-router` `Router` at
   `app.use(flareVue, { router })` with no cast. If a slightly tighter type gives good DX without
   friction, prefer it; otherwise `unknown` + defensive narrowing (as `getRouteContext` does) is fine.
-- vue-router 5 (the playground devDep) exposes the same `beforeEach`/`afterEach`/`onError` + `matched[].path`
-  shapes as vue-router 4 (the peer floor). Confirm before publish.
-- `to.matched[last].path` is the absolute template on the pinned peer floor (vue-router 4.0); confirm the
-  matcher normalization holds at that version.
+- Navigation start time is stamped when our `beforeEach` runs — in registration order among all
+  `beforeEach` guards. A slow async app guard registered earlier defers our `startNavigation` and
+  undercounts the navigation. `beforeEach` is vue-router's earliest hook (no pre-guard seam exists), so
+  this is inherent and matches `@sentry/vue`; installing `flareVue` right after the router (before
+  feature guards) minimizes it. Confirm the playground wires it in that order.
+- vue-router 4.0.0 (the peer floor) and 5.1.0 (the playground devDep) expose identical shapes for this
+  integration — verified against the 4.0.0 `.d.ts`: `afterEach(to, from, failure?)` is 3-arg with the
+  `failure` param present from 4.0.0 (`NavigationHookAfter`), `ErrorTypes` is `NAVIGATION_ABORTED=4 /
+NAVIGATION_CANCELLED=8 / NAVIGATION_DUPLICATED=16` (so the hardcoded `NAVIGATION_CANCELLED = 8` is
+  correct at the floor), and `beforeEach` / `afterEach` / `onError` each return a `() => void` unregister.
+  The unit tests drive a structural fake router, so they exercise both majors by construction; a manual v4
+  playground smoke before publish is optional belt-and-suspenders, not a correctness gate.
+- `to.matched[last].path` as the absolute template is the one shape not pinned from the `.d.ts` (it is a
+  matcher-normalization runtime behavior, not a type). Sentry reads it directly and it holds on 5.1.0;
+  confirm on a 4.0.x install that a nested child route resolves its last matched record's `path` to the
+  full absolute template before publish.
+- After converting `@flareapp/react/tanstack-router` + `react-router` onto the shared `insulate` /
+  `safeInvoke` (Component 0), both packages' existing router + entry tests still pass — Electron-safety
+  is unchanged since the helpers are pure and come from the side-effect-free browser barrel.
 
 ## Out of scope / follow-ups
 

--- a/docs/superpowers/specs/2026-07-14-performance-tracing-framework-router-vue-router-design.md
+++ b/docs/superpowers/specs/2026-07-14-performance-tracing-framework-router-vue-router-design.md
@@ -1,0 +1,360 @@
+# Spec: performance tracing — framework router integration, Vue Router (vue-router 4/5)
+
+## Context
+
+Flare's browser performance tracing already emits `browser_pageload` and `browser_navigation` root
+spans, plus nested `browser_fetch` / `browser_xhr` spans. Framework router integrations replace the
+generic URL-based span name (`/product/p01`) with the parameterized route template (`/product/:id`)
+and set a `flare.route.source` attribute (`route` vs `url`). Two such integrations have shipped:
+
+- `@flareapp/react/tanstack-router` — `traceTanStackRouter(router)` (PR #69).
+- `@flareapp/react/react-router` — `traceReactRouter(router)` (PR #72).
+
+Both build on the **navigation-source seam** in `@flareapp/js` (exported from `@flareapp/js/browser`
+as `registerNavigationSource()`), which lets an integration drive navigation instead of the built-in
+History-API detection. The seam already carries everything a router whose events fire _before_ the URL
+commits needs — added for React Router:
+
+- `startNavigation({ path, url?, hold? })` — `url` overrides the nav root's `url.full` (React Router,
+  and now vue-router, resolve the destination before the browser URL commits); `hold` opens the root
+  idle-suppressed.
+- `settleNavigation(route)` — names the root and releases the hold.
+- `setActiveRouteName(route)` — (re)names the active root + `flare.route.source` in lockstep.
+- `unregister()` — releases any hold and hands navigation back to the built-in detection.
+
+This slice adds the **vue-router** integration. It assumes consumers use `vue-router` (the official
+router) — no other Vue routing library is targeted.
+
+Reference: Sentry's `@sentry/vue` `instrumentVueRouter` (`router.beforeEach` + `router.onError`,
+naming from `to.matched[last].path`) guided the approach; the surface and semantics are adapted to
+Flare's seam and conventions.
+
+## Approved decisions driving this spec
+
+1. **Scope: router tracing only.** Vue component profiling (the analog to `@flareapp/react/profiler`,
+   a Sentry-style global mixin) is a separate follow-up spec, not part of this slice.
+2. **Wiring: Vue-idiomatic plugin option.** `app.use(flareVue, { router })`. This is the canonical Vue
+   plugin convention (router passed as a plugin option) and adds zero new exported API. It is
+   behaviorally identical to the React `trace*Router` calls underneath. The standalone-function surface
+   (`traceVueRouter(router)`) was rejected as the _least_ Vue-idiomatic option — it copies a React idiom
+   Vue has no precedent for. Sentry's separate-init surface maps to Flare's existing `initFlare()`, so a
+   second init-style API would be redundant.
+3. **Route naming: parameterized path.** `to.matched[last].path` → `{ source: 'route' }`, falling back
+   to `to.path` → `{ source: 'url' }`. Matches the React/TanStack slices exactly and the backend's
+   cross-framework parameterized-route aggregation. No `routeLabel: 'name' | 'path'` toggle and no
+   named-route (`custom`) source for v1 — route names are optional and would fragment aggregation.
+4. **Zero `@flareapp/js` change.** The nav seam already has `hold` + `url` + `settleNavigation`. This
+   slice touches only `@flareapp/vue`, the Vue playground, and the e2e suite.
+
+## vue-router lifecycle facts (verified against source)
+
+Verified against `vuejs/router` `packages/router/src/router.ts` + `errors.ts` and the docs:
+
+- `beforeEach(to, from)` fires **before** the URL commits and before `currentRoute` updates. `to.matched`
+  is already resolved (the matcher runs before guards), so `to.matched[last].path` and `to.fullPath` are
+  available here. In vue-router 4/5, each matched record's `path` is the **full absolute** template
+  (`/user/:id/profile` for a nested route), so no chain-joining is needed (unlike React Router). Sentry
+  reads `to.matched[last].path` directly, confirming this.
+- `afterEach(to, from, failure)` fires **after** the navigation is confirmed. Third arg is the
+  `NavigationFailure` (undefined on success). Documented analytics pattern: `if (!failure) …`.
+- A **redirect** (`beforeEach` returns a location, or a route `redirect`) does **not** fire `afterEach`
+  for the original navigation — vue-router's `pushWithRedirect` short-circuits and starts a new
+  navigation (new `beforeEach`, same `from`). `triggerAfterEach` is reached only for a **success** or a
+  **terminal failure**.
+- `ErrorTypes` (the numeric `failure.type`): `NAVIGATION_ABORTED = 4`, `NAVIGATION_CANCELLED = 8`,
+  `NAVIGATION_DUPLICATED = 16`. `cancelled` means a newer navigation superseded this one (a successor
+  will fire its own `afterEach`); `aborted` (guard returned `false`) and `duplicated` are terminal with
+  no successor.
+- `router.onError((error, to, from) => …)` fires for uncaught errors thrown in guards / during resolve.
+- Initial navigation: `from` is `START_LOCATION`, whose `matched` is `[]`. The initial navigation is
+  async, so at plugin-install time `router.currentRoute.value` is usually still `START_LOCATION`.
+- `beforeEach` / `afterEach` / `onError` each return an unregister function.
+
+## Components
+
+### 1. `packages/vue/src/vendor/vueRouterTypes.ts` (new)
+
+Structural subset of the router the integration reads. Vendored (not imported) so this integration needs
+no runtime `vue-router` dependency and the shapes are pinned. Same discipline as
+`packages/vue/src/getRouteContext.ts` (which already reads the router structurally) and the React vendor
+types.
+
+```ts
+export type VueRouteLocationLike = {
+    path: string;
+    fullPath?: string;
+    matched?: { path?: string }[];
+};
+
+/** Truthy = a NavigationFailure; `.type` is a numeric ErrorTypes value. */
+export type NavigationFailureLike = { type?: number } | undefined;
+
+export type VueRouterLike = {
+    currentRoute?: { value?: VueRouteLocationLike };
+    beforeEach(guard: (to: VueRouteLocationLike, from: VueRouteLocationLike) => unknown): () => void;
+    afterEach(
+        guard: (to: VueRouteLocationLike, from: VueRouteLocationLike, failure?: NavigationFailureLike) => unknown,
+    ): () => void;
+    onError(handler: (error: unknown, to?: VueRouteLocationLike, from?: VueRouteLocationLike) => unknown): () => void;
+};
+```
+
+### 2. `packages/vue/src/traceVueRouter.ts` (new, internal)
+
+The whole integration. Imports **only** `registerNavigationSource` + `RouteName` from
+`@flareapp/js/browser` (side-effect-free → Electron-safe; `flareVue.ts` already imports from that barrel
+via `resolveFlare`). **Not exported** from `index.ts` / `inject.ts` — the only public surface is the
+plugin option. Accepts `unknown` and narrows defensively (checks `beforeEach`/`afterEach` are functions),
+returning a no-op cleanup if the shape is wrong, so a shimmed/absent router never throws.
+
+Numeric failure-type constants are defined locally (`NAVIGATION_CANCELLED = 8`) rather than imported, to
+avoid a runtime `vue-router` dependency.
+
+```ts
+import { registerNavigationSource, type RouteName } from '@flareapp/js/browser';
+import type { NavigationFailureLike, VueRouteLocationLike, VueRouterLike } from './vendor/vueRouterTypes';
+
+const NAVIGATION_CANCELLED = 8; // ErrorTypes.NAVIGATION_CANCELLED — a newer nav superseded this one
+
+export function traceVueRouter(router: unknown): () => void {
+    const r = router as Partial<VueRouterLike> | null;
+    if (!r || typeof r.beforeEach !== 'function' || typeof r.afterEach !== 'function') {
+        return () => {}; // wrong shape → inert
+    }
+
+    const nav = registerNavigationSource();
+
+    const routeNameFor = (loc: VueRouteLocationLike): RouteName => {
+        try {
+            const matched = loc.matched;
+            const template = matched && matched.length > 0 ? matched[matched.length - 1]?.path : undefined;
+            if (template) return { name: template, source: 'route' };
+        } catch {
+            // fall through to the URL name
+        }
+        return { name: loc.path, source: 'url' };
+    };
+
+    const hrefOf = (loc: VueRouteLocationLike): string => {
+        const origin = typeof window !== 'undefined' ? window.location.origin : '';
+        return origin + (loc.fullPath ?? loc.path ?? '');
+    };
+
+    const isInitial = (from: VueRouteLocationLike | undefined): boolean =>
+        !from || !from.matched || from.matched.length === 0; // START_LOCATION
+
+    let sawInitial = false;
+    let inFlight = false;
+
+    // Enrich the pageload root immediately if the router already resolved its initial route
+    // (e.g. flareVue installed after `await router.isReady()`); otherwise the first guard pair handles it.
+    try {
+        const current = r.currentRoute?.value;
+        if (current && current.matched && current.matched.length > 0) {
+            nav.setActiveRouteName(routeNameFor(current));
+            sawInitial = true;
+        }
+    } catch {
+        // never break the host on wiring
+    }
+
+    const guard =
+        <A extends unknown[]>(fn: (...a: A) => void) =>
+        (...a: A): void => {
+            try {
+                fn(...a);
+            } catch {
+                // instrumentation never breaks the host's navigation dispatch
+            }
+        };
+
+    const offBefore = r.beforeEach(
+        guard((to: VueRouteLocationLike, from: VueRouteLocationLike) => {
+            // Initial navigation first: START_LOCATION.fullPath is '/', so an app whose initial route is
+            // '/' would otherwise be swallowed by the no-op skip below.
+            if (!sawInitial && isInitial(from)) {
+                nav.setActiveRouteName(routeNameFor(to)); // name the pageload root; open no nav root
+                return;
+            }
+
+            if (to.fullPath && from?.fullPath && to.fullPath === from.fullPath) return; // no-op / duplicated nav
+
+            if (!inFlight) {
+                inFlight = true;
+                nav.startNavigation({ path: to.path, url: hrefOf(to), hold: true });
+            }
+            nav.setActiveRouteName(routeNameFor(to)); // set / re-set across redirect hops
+        }),
+    );
+
+    const offAfter = r.afterEach(
+        guard((to: VueRouteLocationLike, from: VueRouteLocationLike, failure?: NavigationFailureLike) => {
+            if (!sawInitial && isInitial(from)) {
+                if (!failure) {
+                    sawInitial = true;
+                    nav.setActiveRouteName(routeNameFor(to)); // finalize pageload name
+                }
+                return;
+            }
+
+            if (!inFlight) return;
+
+            if (!failure) {
+                inFlight = false;
+                nav.settleNavigation(routeNameFor(to)); // success: name + release hold
+                return;
+            }
+
+            // A redirect never reaches afterEach (vue-router short-circuits to a new navigation), so any
+            // failure here is terminal. `cancelled` (a newer nav superseded this one) keeps the held root
+            // for the successor's afterEach; `aborted` / `duplicated` / unknown release it to the current
+            // location so a blocked navigation can't strand a held root until the finalTimeout backstop.
+            if (failure.type === NAVIGATION_CANCELLED) return;
+            inFlight = false;
+            nav.settleNavigation(routeNameFor(from));
+        }),
+    );
+
+    const offError =
+        typeof r.onError === 'function'
+            ? r.onError(
+                  guard(() => {
+                      if (!inFlight) return;
+                      inFlight = false;
+                      const current = r.currentRoute?.value;
+                      nav.settleNavigation(current ? routeNameFor(current) : { name: '', source: 'url' });
+                  }),
+              )
+            : undefined;
+
+    return () => {
+        try {
+            offBefore?.();
+        } catch {
+            // ignore
+        }
+        try {
+            offAfter?.();
+        } catch {
+            // ignore
+        }
+        try {
+            offError?.();
+        } catch {
+            // ignore
+        }
+        try {
+            nav.unregister();
+        } catch {
+            // ignore
+        }
+    };
+}
+```
+
+### 3. `packages/vue/src/flareVue.ts` (edit) + `types.ts` (edit)
+
+- `FlareVueOptions` gains `router?: unknown` (documented: a vue-router Router instance; enables
+  navigation/pageload performance tracing).
+- In `flareVue` install, after identity tagging and near the end of install, wire tracing:
+
+    ```ts
+    if (options?.router) {
+        try {
+            traceVueRouter(options.router);
+        } catch {
+            // never break plugin install
+        }
+    }
+    ```
+
+    Install is already idempotent per app (`installedApps` WeakSet), so router tracing is wired at most
+    once per app. The returned cleanup is not stored — Vue has no plugin-uninstall hook, and the nav source
+    is last-wins (an HMR re-init or a second app supersedes the prior registration cleanly).
+
+## Trace model for this slice
+
+- **Pageload** (`browser_pageload`, opened by `startBrowserTracing` at `initFlare()`, before the app
+  mounts): named from the initial vue-router navigation. `registerNavigationSource()` (called during
+  plugin install) suppresses the built-in History detection so client navigations don't double-open roots.
+- **Navigation** (`browser_navigation`): opened **held** in `beforeEach` (timed from navigation start,
+  `url.full` from the destination `to.fullPath`), settled in `afterEach`. Nested `browser_fetch` /
+  `browser_xhr` spans from guard-based or component-mount data loading attach to the held root; the idle
+  lifecycle closes it after the last child settles.
+
+## Route name & attributes
+
+`routeNameFor` sets, via the seam's `setActiveRouteName` / `settleNavigation`, the root's `name`,
+`flare.entry_point.handler.identifier`, and `flare.route.source` in lockstep (handled inside the seam's
+`applyRouteName`). Primary: `to.matched[last].path` (`route`). Fallback: `to.path` (`url`). No per-param
+or per-query span attributes (Sentry stamps them; excluded here to match the React slices and avoid PII
+given the codebase's redaction posture).
+
+## Error handling
+
+- Every guard body is wrapped so a tracing error is swallowed and never escapes into vue-router's
+  navigation dispatch (a thrown guard would otherwise abort the user's navigation).
+- `router.onError` releases the hold so a guard exception mid-navigation cannot strand a held root.
+- A wrong-shaped / absent router makes `traceVueRouter` inert (no-op cleanup), never a throw.
+- `traceVueRouter` is invoked inside a try/catch in `flareVue` install, so wiring can never break the
+  plugin.
+
+## Testing
+
+Mirror the React `*.integration.test.ts` / `*.entry.test.ts` split.
+
+- `packages/vue/tests/vue-router.test.ts` — mock `@flareapp/js/browser`'s `registerNavigationSource` to
+  a spy object (`startNavigation` / `setActiveRouteName` / `settleNavigation` / `unregister` spies); drive
+  a fake router (object exposing `beforeEach`/`afterEach`/`onError` that capture the guards + a mutable
+  `currentRoute`). Assert the seam-call sequence for:
+    - initial load → `setActiveRouteName` names the pageload from the initial route (source `route`); no
+      `startNavigation`.
+    - client nav → one `startNavigation({ hold: true })` with `url` = origin + `to.fullPath`; `settleNavigation`
+      with `{ name: '/product/:id', source: 'route' }`.
+    - unmatched route (`matched: []`) → `{ source: 'url' }`, name = `to.path`.
+    - no-op nav (`to.fullPath === from.fullPath`) → no `startNavigation`.
+    - redirect hops (two `beforeEach`, one with a redirect, single successful `afterEach`) → one
+      `startNavigation`, one `settleNavigation` named the final target.
+    - `cancelled` (type 8) afterEach → held root kept; the superseding nav's success settles it.
+    - `aborted` (type 4) afterEach → `settleNavigation(from)` (release).
+    - `onError` mid-nav → `settleNavigation` (release).
+    - install after `router.isReady()` (resolved `currentRoute`) → pageload named immediately, first
+      `beforeEach` treated as a client nav.
+    - cleanup → guards removed + `nav.unregister()` called.
+- `packages/vue/tests/vue-router.entry.test.ts` — assert `traceVueRouter` (and `flareVue` with a
+  `router` option) does not import the `@flareapp/js` root (Electron-safety), matching the React entry
+  test discipline and the existing `verify:inject` guard.
+
+## Playground
+
+- `playgrounds/vue/src/flare.ts` — `enableTracing: true` (as the react / react-router playgrounds do).
+- `playgrounds/vue/src/main.ts` — `app.use(flareVue, { router })`.
+- e2e: extend the Vue playground project to assert a client navigation (e.g. products → product detail)
+  emits a `browser_navigation` span named `/product/:id`. Reuse the existing OTLP span-inspection helpers
+  (the react-router slice noted extracting the duplicated helpers as a follow-up; reuse in place here).
+
+## Items to verify during implementation
+
+- `enableTracing: true` on the singleton results in `startBrowserTracing` running at `initFlare()` and a
+  live pageload root by the time `flareVue` installs (same assumption the React playgrounds rely on).
+- `FlareVueOptions['router']` typed as `unknown` accepts a real `vue-router` `Router` at
+  `app.use(flareVue, { router })` with no cast. If a slightly tighter type gives good DX without
+  friction, prefer it; otherwise `unknown` + defensive narrowing (as `getRouteContext` does) is fine.
+- vue-router 5 (the playground devDep) exposes the same `beforeEach`/`afterEach`/`onError` + `matched[].path`
+  shapes as vue-router 4 (the peer floor). Confirm before publish.
+- `to.matched[last].path` is the absolute template on the pinned peer floor (vue-router 4.0); confirm the
+  matcher normalization holds at that version.
+
+## Out of scope / follow-ups
+
+- **Vue component profiling** (Sentry-style global mixin; the `@flareapp/react/profiler` analog) — separate spec.
+- `routeLabel: 'name' | 'path'` toggle and named-route (`custom`) source — deliberately excluded; possible
+  follow-up if requested.
+- Per-param / per-query span attributes — excluded (PII posture).
+- Hash-history routers: `url.full` uses `to.fullPath` (the in-app path, not the `#/…` form) — same
+  documented limitation as the React Router hash case.
+- **Pre-publish coupling:** raise `@flareapp/vue`'s `@flareapp/js` peer floor to the version carrying the
+  nav seam before releasing (the seam is on `main` but the published `@flareapp/js` is still 2.6.0). Same
+  carry-forward the React Router slice recorded; coordinate with the other lockstep-set peer bumps.
+- Backend `flare.route.source` + parameterized-name semantics remain gated (B5/B9/P4); `enableTracing`
+  stays opt-in.

--- a/docs/superpowers/specs/2026-07-14-performance-tracing-framework-router-vue-router-design.md
+++ b/docs/superpowers/specs/2026-07-14-performance-tracing-framework-router-vue-router-design.md
@@ -292,10 +292,11 @@ export function traceVueRouter(router: unknown): () => void {
 
 - `FlareVueOptions` gains `router?: unknown` (documented: a vue-router Router instance; enables
   navigation/pageload performance tracing).
-- In `flareVue` install, after identity tagging and near the end of install, wire tracing:
+- In `flareVue` install, after identity tagging and near the end of install, wire tracing — but only
+  when tracing is actually enabled:
 
     ```ts
-    if (options?.router) {
+    if (options?.router && flare.config?.enableTracing) {
         try {
             traceVueRouter(options.router);
         } catch {
@@ -304,11 +305,16 @@ export function traceVueRouter(router: unknown): () => void {
     }
     ```
 
-    Install is already idempotent per app (`installedApps` WeakSet), so router tracing is wired at most
-    once per app. `flareVue` still discards the returned cleanup (Vue has no plugin-uninstall hook), but
-    `traceVueRouter` self-dedups per router instance (module-level `WeakMap`, Component 2): an HMR re-init
-    against a persistent router tears down the prior guard triple before re-registering, so guards can't
-    accumulate. The nav source stays last-wins as a second line of defense. (The dedup is effective when
+    The `enableTracing` gate matters because it is the same flag that gates `startBrowserTracing` at
+    init: with tracing off, `startBrowserTracing` never ran, so `traceVueRouter` would attach a guard
+    triple and register a navigation source that can only no-op (`activeFlare` is null) — dead
+    instrumentation on the host's router. Gating here skips that. Optional chaining keeps a malformed
+    injected (Electron) flare fail-closed rather than throwing. Install is already idempotent per app
+    (`installedApps` WeakSet), so router tracing is wired at most once per app. `flareVue` still discards
+    the returned cleanup (Vue has no plugin-uninstall hook), but `traceVueRouter` self-dedups per router
+    instance (module-level `WeakMap`, Component 2): an HMR re-init against a persistent router tears down
+    the prior guard triple before re-registering, so guards can't accumulate. The nav source stays
+    last-wins as a second line of defense. (The dedup is effective when
     the cached `@flareapp/vue` module survives the HMR update, as Vite's pre-bundled deps normally do; a
     full module re-eval resets the map, which is harmless.)
 
@@ -346,6 +352,9 @@ given the codebase's redaction posture).
 - A wrong-shaped / absent router makes `traceVueRouter` inert (no-op cleanup), never a throw.
 - `traceVueRouter` is invoked inside a try/catch in `flareVue` install, so wiring can never break the
   plugin.
+- The `flare.config?.enableTracing` gate (Component 3) skips wiring entirely when tracing is off, so a
+  `{ router }` option with tracing disabled leaves the router's guards and the nav seam untouched
+  rather than attaching no-op instrumentation.
 
 ## Testing
 
@@ -379,7 +388,10 @@ Mirror the React `*.integration.test.ts` / `*.entry.test.ts` split.
     - cleanup → guards removed + `nav.unregister()` called.
 - `packages/vue/tests/vue-router.entry.test.ts` — assert `traceVueRouter` (and `flareVue` with a
   `router` option) does not import the `@flareapp/js` root (Electron-safety), matching the React entry
-  test discipline and the existing `verify:inject` guard.
+  test discipline and the existing `verify:inject` guard. Also assert the Component 3 wiring gate: with
+  `{ router }` and `enableTracing: true` the nav seam is registered exactly once; with `{ router }` but
+  `enableTracing: false`, or with no `router` at all, `registerNavigationSource` (and the router guards)
+  are never touched.
 - `packages/js/tests/instrumentationGuard.test.ts` — unit-test the extracted helpers (Component 0):
   `insulate` swallows a throw and yields `undefined`; `safeInvoke` tolerates a nullish fn and swallows a
   throw. Lands with the prerequisite refactor, not the vue slice.

--- a/e2e/specs/vue.spec.ts
+++ b/e2e/specs/vue.spec.ts
@@ -1,6 +1,7 @@
 import { testIds } from '../../playgrounds/shared/src';
 import { expect, test } from '../fixtures/fake-flare';
 import { logScenariosFor, runLogScenario } from './logShared';
+import { attr, hasSpanType, spansOf } from './otlp';
 import { runScenario, scenariosFor } from './shared';
 
 test.describe('vue playground', () => {
@@ -27,6 +28,57 @@ test.describe('vue playground', () => {
                 await runScenario(page, fakeFlare, scenario);
             });
         }
+    });
+});
+
+test.describe('vue-router tracing', () => {
+    test('pageload root carries the parameterized route and route source', async ({ page, fakeFlare }) => {
+        await page.goto('/product/p01');
+        await page.waitForLoadState('networkidle');
+
+        const trace = await fakeFlare.waitForTrace({
+            timeout: 9000,
+            predicate: (r) => {
+                const pl = spansOf(r.bodyJson).find((s) => hasSpanType(s, 'browser_pageload'));
+                return !!pl && JSON.stringify(attr(pl, 'flare.route.source') ?? '').includes('route');
+            },
+        });
+        const pageload = spansOf(trace.bodyJson).find((s) => hasSpanType(s, 'browser_pageload'));
+        expect(pageload && attr(pageload, 'flare.entry_point.handler.identifier')).toEqual({
+            stringValue: '/product/:id',
+        });
+        expect(pageload && attr(pageload, 'flare.route.source')).toEqual({ stringValue: 'route' });
+    });
+
+    test('client navigation opens a parameterized browser_navigation root (exactly one)', async ({
+        page,
+        fakeFlare,
+    }) => {
+        await page.goto('/');
+        await page.waitForLoadState('networkidle');
+
+        await page.locator('a[href="/product/p01"]').first().click();
+
+        const trace = await fakeFlare.waitForTrace({
+            timeout: 9000,
+            predicate: (r) => {
+                const nav = spansOf(r.bodyJson).find((s) => hasSpanType(s, 'browser_navigation'));
+                return (
+                    !!nav &&
+                    JSON.stringify(attr(nav, 'flare.entry_point.handler.identifier') ?? '').includes('/product/:id')
+                );
+            },
+        });
+        const nav = spansOf(trace.bodyJson).find((s) => hasSpanType(s, 'browser_navigation'));
+        expect(nav && attr(nav, 'flare.entry_point.handler.identifier')).toEqual({ stringValue: '/product/:id' });
+        expect(nav && attr(nav, 'flare.route.source')).toEqual({ stringValue: 'route' });
+
+        // No-double-roots invariant: registerNavigationSource suppresses the History-based root, so this
+        // one click produces exactly ONE browser_navigation root across all traces.
+        const navSpans = (await fakeFlare.traces())
+            .flatMap((t) => spansOf(t.bodyJson))
+            .filter((s) => hasSpanType(s, 'browser_navigation'));
+        expect(navSpans).toHaveLength(1);
     });
 });
 

--- a/packages/js/src/browser.ts
+++ b/packages/js/src/browser.ts
@@ -58,6 +58,7 @@ export { collectBrowser } from './browser/context/collectBrowser';
 export { FetchFileReader } from './browser/FetchFileReader';
 export { BrowserFlushScheduler } from './browser/BrowserFlushScheduler';
 export { registerNavigationSource, type NavigationSource, type RouteName } from './tracing/browserTracing';
+export { insulate, safeInvoke } from './tracing/instrumentationGuard';
 export {
     activeComponentRoot,
     reserveSpanId,

--- a/packages/js/src/tracing/instrumentationGuard.ts
+++ b/packages/js/src/tracing/instrumentationGuard.ts
@@ -1,0 +1,24 @@
+// Pure, environment-agnostic guards shared by the framework router integrations. They encode the one
+// rule every host-invoked instrumentation callback must obey: a tracing throw can never escape into the
+// host's dispatch. Exported from the side-effect-free '@flareapp/js/browser' barrel.
+
+/** Wrap a host-invoked callback (router guard / store subscriber) so a tracing throw can never escape
+ *  into the host's dispatch. A thrown callback resolves to `undefined`. */
+export function insulate<A extends unknown[]>(fn: (...a: A) => void): (...a: A) => void {
+    return (...a: A): void => {
+        try {
+            fn(...a);
+        } catch {
+            // instrumentation never breaks the host
+        }
+    };
+}
+
+/** Invoke a teardown fn now (if present), swallowing any throw. For cleanup chains. */
+export function safeInvoke(fn: (() => void) | null | undefined): void {
+    try {
+        fn?.();
+    } catch {
+        // ignore
+    }
+}

--- a/packages/js/tests/instrumentationGuard.test.ts
+++ b/packages/js/tests/instrumentationGuard.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { insulate, safeInvoke } from '../src/tracing/instrumentationGuard';
+
+describe('insulate', () => {
+    it('forwards args to the wrapped fn', () => {
+        const fn = vi.fn();
+        insulate(fn)('a', 1);
+        expect(fn).toHaveBeenCalledWith('a', 1);
+    });
+
+    it('swallows a throw and returns undefined', () => {
+        const wrapped = insulate(() => {
+            throw new Error('boom');
+        });
+        expect(wrapped()).toBeUndefined();
+        expect(() => wrapped()).not.toThrow();
+    });
+});
+
+describe('safeInvoke', () => {
+    it('invokes the fn', () => {
+        const fn = vi.fn();
+        safeInvoke(fn);
+        expect(fn).toHaveBeenCalledOnce();
+    });
+
+    it('tolerates null / undefined', () => {
+        expect(() => safeInvoke(null)).not.toThrow();
+        expect(() => safeInvoke(undefined)).not.toThrow();
+    });
+
+    it('swallows a throw', () => {
+        expect(() =>
+            safeInvoke(() => {
+                throw new Error('boom');
+            }),
+        ).not.toThrow();
+    });
+});

--- a/packages/react/src/react-router.ts
+++ b/packages/react/src/react-router.ts
@@ -1,7 +1,7 @@
 // Electron-safe entry: NO @flareapp/js root import. The navigation-source seam comes from
 // @flareapp/js/browser (side-effect-free). NO runtime dependency on react-router — the router is
 // consumed structurally (see ./vendor/reactRouterTypes).
-import { registerNavigationSource, type RouteName } from '@flareapp/js/browser';
+import { insulate, registerNavigationSource, safeInvoke, type RouteName } from '@flareapp/js/browser';
 
 import type { RRDataRouter, RRLocation, RRMatch, RRRouterState } from './vendor/reactRouterTypes';
 
@@ -123,24 +123,10 @@ export function traceReactRouter(router: RRDataRouter): () => void {
         // else (inFlight && non-idle): a redirect / superseding hop -> keep the single held root.
     };
 
-    const unsubscribe = router.subscribe((state) => {
-        try {
-            onState(state);
-        } catch {
-            // a tracing error must never escape into the router's state dispatch
-        }
-    });
+    const unsubscribe = router.subscribe(insulate(onState));
 
     return () => {
-        try {
-            unsubscribe();
-        } catch {
-            // ignore
-        }
-        try {
-            nav.unregister();
-        } catch {
-            // ignore
-        }
+        safeInvoke(unsubscribe);
+        safeInvoke(() => nav.unregister());
     };
 }

--- a/packages/react/src/tanstack-router.ts
+++ b/packages/react/src/tanstack-router.ts
@@ -1,7 +1,7 @@
 // Electron-safe entry: NO @flareapp/js root import. The navigation-source seam
 // comes from @flareapp/js/browser (side-effect-free). NO runtime dependency on
 // @tanstack/react-router — the router is consumed structurally (see ./vendor).
-import { registerNavigationSource, type RouteName } from '@flareapp/js/browser';
+import { insulate, registerNavigationSource, safeInvoke, type RouteName } from '@flareapp/js/browser';
 
 import type { TsrLocation, TsrNavEvent, TsrRouter } from './vendor/tanstackRouterTypes';
 
@@ -27,17 +27,6 @@ export function traceTanStackRouter(router: TsrRouter): () => void {
         return { name: loc.pathname, source: 'url' };
     };
 
-    // A tracing error must never escape into the router's event dispatch.
-    const guard =
-        (fn: (event: TsrNavEvent) => void) =>
-        (event: TsrNavEvent): void => {
-            try {
-                fn(event);
-            } catch {
-                // swallow: instrumentation never breaks the host
-            }
-        };
-
     // Enrich the pageload root immediately from the current (already-resolved) location.
     try {
         nav.setActiveRouteName(routeNameFor(router.state.location));
@@ -49,7 +38,7 @@ export function traceTanStackRouter(router: TsrRouter): () => void {
 
     const offBeforeLoad = router.subscribe(
         'onBeforeLoad',
-        guard((e) => {
+        insulate((e: TsrNavEvent) => {
             if (e.fromLocation === undefined) return; // initial pageload (handled via onResolved)
             if (e.toLocation.state === e.fromLocation.state) return; // no-op reload (e.g. router.invalidate())
             if (!inFlight) {
@@ -62,7 +51,7 @@ export function traceTanStackRouter(router: TsrRouter): () => void {
 
     const offResolved = router.subscribe(
         'onResolved',
-        guard((e) => {
+        insulate((e: TsrNavEvent) => {
             if (e.fromLocation === undefined) {
                 nav.setActiveRouteName(routeNameFor(e.toLocation)); // one-shot pageload correction
                 return;
@@ -75,20 +64,8 @@ export function traceTanStackRouter(router: TsrRouter): () => void {
     );
 
     return () => {
-        try {
-            offBeforeLoad();
-        } catch {
-            // ignore
-        }
-        try {
-            offResolved();
-        } catch {
-            // ignore
-        }
-        try {
-            nav.unregister();
-        } catch {
-            // ignore
-        }
+        safeInvoke(offBeforeLoad);
+        safeInvoke(offResolved);
+        safeInvoke(() => nav.unregister());
     };
 }

--- a/packages/react/tests/react-router.entry.test.ts
+++ b/packages/react/tests/react-router.entry.test.ts
@@ -10,14 +10,22 @@ describe('@flareapp/react/react-router entry', () => {
     test('importing the entry does NOT evaluate the @flareapp/js root singleton', async () => {
         const rootFactory = vi.fn(() => ({ flare: {} }));
         vi.doMock('@flareapp/js', rootFactory);
-        vi.doMock('@flareapp/js/browser', () => ({ registerNavigationSource: () => ({}) }));
+        vi.doMock('@flareapp/js/browser', () => ({
+            registerNavigationSource: () => ({}),
+            insulate: (fn: (...a: unknown[]) => void) => fn,
+            safeInvoke: (fn?: () => void) => fn?.(),
+        }));
         await import('../src/react-router');
         expect(rootFactory).not.toHaveBeenCalled();
         expect((window as unknown as { flare?: unknown }).flare).toBeUndefined();
     });
 
     test('exports traceReactRouter', async () => {
-        vi.doMock('@flareapp/js/browser', () => ({ registerNavigationSource: () => ({}) }));
+        vi.doMock('@flareapp/js/browser', () => ({
+            registerNavigationSource: () => ({}),
+            insulate: (fn: (...a: unknown[]) => void) => fn,
+            safeInvoke: (fn?: () => void) => fn?.(),
+        }));
         const mod = await import('../src/react-router');
         expect(typeof mod.traceReactRouter).toBe('function');
     });

--- a/packages/react/tests/react-router.integration.test.ts
+++ b/packages/react/tests/react-router.integration.test.ts
@@ -8,7 +8,25 @@ const nav = vi.hoisted(() => ({
     settleNavigation: vi.fn(),
     unregister: vi.fn(),
 }));
-vi.mock('@flareapp/js/browser', () => ({ registerNavigationSource: vi.fn(() => nav) }));
+vi.mock('@flareapp/js/browser', () => ({
+    registerNavigationSource: vi.fn(() => nav),
+    insulate:
+        (fn: (...a: unknown[]) => void) =>
+        (...a: unknown[]) => {
+            try {
+                fn(...a);
+            } catch {
+                /* swallow */
+            }
+        },
+    safeInvoke: (fn?: (() => void) | null) => {
+        try {
+            fn?.();
+        } catch {
+            /* swallow */
+        }
+    },
+}));
 
 import { traceReactRouter } from '../src/react-router';
 import type { RRDataRouter } from '../src/vendor/reactRouterTypes';

--- a/packages/react/tests/react-router.test.ts
+++ b/packages/react/tests/react-router.test.ts
@@ -7,7 +7,25 @@ const nav = vi.hoisted(() => ({
     settleNavigation: vi.fn(),
     unregister: vi.fn(),
 }));
-vi.mock('@flareapp/js/browser', () => ({ registerNavigationSource: vi.fn(() => nav) }));
+vi.mock('@flareapp/js/browser', () => ({
+    registerNavigationSource: vi.fn(() => nav),
+    insulate:
+        (fn: (...a: unknown[]) => void) =>
+        (...a: unknown[]) => {
+            try {
+                fn(...a);
+            } catch {
+                /* swallow */
+            }
+        },
+    safeInvoke: (fn?: (() => void) | null) => {
+        try {
+            fn?.();
+        } catch {
+            /* swallow */
+        }
+    },
+}));
 
 import { routeNameFromMatches, traceReactRouter } from '../src/react-router';
 import type { RRMatch, RRRouterState } from '../src/vendor/reactRouterTypes';

--- a/packages/react/tests/tanstack-router.entry.test.ts
+++ b/packages/react/tests/tanstack-router.entry.test.ts
@@ -10,14 +10,22 @@ describe('@flareapp/react/tanstack-router entry', () => {
     test('importing the entry does NOT evaluate the @flareapp/js root singleton', async () => {
         const rootFactory = vi.fn(() => ({ flare: {} }));
         vi.doMock('@flareapp/js', rootFactory);
-        vi.doMock('@flareapp/js/browser', () => ({ registerNavigationSource: () => ({}) }));
+        vi.doMock('@flareapp/js/browser', () => ({
+            registerNavigationSource: () => ({}),
+            insulate: (fn: (...a: unknown[]) => void) => fn,
+            safeInvoke: (fn?: () => void) => fn?.(),
+        }));
         await import('../src/tanstack-router');
         expect(rootFactory).not.toHaveBeenCalled();
         expect((window as unknown as { flare?: unknown }).flare).toBeUndefined();
     });
 
     test('exports traceTanStackRouter', async () => {
-        vi.doMock('@flareapp/js/browser', () => ({ registerNavigationSource: () => ({}) }));
+        vi.doMock('@flareapp/js/browser', () => ({
+            registerNavigationSource: () => ({}),
+            insulate: (fn: (...a: unknown[]) => void) => fn,
+            safeInvoke: (fn?: () => void) => fn?.(),
+        }));
         const mod = await import('../src/tanstack-router');
         expect(typeof mod.traceTanStackRouter).toBe('function');
     });

--- a/packages/react/tests/tanstack-router.test.ts
+++ b/packages/react/tests/tanstack-router.test.ts
@@ -6,7 +6,25 @@ const nav = vi.hoisted(() => ({
     setActiveRouteName: vi.fn(),
     unregister: vi.fn(),
 }));
-vi.mock('@flareapp/js/browser', () => ({ registerNavigationSource: vi.fn(() => nav) }));
+vi.mock('@flareapp/js/browser', () => ({
+    registerNavigationSource: vi.fn(() => nav),
+    insulate:
+        (fn: (...a: unknown[]) => void) =>
+        (...a: unknown[]) => {
+            try {
+                fn(...a);
+            } catch {
+                /* swallow */
+            }
+        },
+    safeInvoke: (fn?: (() => void) | null) => {
+        try {
+            fn?.();
+        } catch {
+            /* swallow */
+        }
+    },
+}));
 
 import { traceTanStackRouter } from '../src/tanstack-router';
 import type { TsrMatch } from '../src/vendor/tanstackRouterTypes';

--- a/packages/vue/src/flareVue.ts
+++ b/packages/vue/src/flareVue.ts
@@ -155,7 +155,10 @@ export const flareVue: Plugin<[FlareVueOptions?]> = (app: App, options?: FlareVu
         };
     }
 
-    if (options?.router) {
+    // Only wire router tracing when tracing is actually enabled. `enableTracing` is what gates
+    // `startBrowserTracing` at init, so without it `traceVueRouter` would attach guards and register a
+    // navigation source that can only no-op. Gate here to avoid that dead instrumentation on the router.
+    if (options?.router && flare.config?.enableTracing) {
         try {
             traceVueRouter(options.router);
         } catch {

--- a/packages/vue/src/flareVue.ts
+++ b/packages/vue/src/flareVue.ts
@@ -10,6 +10,7 @@ import { getRouteContext } from './getRouteContext';
 import { registerVueSdkInfo, tagVueFramework } from './identify';
 import { resolveFlare } from './resolveFlare';
 import { serializeProps } from './serializeProps';
+import { traceVueRouter } from './traceVueRouter';
 import { FlareVueContext, FlareVueOptions, FlareVueWarningContext } from './types';
 
 export function vueContextToAttributes(context: FlareVueContext): Attributes {
@@ -152,5 +153,13 @@ export const flareVue: Plugin<[FlareVueOptions?]> = (app: App, options?: FlareVu
                 initialWarnHandler(msg, instance, trace);
             }
         };
+    }
+
+    if (options?.router) {
+        try {
+            traceVueRouter(options.router);
+        } catch {
+            // never break plugin install
+        }
     }
 };

--- a/packages/vue/src/traceVueRouter.ts
+++ b/packages/vue/src/traceVueRouter.ts
@@ -127,7 +127,7 @@ export function traceVueRouter(router: unknown): () => void {
         safeInvoke(offAfter);
         safeInvoke(offError);
         safeInvoke(() => nav.unregister());
-        instrumented.delete(r);
+        if (instrumented.get(r) === cleanup) instrumented.delete(r);
     };
     instrumented.set(r, cleanup);
     return cleanup;

--- a/packages/vue/src/traceVueRouter.ts
+++ b/packages/vue/src/traceVueRouter.ts
@@ -1,0 +1,134 @@
+import { insulate, registerNavigationSource, safeInvoke, type RouteName } from '@flareapp/js/browser';
+
+import type { NavigationFailureLike, VueRouteLocationLike, VueRouterLike } from './vendor/vueRouterTypes';
+
+const NAVIGATION_CANCELLED = 8; // ErrorTypes.NAVIGATION_CANCELLED — a newer nav superseded this one
+
+// Dedup re-instrumentation of the same router. Vite HMR can re-run plugin install against a persistent
+// router; without this each cycle appends another guard triple that is never removed. Keyed on the
+// router object, so a genuinely new router is unaffected.
+const instrumented = new WeakMap<object, () => void>();
+
+/**
+ * Trace a vue-router instance: name the `browser_pageload` root from the initial route, and open a
+ * parameterized, held `browser_navigation` root per route change, settled once the navigation confirms.
+ * Returns a cleanup that removes the guards and unregisters. Consumed by `flareVue({ router })`; internal
+ * (not part of the public entry). Inert for a non-router value; never throws into the host.
+ */
+export function traceVueRouter(router: unknown): () => void {
+    const r = router as Partial<VueRouterLike> | null;
+    if (!r || typeof r.beforeEach !== 'function' || typeof r.afterEach !== 'function') {
+        return () => {}; // wrong shape → inert
+    }
+
+    instrumented.get(r)?.(); // HMR: tear down any prior instrumentation of this same router first
+
+    const nav = registerNavigationSource();
+
+    const routeNameFor = (loc: VueRouteLocationLike): RouteName => {
+        try {
+            const matched = loc.matched;
+            const template = matched && matched.length > 0 ? matched[matched.length - 1]?.path : undefined;
+            if (template) return { name: template, source: 'route' };
+        } catch {
+            // fall through to the URL name
+        }
+        return { name: loc.path, source: 'url' };
+    };
+
+    const hrefOf = (loc: VueRouteLocationLike): string => {
+        const origin = typeof window !== 'undefined' ? window.location.origin : '';
+        return origin + (loc.fullPath ?? loc.path ?? '');
+    };
+
+    const isInitial = (from: VueRouteLocationLike | undefined): boolean =>
+        !from || !from.matched || from.matched.length === 0; // START_LOCATION
+
+    let sawInitial = false;
+    let inFlight = false;
+
+    // Enrich the pageload root immediately if the router already resolved its initial route (e.g. flareVue
+    // installed after `await router.isReady()`); otherwise the first guard pair handles it.
+    try {
+        const current = r.currentRoute?.value;
+        if (current && current.matched && current.matched.length > 0) {
+            nav.setActiveRouteName(routeNameFor(current));
+            sawInitial = true;
+        }
+    } catch {
+        // never break the host on wiring
+    }
+
+    const offBefore = r.beforeEach(
+        insulate((to: VueRouteLocationLike, from: VueRouteLocationLike) => {
+            // Initial navigation first: START_LOCATION.fullPath is '/', so an app whose initial route is
+            // '/' would otherwise be swallowed by the same-location skip below.
+            if (!sawInitial && isInitial(from)) {
+                nav.setActiveRouteName(routeNameFor(to)); // name the pageload root; open no nav root
+                return;
+            }
+
+            // Only a `force: true` re-navigation reaches beforeEach with to.fullPath === from.fullPath: a
+            // plain duplicated nav is short-circuited before guards run and surfaces solely as an afterEach
+            // failure (type 16, dropped by the !inFlight guard there). Skip it so a same-URL refresh opens
+            // no navigation root.
+            if (to.fullPath && from?.fullPath && to.fullPath === from.fullPath) return;
+
+            if (!inFlight) {
+                inFlight = true;
+                nav.startNavigation({ path: to.path, url: hrefOf(to), hold: true });
+            }
+            nav.setActiveRouteName(routeNameFor(to)); // set / re-set across redirect hops
+        }),
+    );
+
+    const offAfter = r.afterEach(
+        insulate((to: VueRouteLocationLike, from: VueRouteLocationLike, failure?: NavigationFailureLike) => {
+            if (!sawInitial && isInitial(from)) {
+                if (!failure) {
+                    sawInitial = true;
+                    nav.setActiveRouteName(routeNameFor(to)); // finalize pageload name
+                }
+                return;
+            }
+
+            if (!inFlight) return;
+
+            if (!failure) {
+                inFlight = false;
+                nav.settleNavigation(routeNameFor(to)); // success: name + release hold
+                return;
+            }
+
+            // A redirect never reaches afterEach (vue-router short-circuits to a new navigation), so any
+            // failure here is terminal. `cancelled` (a newer nav superseded this one) keeps the held root
+            // for the successor's afterEach; `aborted` / `duplicated` / unknown release it to the current
+            // location so a blocked navigation can't strand a held root until the finalTimeout backstop.
+            if (failure.type === NAVIGATION_CANCELLED) return;
+            inFlight = false;
+            nav.settleNavigation(routeNameFor(from));
+        }),
+    );
+
+    const offError =
+        typeof r.onError === 'function'
+            ? r.onError(
+                  insulate(() => {
+                      if (!inFlight) return;
+                      inFlight = false;
+                      const current = r.currentRoute?.value;
+                      nav.settleNavigation(current ? routeNameFor(current) : { name: '', source: 'url' });
+                  }),
+              )
+            : undefined;
+
+    const cleanup = (): void => {
+        safeInvoke(offBefore);
+        safeInvoke(offAfter);
+        safeInvoke(offError);
+        safeInvoke(() => nav.unregister());
+        instrumented.delete(r);
+    };
+    instrumented.set(r, cleanup);
+    return cleanup;
+}

--- a/packages/vue/src/types.ts
+++ b/packages/vue/src/types.ts
@@ -53,6 +53,8 @@ export type FlareErrorBoundaryHookParams = {
 
 export type FlareVueOptions = {
     flare?: Flare;
+    /** A vue-router Router instance. When set, enables navigation/pageload performance tracing. */
+    router?: unknown;
     captureWarnings?: boolean;
     attachProps?: boolean;
     propsMaxDepth?: number;

--- a/packages/vue/src/vendor/vueRouterTypes.ts
+++ b/packages/vue/src/vendor/vueRouterTypes.ts
@@ -1,0 +1,21 @@
+// Structural subset of vue-router the tracing integration reads. Vendored (not imported) so this needs
+// no runtime vue-router dependency and non-router consumers of @flareapp/vue type-check cleanly. Verify
+// against the peer floor (vue-router 4.0.0) if these shapes drift.
+
+export type VueRouteLocationLike = {
+    path: string;
+    fullPath?: string;
+    matched?: { path?: string }[];
+};
+
+/** Truthy = a NavigationFailure; `.type` is a numeric ErrorTypes value (ABORTED 4 / CANCELLED 8 / DUPLICATED 16). */
+export type NavigationFailureLike = { type?: number } | undefined;
+
+export type VueRouterLike = {
+    currentRoute?: { value?: VueRouteLocationLike };
+    beforeEach(guard: (to: VueRouteLocationLike, from: VueRouteLocationLike) => unknown): () => void;
+    afterEach(
+        guard: (to: VueRouteLocationLike, from: VueRouteLocationLike, failure?: NavigationFailureLike) => unknown,
+    ): () => void;
+    onError(handler: (error: unknown, to?: VueRouteLocationLike, from?: VueRouteLocationLike) => unknown): () => void;
+};

--- a/packages/vue/tests/FlareErrorBoundary.test.ts
+++ b/packages/vue/tests/FlareErrorBoundary.test.ts
@@ -2,6 +2,7 @@ import type { Attributes } from '@flareapp/js';
 import { mount } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { defineComponent, h, nextTick } from 'vue';
+import type { ComponentCustomProperties } from 'vue';
 
 import { FlareErrorBoundary } from '../src/FlareErrorBoundary';
 import { ComponentHierarchyFrame, FlareVueContext } from '../src/types';
@@ -971,9 +972,12 @@ describe('FlareErrorBoundary', () => {
             mount(FlareErrorBoundary, {
                 global: {
                     config: {
+                        // vue-router's `declare module 'vue'` augmentation (pulled into this package's
+                        // tsc program by the router-tracing tests) types globalProperties as the full
+                        // ComponentCustomProperties; the boundary only reads $router.currentRoute.value.
                         globalProperties: {
                             $router: mockRouter(mockRoute),
-                        },
+                        } as unknown as ComponentCustomProperties,
                     },
                 },
                 slots: {
@@ -1016,9 +1020,12 @@ describe('FlareErrorBoundary', () => {
             mount(FlareErrorBoundary, {
                 global: {
                     config: {
+                        // vue-router's `declare module 'vue'` augmentation (pulled into this package's
+                        // tsc program by the router-tracing tests) types globalProperties as the full
+                        // ComponentCustomProperties; the boundary only reads $router.currentRoute.value.
                         globalProperties: {
                             $router: mockRouter(mockRoute),
-                        },
+                        } as unknown as ComponentCustomProperties,
                     },
                 },
                 props: { beforeSubmit },

--- a/packages/vue/tests/vue-router.entry.test.ts
+++ b/packages/vue/tests/vue-router.entry.test.ts
@@ -62,6 +62,7 @@ describe('@flareapp/vue vue-router tracing entry', () => {
             reportMessage: vi.fn(),
             setSdkInfo: vi.fn(),
             setFramework: vi.fn(),
+            config: { enableTracing: true },
         } as unknown as import('../src/types').FlareVueOptions['flare'];
 
         const router = {
@@ -77,6 +78,63 @@ describe('@flareapp/vue vue-router tracing entry', () => {
         expect(registerNavigationSource).toHaveBeenCalledTimes(1);
         expect(router.beforeEach).toHaveBeenCalledTimes(1);
         expect(router.afterEach).toHaveBeenCalledTimes(1);
+    });
+
+    test('installing flareVue with a router but tracing disabled does not touch the nav seam', async () => {
+        const registerNavigationSource = vi.fn(() => ({
+            startNavigation: vi.fn(),
+            setActiveRouteName: vi.fn(),
+            settleNavigation: vi.fn(),
+            unregister: vi.fn(),
+        }));
+        vi.doMock('@flareapp/js/browser', async () => {
+            const actual = await vi.importActual<Record<string, unknown>>('@flareapp/js/browser');
+            return {
+                ...actual,
+                registerNavigationSource,
+                insulate:
+                    (fn: (...a: unknown[]) => void) =>
+                    (...a: unknown[]) => {
+                        try {
+                            fn(...a);
+                        } catch {
+                            /* swallow */
+                        }
+                    },
+                safeInvoke: (fn?: (() => void) | null) => {
+                    try {
+                        fn?.();
+                    } catch {
+                        /* swallow */
+                    }
+                },
+            };
+        });
+
+        const { flareVue } = await import('../src/inject');
+        const { createApp } = await import('vue');
+
+        const flareStub = {
+            reportSilently: vi.fn(),
+            reportMessage: vi.fn(),
+            setSdkInfo: vi.fn(),
+            setFramework: vi.fn(),
+            config: { enableTracing: false },
+        } as unknown as import('../src/types').FlareVueOptions['flare'];
+
+        const router = {
+            currentRoute: { value: { path: '/', fullPath: '/', matched: [] } },
+            beforeEach: vi.fn(() => () => {}),
+            afterEach: vi.fn(() => () => {}),
+            onError: vi.fn(() => () => {}),
+        };
+
+        const app = createApp({ render: () => null });
+        app.use(flareVue, { flare: flareStub, router });
+
+        expect(registerNavigationSource).not.toHaveBeenCalled();
+        expect(router.beforeEach).not.toHaveBeenCalled();
+        expect(router.afterEach).not.toHaveBeenCalled();
     });
 
     test('installing flareVue without a router option does not touch the nav seam', async () => {

--- a/packages/vue/tests/vue-router.entry.test.ts
+++ b/packages/vue/tests/vue-router.entry.test.ts
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+describe('@flareapp/vue vue-router tracing entry', () => {
+    beforeEach(() => {
+        vi.resetModules();
+        delete (window as unknown as { flare?: unknown }).flare;
+    });
+
+    test('importing traceVueRouter does NOT evaluate the @flareapp/js root singleton', async () => {
+        const rootFactory = vi.fn(() => ({ flare: {} }));
+        vi.doMock('@flareapp/js', rootFactory);
+        vi.doMock('@flareapp/js/browser', () => ({
+            registerNavigationSource: () => ({}),
+            insulate: (fn: (...a: unknown[]) => void) => fn,
+            safeInvoke: (fn?: () => void) => fn?.(),
+        }));
+        await import('../src/traceVueRouter');
+        expect(rootFactory).not.toHaveBeenCalled();
+        expect((window as unknown as { flare?: unknown }).flare).toBeUndefined();
+    });
+
+    test('installing flareVue with a router option wires tracing exactly once', async () => {
+        const registerNavigationSource = vi.fn(() => ({
+            startNavigation: vi.fn(),
+            setActiveRouteName: vi.fn(),
+            settleNavigation: vi.fn(),
+            unregister: vi.fn(),
+        }));
+        vi.doMock('@flareapp/js/browser', async () => {
+            // Spread the REAL barrel (for createFlareResolver, called at resolveFlare.ts module load),
+            // override registerNavigationSource with the spy, and shim insulate/safeInvoke so this test
+            // passes even against a dist built before Task 1 added them.
+            const actual = await vi.importActual<Record<string, unknown>>('@flareapp/js/browser');
+            return {
+                ...actual,
+                registerNavigationSource,
+                insulate:
+                    (fn: (...a: unknown[]) => void) =>
+                    (...a: unknown[]) => {
+                        try {
+                            fn(...a);
+                        } catch {
+                            /* swallow */
+                        }
+                    },
+                safeInvoke: (fn?: (() => void) | null) => {
+                    try {
+                        fn?.();
+                    } catch {
+                        /* swallow */
+                    }
+                },
+            };
+        });
+
+        const { flareVue } = await import('../src/inject');
+        const { createApp } = await import('vue');
+
+        const flareStub = {
+            reportSilently: vi.fn(),
+            reportMessage: vi.fn(),
+            setSdkInfo: vi.fn(),
+            setFramework: vi.fn(),
+        } as unknown as import('../src/types').FlareVueOptions['flare'];
+
+        const router = {
+            currentRoute: { value: { path: '/', fullPath: '/', matched: [] } },
+            beforeEach: vi.fn(() => () => {}),
+            afterEach: vi.fn(() => () => {}),
+            onError: vi.fn(() => () => {}),
+        };
+
+        const app = createApp({ render: () => null });
+        app.use(flareVue, { flare: flareStub, router });
+
+        expect(registerNavigationSource).toHaveBeenCalledTimes(1);
+        expect(router.beforeEach).toHaveBeenCalledTimes(1);
+        expect(router.afterEach).toHaveBeenCalledTimes(1);
+    });
+
+    test('installing flareVue without a router option does not touch the nav seam', async () => {
+        const registerNavigationSource = vi.fn();
+        vi.doMock('@flareapp/js/browser', async () => {
+            // Spread the REAL barrel (for createFlareResolver, called at resolveFlare.ts module load),
+            // override registerNavigationSource with the spy, and shim insulate/safeInvoke so this test
+            // passes even against a dist built before Task 1 added them.
+            const actual = await vi.importActual<Record<string, unknown>>('@flareapp/js/browser');
+            return {
+                ...actual,
+                registerNavigationSource,
+                insulate:
+                    (fn: (...a: unknown[]) => void) =>
+                    (...a: unknown[]) => {
+                        try {
+                            fn(...a);
+                        } catch {
+                            /* swallow */
+                        }
+                    },
+                safeInvoke: (fn?: (() => void) | null) => {
+                    try {
+                        fn?.();
+                    } catch {
+                        /* swallow */
+                    }
+                },
+            };
+        });
+        const { flareVue } = await import('../src/inject');
+        const { createApp } = await import('vue');
+        const flareStub = {
+            reportSilently: vi.fn(),
+            reportMessage: vi.fn(),
+            setSdkInfo: vi.fn(),
+            setFramework: vi.fn(),
+        } as unknown as import('../src/types').FlareVueOptions['flare'];
+        const app = createApp({ render: () => null });
+        app.use(flareVue, { flare: flareStub });
+        expect(registerNavigationSource).not.toHaveBeenCalled();
+    });
+});

--- a/packages/vue/tests/vue-router.integration.test.ts
+++ b/packages/vue/tests/vue-router.integration.test.ts
@@ -178,6 +178,7 @@ describe('traceVueRouter against a real vue-router', () => {
         await router.push('/product/p01').catch(() => {});
         expect(nav.startNavigation).toHaveBeenCalledTimes(1);
         expect(nav.settleNavigation).toHaveBeenCalledTimes(1);
+        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/', source: 'route' });
     });
 
     it('names the pageload immediately when installed after the router is ready', async () => {

--- a/packages/vue/tests/vue-router.integration.test.ts
+++ b/packages/vue/tests/vue-router.integration.test.ts
@@ -1,0 +1,205 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createApp } from 'vue';
+import { createMemoryHistory, createRouter, type Router } from 'vue-router';
+
+const nav = vi.hoisted(() => ({
+    startNavigation: vi.fn(),
+    setActiveRouteName: vi.fn(),
+    settleNavigation: vi.fn(),
+    unregister: vi.fn(),
+}));
+vi.mock('@flareapp/js/browser', () => ({
+    registerNavigationSource: vi.fn(() => nav),
+    insulate:
+        (fn: (...a: unknown[]) => void) =>
+        (...a: unknown[]) => {
+            try {
+                fn(...a);
+            } catch {
+                /* swallow */
+            }
+        },
+    safeInvoke: (fn?: (() => void) | null) => {
+        try {
+            fn?.();
+        } catch {
+            /* swallow */
+        }
+    },
+}));
+
+import { traceVueRouter } from '../src/traceVueRouter';
+
+const stub = { render: () => null };
+function makeRouter(extra: Parameters<typeof createRouter>[0]['routes'] = []): Router {
+    return createRouter({
+        history: createMemoryHistory(),
+        routes: [
+            { path: '/', name: 'products', component: stub },
+            { path: '/product/:id', name: 'product', component: stub },
+            { path: '/cart', name: 'cart', component: stub },
+            { path: '/blocked', name: 'blocked', component: stub },
+            { path: '/user/:id', component: stub, children: [{ path: 'profile', component: stub }] },
+            { path: '/old', redirect: '/cart' },
+            ...extra,
+        ],
+    });
+}
+function mountWith(router: Router): void {
+    createApp({ render: () => null }).use(router);
+}
+
+beforeEach(() => {
+    nav.startNavigation.mockClear();
+    nav.setActiveRouteName.mockClear();
+    nav.settleNavigation.mockClear();
+    nav.unregister.mockClear();
+});
+
+describe('traceVueRouter against a real vue-router', () => {
+    it('names the pageload root from the initial route and opens no nav root', async () => {
+        const router = makeRouter();
+        traceVueRouter(router);
+        mountWith(router);
+        await router.isReady();
+        expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/', source: 'route' });
+        expect(nav.startNavigation).not.toHaveBeenCalled();
+    });
+
+    it('opens a held nav root with the destination url and settles the parameterized name', async () => {
+        const router = makeRouter();
+        traceVueRouter(router);
+        mountWith(router);
+        await router.isReady();
+        nav.startNavigation.mockClear();
+        await router.push('/product/p01');
+        expect(nav.startNavigation).toHaveBeenCalledTimes(1);
+        expect(nav.startNavigation.mock.calls[0]![0]).toMatchObject({ path: '/product/p01', hold: true });
+        expect(nav.startNavigation.mock.calls[0]![0].url).toBe(`${window.location.origin}/product/p01`);
+        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/product/:id', source: 'route' });
+    });
+
+    it('names a nested child route with the absolute parameterized template', async () => {
+        const router = makeRouter();
+        traceVueRouter(router);
+        mountWith(router);
+        await router.isReady();
+        nav.settleNavigation.mockClear();
+        await router.push('/user/u01/profile');
+        // Confirms vue-router normalizes the child's relative `path` to the full absolute template —
+        // the one runtime behavior the spec flagged as unpinned (matched[last].path, not chain-joined).
+        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/user/:id/profile', source: 'route' });
+    });
+
+    it('names a truly unmatched route from its path with url source', async () => {
+        const router = createRouter({ history: createMemoryHistory(), routes: [{ path: '/', component: stub }] });
+        traceVueRouter(router);
+        mountWith(router);
+        await router.isReady();
+        nav.settleNavigation.mockClear();
+        await router.push('/does/not/exist').catch(() => {});
+        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/does/not/exist', source: 'url' });
+    });
+
+    it('follows a route-config redirect and settles the final target (one nav root)', async () => {
+        const router = makeRouter();
+        traceVueRouter(router);
+        mountWith(router);
+        await router.isReady();
+        nav.startNavigation.mockClear();
+        await router.push('/old');
+        expect(nav.startNavigation).toHaveBeenCalledTimes(1);
+        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/cart', source: 'route' });
+    });
+
+    it('follows a guard-returned redirect (one nav root, final name)', async () => {
+        const router = makeRouter();
+        traceVueRouter(router);
+        router.beforeEach((to) => (to.path === '/product/p01' ? '/cart' : undefined));
+        mountWith(router);
+        await router.isReady();
+        nav.startNavigation.mockClear();
+        await router.push('/product/p01');
+        expect(nav.startNavigation).toHaveBeenCalledTimes(1);
+        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/cart', source: 'route' });
+    });
+
+    it('settles an aborted navigation to the current location', async () => {
+        const router = makeRouter();
+        traceVueRouter(router);
+        router.beforeEach((to) => (to.path === '/blocked' ? false : undefined));
+        mountWith(router);
+        await router.isReady();
+        nav.startNavigation.mockClear();
+        nav.settleNavigation.mockClear();
+        await router.push('/blocked');
+        expect(nav.startNavigation).toHaveBeenCalledTimes(1);
+        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/', source: 'route' });
+    });
+
+    it('emits no nav span for a plain duplicated navigation', async () => {
+        const router = makeRouter();
+        traceVueRouter(router);
+        mountWith(router);
+        await router.isReady();
+        await router.push('/cart');
+        nav.startNavigation.mockClear();
+        nav.settleNavigation.mockClear();
+        await router.push('/cart');
+        expect(nav.startNavigation).not.toHaveBeenCalled();
+        expect(nav.settleNavigation).not.toHaveBeenCalled();
+    });
+
+    it('skips a force re-navigation to the current location (no nav root)', async () => {
+        const router = makeRouter();
+        traceVueRouter(router);
+        mountWith(router);
+        await router.isReady();
+        await router.push('/cart');
+        nav.startNavigation.mockClear();
+        // force: true re-runs guards for the same location, so beforeEach DOES fire with
+        // to.fullPath === from.fullPath — the same-location skip must suppress it (distinct from the
+        // plain-duplicate case above, which never reaches beforeEach at all).
+        await router.push({ path: '/cart', force: true });
+        expect(nav.startNavigation).not.toHaveBeenCalled();
+    });
+
+    it('releases the held root when a guard throws (onError)', async () => {
+        const router = makeRouter();
+        traceVueRouter(router);
+        router.beforeEach((to) => {
+            if (to.path === '/product/p01') throw new Error('guard boom');
+        });
+        mountWith(router);
+        await router.isReady();
+        nav.startNavigation.mockClear();
+        nav.settleNavigation.mockClear();
+        await router.push('/product/p01').catch(() => {});
+        expect(nav.startNavigation).toHaveBeenCalledTimes(1);
+        expect(nav.settleNavigation).toHaveBeenCalledTimes(1);
+    });
+
+    it('names the pageload immediately when installed after the router is ready', async () => {
+        const router = makeRouter();
+        mountWith(router);
+        await router.isReady();
+        traceVueRouter(router);
+        expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/', source: 'route' });
+        nav.startNavigation.mockClear();
+        await router.push('/cart');
+        expect(nav.startNavigation).toHaveBeenCalledTimes(1);
+    });
+
+    it('cleanup removes the guards and unregisters the nav source', async () => {
+        const router = makeRouter();
+        const stop = traceVueRouter(router);
+        mountWith(router);
+        await router.isReady();
+        stop();
+        expect(nav.unregister).toHaveBeenCalledTimes(1);
+        nav.startNavigation.mockClear();
+        await router.push('/cart');
+        expect(nav.startNavigation).not.toHaveBeenCalled();
+    });
+});

--- a/packages/vue/tests/vue-router.test.ts
+++ b/packages/vue/tests/vue-router.test.ts
@@ -33,7 +33,7 @@ import { traceVueRouter } from '../src/traceVueRouter';
 type Loc = { path: string; fullPath: string; matched: { path: string }[] };
 type Guard = (...a: any[]) => unknown;
 
-function fakeRouter(current: Loc) {
+function fakeRouter(current: Loc | undefined) {
     let before: Guard[] = [];
     let after: Guard[] = [];
     let error: Guard[] = [];
@@ -59,6 +59,7 @@ function fakeRouter(current: Loc) {
         },
         fireBefore: (to: Loc, from: Loc) => before.forEach((g) => g(to, from)),
         fireAfter: (to: Loc, from: Loc, failure?: { type: number }) => after.forEach((g) => g(to, from, failure)),
+        fireError: () => error.forEach((g) => g()),
         counts: () => ({ before: before.length, after: after.length, error: error.length }),
     };
 }
@@ -66,6 +67,8 @@ function fakeRouter(current: Loc) {
 const home: Loc = { path: '/', fullPath: '/', matched: [{ path: '/' }] };
 const product: Loc = { path: '/product/p01', fullPath: '/product/p01', matched: [{ path: '/product/:id' }] };
 const cart: Loc = { path: '/cart', fullPath: '/cart', matched: [{ path: '/cart' }] };
+const blocked: Loc = { path: '/blocked', fullPath: '/blocked', matched: [{ path: '/blocked' }] };
+const START: Loc = { path: '/', fullPath: '/', matched: [] };
 
 beforeEach(() => {
     nav.startNavigation.mockClear();
@@ -101,5 +104,24 @@ describe('traceVueRouter edge cases', () => {
         traceVueRouter(router); // re-instrument the SAME router
         expect(router.counts()).toEqual({ before: 1, after: 1, error: 1 }); // prior removed, not doubled
         expect(nav.unregister).toHaveBeenCalledTimes(1); // prior nav source released
+    });
+
+    it('falls back to an empty name on onError when there is no current route', () => {
+        const router = fakeRouter(undefined); // currentRoute.value is undefined
+        traceVueRouter(router); // must not throw on install-time enrichment either
+        router.fireBefore(product, home); // client nav (home has matched → not initial): opens held root
+        router.fireError();
+        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '', source: 'url' });
+    });
+
+    it('keeps a blocked initial navigation in pageload naming until the first success', () => {
+        const router = fakeRouter(START); // START_LOCATION-like: empty matched → sawInitial stays false
+        traceVueRouter(router);
+        router.fireBefore(blocked, START); // treated as pageload naming, no nav root
+        router.fireAfter(blocked, START, { type: 4 }); // aborted initial → still no nav root, sawInitial stays false
+        router.fireBefore(product, START); // from is still START: aborted nav never committed
+        router.fireAfter(product, START, undefined); // success → finalizes the pageload name
+        expect(nav.startNavigation).not.toHaveBeenCalled();
+        expect(nav.setActiveRouteName).toHaveBeenLastCalledWith({ name: '/product/:id', source: 'route' });
     });
 });

--- a/packages/vue/tests/vue-router.test.ts
+++ b/packages/vue/tests/vue-router.test.ts
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const nav = vi.hoisted(() => ({
+    startNavigation: vi.fn(),
+    setActiveRouteName: vi.fn(),
+    settleNavigation: vi.fn(),
+    unregister: vi.fn(),
+}));
+const registerNavigationSource = vi.hoisted(() => vi.fn(() => nav));
+vi.mock('@flareapp/js/browser', () => ({
+    registerNavigationSource,
+    insulate:
+        (fn: (...a: unknown[]) => void) =>
+        (...a: unknown[]) => {
+            try {
+                fn(...a);
+            } catch {
+                /* swallow */
+            }
+        },
+    safeInvoke: (fn?: (() => void) | null) => {
+        try {
+            fn?.();
+        } catch {
+            /* swallow */
+        }
+    },
+}));
+
+import { traceVueRouter } from '../src/traceVueRouter';
+
+type Loc = { path: string; fullPath: string; matched: { path: string }[] };
+type Guard = (...a: any[]) => unknown;
+
+function fakeRouter(current: Loc) {
+    let before: Guard[] = [];
+    let after: Guard[] = [];
+    let error: Guard[] = [];
+    return {
+        currentRoute: { value: current },
+        beforeEach: (g: Guard) => {
+            before.push(g);
+            return () => {
+                before = before.filter((x) => x !== g);
+            };
+        },
+        afterEach: (g: Guard) => {
+            after.push(g);
+            return () => {
+                after = after.filter((x) => x !== g);
+            };
+        },
+        onError: (g: Guard) => {
+            error.push(g);
+            return () => {
+                error = error.filter((x) => x !== g);
+            };
+        },
+        fireBefore: (to: Loc, from: Loc) => before.forEach((g) => g(to, from)),
+        fireAfter: (to: Loc, from: Loc, failure?: { type: number }) => after.forEach((g) => g(to, from, failure)),
+        counts: () => ({ before: before.length, after: after.length, error: error.length }),
+    };
+}
+
+const home: Loc = { path: '/', fullPath: '/', matched: [{ path: '/' }] };
+const product: Loc = { path: '/product/p01', fullPath: '/product/p01', matched: [{ path: '/product/:id' }] };
+const cart: Loc = { path: '/cart', fullPath: '/cart', matched: [{ path: '/cart' }] };
+
+beforeEach(() => {
+    nav.startNavigation.mockClear();
+    nav.setActiveRouteName.mockClear();
+    nav.settleNavigation.mockClear();
+    nav.unregister.mockClear();
+    registerNavigationSource.mockClear();
+});
+
+describe('traceVueRouter edge cases', () => {
+    it('is inert for a non-router value (no registration, no-op cleanup)', () => {
+        const stop = traceVueRouter({});
+        expect(registerNavigationSource).not.toHaveBeenCalled();
+        expect(() => stop()).not.toThrow();
+    });
+
+    it('keeps the held root on a cancelled nav and settles when the successor succeeds', () => {
+        const router = fakeRouter(home);
+        traceVueRouter(router);
+        router.fireBefore(product, home); // open held, name product (inFlight)
+        router.fireBefore(cart, home); // superseding nav → re-name cart, no new root
+        router.fireAfter(product, home, { type: 8 }); // cancelled → keep
+        router.fireAfter(cart, home, undefined); // success → settle cart
+        expect(nav.startNavigation).toHaveBeenCalledTimes(1);
+        expect(nav.settleNavigation).toHaveBeenCalledTimes(1);
+        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/cart', source: 'route' });
+    });
+
+    it('tears down prior instrumentation when the same router is re-instrumented (HMR)', () => {
+        const router = fakeRouter(home);
+        traceVueRouter(router);
+        expect(router.counts()).toEqual({ before: 1, after: 1, error: 1 });
+        traceVueRouter(router); // re-instrument the SAME router
+        expect(router.counts()).toEqual({ before: 1, after: 1, error: 1 }); // prior removed, not doubled
+        expect(nav.unregister).toHaveBeenCalledTimes(1); // prior nav source released
+    });
+});

--- a/playgrounds/vue/src/flare.ts
+++ b/playgrounds/vue/src/flare.ts
@@ -8,6 +8,11 @@ export const initFlare = (): void => {
         flare.configure({
             ingestUrl: url,
             logsIngestUrl: url.replace('/v1/errors', '/v1/logs'),
+            tracesIngestUrl: url.replace('/v1/errors', '/v1/traces'),
+            // e2e-only timing: keep the nav/pageload root active long enough for a prompt Playwright
+            // click to land and nest under it, then flush an ended root fast.
+            idleTimeout: 2000,
+            spanFlushIntervalMs: 500,
         });
     }
 
@@ -17,6 +22,8 @@ export const initFlare = (): void => {
         // and fail like the error reports do). The fake-server logsIngestUrl
         // override above only applies under e2e (VITE_FLARE_URL set).
         enableLogs: true,
+        enableTracing: true,
+        tracesSampleRate: 1,
         beforeEvaluate: (error) => {
             if (error.message === 'hook-drop-report') return null;
             return error;

--- a/playgrounds/vue/src/main.ts
+++ b/playgrounds/vue/src/main.ts
@@ -10,6 +10,6 @@ initFlare();
 
 const app = createApp(Layout);
 app.use(router);
-app.use(flareVue, {});
+app.use(flareVue, { router });
 app.component('FlareErrorBoundary', FlareErrorBoundary);
 app.mount('#app');


### PR DESCRIPTION
## Summary

Adds parameterized `browser_pageload` / `browser_navigation` span naming for **vue-router** apps — the third framework-router tracing slice after TanStack Router (#69) and React Router v7 (#72). Wired the Vue-idiomatic way, through the existing plugin:

```ts
app.use(flareVue, { router });
```

When a `router` is passed, `flareVue` drives the existing `registerNavigationSource` nav seam from vue-router's `beforeEach` / `afterEach` / `onError` guards, naming roots from the parameterized route template (`/product/:id`) with a `flare.route.source` of `route` (falling back to the raw path with `url`). Wiring is gated on both the `router` option and `enableTracing`: no `router` (or tracing disabled) → nothing attached to the router and no nav seam registered. Error capture is unchanged.

## What's included

- **`@flareapp/js`** — extracts two pure guard helpers (`insulate` / `safeInvoke`) into the side-effect-free `@flareapp/js/browser` barrel, and converts the two existing React router integrations onto them (collapsing three near-duplicate try/catch wrappers into one definition). Behavior-preserving.
- **`@flareapp/vue`** — new internal `traceVueRouter` module + vendored structural router types (no runtime `vue-router` dependency, Electron-safe). Exposed only through `flareVue({ router })` and wired only when `enableTracing` is on; not a new public export.
- **Playground + e2e** — the Vue playground enables tracing and passes the router; new Playwright assertions cover a deep-linked pageload and a client navigation (parameterized name + `route` source + the exactly-one-nav-root invariant).

## Design notes

- Naming: `to.matched[last].path` → `route`, fallback `to.path` → `url`. No `routeLabel` toggle / `custom` source / per-param attributes (matches the React slices; PII posture).
- Lifecycle (verified against vue-router source): a held nav root opens in `beforeEach` (URL from `to.fullPath`, since vue-router resolves the destination before the URL commits) and settles in `afterEach`; redirects keep one root across hops; `cancelled` keeps the root for its successor, while `aborted` / `duplicated` / `onError` release it.
- Zero nav-seam behavior change — the `hold` / `url` / `settleNavigation` primitives already exist from #72.

## Testing

- Unit: real-vue-router integration tests (which auto-verify `matched[last].path` template normalization) plus fake-router tests for the deterministic-hard cases (cancelled race, wrong-shape inertness, HMR dedup, onError empty-name fallback, blocked-initial navigation). Entry tests assert the `enableTracing` wiring gate: the nav seam is registered exactly once with `{ router }` + tracing on, and left untouched when tracing is off or no `router` is passed.
- Full repo green: 1370 unit tests, 37/37 Playwright (vue + react-router regression), inject entries root-free.

## Notes for reviewers

- The vue package's `tsc` reports 2 pre-existing errors in `tests/FlareErrorBoundary.test.ts` (an incomplete router mock literal) that are present on `main` and untouched here — not introduced by this PR.
- Pre-publish: raise `@flareapp/vue`'s `@flareapp/js` peer floor to the version shipping `insulate` / `safeInvoke` + the nav seam before release. Backend `flare.route.source` semantics remain gated, so `enableTracing` stays opt-in.

