### PR TITLE
feat(sveltekit): SvelteKit 2 browser tracing (traceSvelteKitRouter)

### DIFF
--- a/docs/superpowers/specs/2026-07-16-performance-tracing-framework-router-sveltekit-design.md
+++ b/docs/superpowers/specs/2026-07-16-performance-tracing-framework-router-sveltekit-design.md
@@ -52,6 +52,10 @@ spec diverges from Sentry, the divergence is called out and justified — see
    no-ops when off"). Rationale in "Why no enableTracing gate" below.
 6. **Deliverables:** implementation + unit tests + playground wiring and e2e. **No README section**
    (explicitly not selected). Limitations are documented in terse JSDoc on the export instead.
+7. **In scope: fetch/XHR span coverage on SvelteKit.** No svelte playground route makes a single HTTP
+   call today, so the trace model's claim that `browser_fetch` / `browser_xhr` "nest under whichever
+   root is active, unchanged" is untested on SvelteKit. This slice adds an HTTP scenarios page and the
+   e2e assertions for it. See "Fetch and XHR coverage" below.
 
 ## Seam selection (decided; recorded because the reasoning is load-bearing)
 
@@ -597,26 +601,29 @@ enabled, no-ops when off, returns a cleanup. Then the limitations:
 - **Backend still gated.** `flare.route.source` and parameterized-name semantics need backend
   agreement (B5/B9/P4). `enableTracing` stays opt-in.
 
-## Out of scope / follow-ups
+## Fetch and XHR coverage (in scope)
 
-- **An HTTP-calls page in the svelte playground, to verify `browser_fetch` / `browser_xhr` on
-  SvelteKit.** Sequence this immediately after this slice; it depends on the `enableTracing` +
-  `tracesIngestUrl` wiring the Playground section adds. No svelte playground route makes any HTTP call
-  today, so fetch/XHR instrumentation is entirely unexercised on SvelteKit even though this slice
-  claims those spans "nest under whichever root is active, unchanged".
-    - **Shape**: a `/http` route mirroring `/broken` (one button per scenario, `testIds.*` selectors).
-      Scenarios: plain global `fetch`; a 404/500 fetch; an XHR GET; a fetch fired mid-navigation (proves
-      it nests under the `browser_navigation` root, not the pageload root); and a `+page.ts` using
-      `load({ fetch })`.
-    - **The `load({ fetch })` case is the valuable one.** It pins the finding below, which is currently
-      reasoned-from-source but unproven at runtime.
-    - **Assert on `parentSpanId`**, not duration: the fetch span's parent must be the active root's
-      `spanId`. That is a structural signal rather than a timing one.
-    - **Do not target Flare's own ingest URLs.** `isFlareIngestUrl()` deliberately drops those spans, so
-      the test would fail looking like broken instrumentation. Add a `+server.ts` endpoint instead.
-    - **Expect no span** for a hydration `initial_fetch` (it short-circuits to an inlined
-      `<script type="application/json">` payload and returns a synthetic `Response` with no network
-      call) or for a `subsequent_fetch` cache hit. Both are correct: a span would be a lie.
+The trace model above claims `browser_fetch` / `browser_xhr` spans "nest under whichever root is
+active, unchanged". On SvelteKit that is currently an assumption: **no svelte playground route makes
+a single HTTP call**, so neither instrumentation is exercised at all. This slice closes that.
+
+- **Surface**: a `/http` route mirroring `/broken` — one button per scenario, `testIds.httpTrigger(id)`
+  selectors, plus a `testIds.httpResult` line so the e2e can await completion instead of sleeping.
+- **Scenarios**: global `fetch` 200; `fetch` 404; `fetch` 500; XHR 200; XHR 404; and a `+page.ts`
+  using `load({ fetch })`.
+- **Request target**: a playground-owned `/api/echo` `+server.ts` taking `status` and `delay`.
+  **Never aim a scenario at a Flare ingest URL** — `isFlareIngestUrl()`
+  (`packages/js/src/tracing/httpRequestSpan.ts:28`) drops spans whose URL starts with `ingestUrl` /
+  `logsIngestUrl` / `tracesIngestUrl`, so such a call is silently untraced and reads as broken
+  instrumentation.
+- **The assertion that matters is `parentSpanId`**, not duration: a request span's parent must be the
+  root that was active when it fired. Structural, not timing-dependent.
+- **The `load({ fetch })` case is the valuable one.** It must be reached by a **client navigation**;
+  deep-linking runs the load on the server, where there is no patch and correctly no span. It pins the
+  finding below, which is otherwise reasoned-from-source and unproven at runtime.
+- **Expect no span** for a hydration `initial_fetch` (it short-circuits to an inlined
+  `<script type="application/json">` payload and returns a synthetic `Response` with no network call)
+  or for a `subsequent_fetch` cache hit. Both are correct: a span would be a lie.
 
 ### SvelteKit's fetches ARE traced (recorded because the source invites the opposite conclusion)
 
@@ -631,8 +638,10 @@ directly to allow using a 3rd party-patched fetch implementation" — Kit design
 Since `fetcher.js` evaluates before `hooks.client.ts` (`bundle.js` imports `./entry.js` before
 `__sveltekit/manifest`), the resulting stack is `flarePatch -> kitWrapper -> native`, and a
 `load({ fetch })` call does produce a `browser_fetch` span. **Do not add a "load fetches are untraced"
-limitation to the JSDoc; it is false.** The follow-up above is what turns this from source-reading
-into evidence.
+limitation to the JSDoc; it is false.** The `load({ fetch })` scenario above is what turns this from
+source-reading into evidence.
+
+## Out of scope / follow-ups
 
 - **Server-side tracing and server→client correlation.** Blocked on `@flareapp/node` having any
   tracing at all. When it lands, the SvelteKit side is a `handle` hook injecting traceparent meta tags

--- a/docs/superpowers/specs/2026-07-16-performance-tracing-framework-router-sveltekit-design.md
+++ b/docs/superpowers/specs/2026-07-16-performance-tracing-framework-router-sveltekit-design.md
@@ -599,6 +599,41 @@ enabled, no-ops when off, returns a cleanup. Then the limitations:
 
 ## Out of scope / follow-ups
 
+- **An HTTP-calls page in the svelte playground, to verify `browser_fetch` / `browser_xhr` on
+  SvelteKit.** Sequence this immediately after this slice; it depends on the `enableTracing` +
+  `tracesIngestUrl` wiring the Playground section adds. No svelte playground route makes any HTTP call
+  today, so fetch/XHR instrumentation is entirely unexercised on SvelteKit even though this slice
+  claims those spans "nest under whichever root is active, unchanged".
+    - **Shape**: a `/http` route mirroring `/broken` (one button per scenario, `testIds.*` selectors).
+      Scenarios: plain global `fetch`; a 404/500 fetch; an XHR GET; a fetch fired mid-navigation (proves
+      it nests under the `browser_navigation` root, not the pageload root); and a `+page.ts` using
+      `load({ fetch })`.
+    - **The `load({ fetch })` case is the valuable one.** It pins the finding below, which is currently
+      reasoned-from-source but unproven at runtime.
+    - **Assert on `parentSpanId`**, not duration: the fetch span's parent must be the active root's
+      `spanId`. That is a structural signal rather than a timing one.
+    - **Do not target Flare's own ingest URLs.** `isFlareIngestUrl()` deliberately drops those spans, so
+      the test would fail looking like broken instrumentation. Add a `+server.ts` endpoint instead.
+    - **Expect no span** for a hydration `initial_fetch` (it short-circuits to an inlined
+      `<script type="application/json">` payload and returns a synthetic `Response` with no network
+      call) or for a `subsequent_fetch` cache hit. Both are correct: a span would be a lie.
+
+### SvelteKit's fetches ARE traced (recorded because the source invites the opposite conclusion)
+
+`runtime/client/fetcher.js:9` captures `const native_fetch = window.fetch` at module scope, which
+reads like Kit pinning the unpatched original before `hooks.client.ts` can install anything. It is
+not. That reference is used **only inside Kit's own `window.fetch` wrapper** (`:66`, `:77`), which the
+same module installs at eval time, so the wrapper cannot recurse into itself. Every path Kit exposes
+reads `window.fetch` at **call** time: `initial_fetch` (`:117`), `subsequent_fetch` (`:137`),
+`dev_fetch` (`:151`), and `load_data` (`client.js:3091`, carrying the comment "use window.fetch
+directly to allow using a 3rd party-patched fetch implementation" — Kit designs for this).
+
+Since `fetcher.js` evaluates before `hooks.client.ts` (`bundle.js` imports `./entry.js` before
+`__sveltekit/manifest`), the resulting stack is `flarePatch -> kitWrapper -> native`, and a
+`load({ fetch })` call does produce a `browser_fetch` span. **Do not add a "load fetches are untraced"
+limitation to the JSDoc; it is false.** The follow-up above is what turns this from source-reading
+into evidence.
+
 - **Server-side tracing and server→client correlation.** Blocked on `@flareapp/node` having any
   tracing at all. When it lands, the SvelteKit side is a `handle` hook injecting traceparent meta tags
   (Sentry's `addSentryCodeToPage` + `transformPageChunk` shape) plus a client-side pickup in the

--- a/docs/superpowers/specs/2026-07-16-performance-tracing-framework-router-sveltekit-design.md
+++ b/docs/superpowers/specs/2026-07-16-performance-tracing-framework-router-sveltekit-design.md
@@ -1,0 +1,407 @@
+# Spec: performance tracing — framework router integration, SvelteKit 2
+
+## Context
+
+Flare's browser performance tracing already emits `browser_pageload` and `browser_navigation` root
+spans, plus nested `browser_fetch` / `browser_xhr` spans. Framework router integrations replace the
+generic URL-based span name (`/product/p01`) with the parameterized route template (`/product/[id]`)
+and set a `flare.route.source` attribute (`route` vs `url`). Three such integrations have shipped:
+
+- `@flareapp/react/tanstack-router` — `traceTanStackRouter(router)` (PR #69).
+- `@flareapp/react/react-router` — `traceReactRouter(router)` (PR #72).
+- `@flareapp/vue` — wired through `app.use(flareVue, { router })` (PR #74).
+
+All three build on the **navigation-source seam** in `@flareapp/js` (exported from
+`@flareapp/js/browser` as `registerNavigationSource()`), which lets an integration drive navigation
+instead of the built-in History-API detection:
+
+- `startNavigation({ path, url?, hold? })` — `url` overrides the nav root's `url.full` (for routers
+  that resolve the destination before the browser URL commits); `hold` opens the root idle-suppressed.
+- `settleNavigation(route)` — names the root and releases the hold.
+- `setActiveRouteName(route)` — (re)names the active root + `flare.route.source` in lockstep.
+- `unregister()` — releases any hold and hands navigation back to the built-in detection.
+
+This slice adds the **SvelteKit 2** client integration — the last router on the original
+carry-forward list. **This slice requires no change to the seam**: `hold`, `url`, and
+`settleNavigation` already exist from PR #72, and SvelteKit is exactly the pre-URL-commit shape they
+were built for.
+
+Reference: Sentry's `@sentry/sveltekit` `browserTracingIntegration` guided the approach. Where this
+spec diverges from Sentry, the divergence is called out and justified — see
+"Deliberate divergences from Sentry".
+
+## Approved decisions driving this spec
+
+1. **Client router only.** Server-side spans and server→client trace correlation are out of scope:
+   `@flareapp/node` has no tracing instrumentation at all today (no spans, no traceparent), so there
+   is no server trace to correlate a client pageload with. Sentry's `<meta name="sentry-trace">`
+   injection via `transformPageChunk` has no Flare analog to build against yet.
+2. **Seam = `navigating` from `$app/state`, observed with `$effect`.** Not `$app/stores` (Sentry's
+   choice), not `beforeNavigate`/`afterNavigate`. Rationale in "Seam selection" below.
+3. **Route names use SvelteKit's native bracket syntax verbatim** — `/product/[id]`, from
+   `page.route.id`. No normalization to `:id`. Matches Sentry, and matches this repo's precedent of
+   preserving each router's native template syntax (vue-router and react-router emit `:id` only
+   because that is what those routers natively use).
+4. **Public surface = `traceSvelteKitRouter()`**, a standalone export from `@flareapp/sveltekit/client`
+   called from `hooks.client.ts`. SvelteKit has no router object to pass and no plugin system, so the
+   vue `app.use(plugin, { router })` shape has no analog; a call at client init is the idiomatic
+   SvelteKit equivalent, and it sits alongside the existing `trackRouteContext()` rather than changing
+   what that already-published API does.
+5. **Deliverables:** implementation + unit tests + playground wiring and e2e. **No README section**
+   (explicitly not selected). Limitations are documented in terse JSDoc on the export instead.
+
+## Seam selection (decided; recorded because the reasoning is load-bearing)
+
+Three candidate seams were evaluated against SvelteKit 2.67 source.
+
+| Seam                                       | Wireable from `hooks.client.ts` | Synchronous         | Deprecated |
+| ------------------------------------------ | ------------------------------- | ------------------- | ---------- |
+| `navigating` from `$app/stores` (Sentry's) | yes                             | yes                 | yes        |
+| `navigating` from `$app/state`             | yes                             | no (effect-batched) | no         |
+| `beforeNavigate` / `afterNavigate`         | **no**                          | yes                 | no         |
+
+- **`beforeNavigate`/`afterNavigate`/`onNavigate` were rejected**: all three go through
+  `add_navigation_callback` (client.js:2213), which wraps `onMount`, so they require component context
+  and can only be wired from a `+layout.svelte`. Separately, `onNavigate` fires at client.js:1884 —
+  _after_ load functions have already run — so it cannot time a navigation's start. And a navigation
+  cancelled by a later `beforeNavigate` guard would strand a held root until the 30s `finalTimeout`.
+- **`$app/stores` was rejected despite being Sentry's choice.** Sentry's peer ranges explain why they
+  use it: `@sentry/svelte` supports `svelte: 3.x || 4.x || 5.x` and `@sentry/sveltekit` supports
+  `@sveltejs/kit: 2.x` down to 2.0. `$app/state` requires Svelte 5 **and** Kit 2.12+, so Sentry
+  cannot use it — their source carries a `TODO(v11)` to migrate once Svelte 5 becomes their floor.
+  `@flareapp/sveltekit` already peers `svelte: ^5.3.0` and `@sveltejs/kit: ^2.12.0`, so that
+  constraint does not bind us. Copying `$app/stores` would mean adopting a deprecated API to solve a
+  compatibility problem we do not have.
+- **`$app/state` selected.** It is the API Kit's own docs mandate, and it matches the existing
+  `trackRouteContext.svelte.ts`. Its one weakness — `$effect` batching, discussed next — is
+  neutralized by a fallback branch already proven in `react-router.ts`.
+
+### The batching risk, and why it is contained
+
+`$app/state`'s `navigating` is a getter over `_navigating.current`, a `$state.raw` value
+(`client/state.svelte.js`). Reading it requires an `$effect`, and Svelte flushes effects on a
+microtask. Kit sets `navigating` non-null at client.js:1735 and null at client.js:2023, with
+`await load_route(intent)` in between — so microtask FIFO ordering means the effect will observe the
+non-null state in practice. But that is a guarantee resting on ordering between two libraries'
+internals, and its failure mode is _silent_: a dropped span.
+
+The containment: if an effect ever did coalesce non-null→null into one run, the committed `page.url`
+would still have changed while `inFlight` is false. That is exactly the "loader-less navigation" case
+`packages/react/src/react-router.ts:115-122` already handles — open the root un-held and name it
+immediately. Worst case therefore degrades from _a silently dropped span_ to _an instant,
+correctly-named navigation root_.
+
+## SvelteKit lifecycle facts (verified against `@sveltejs/kit@2.67.0` source)
+
+All line numbers refer to `node_modules/@sveltejs/kit/src/runtime/client/client.js`.
+
+- **Navigation ordering in `navigate()`** (defined at :1689): `_before_navigate()` runs `beforeNavigate`
+  callbacks (:1663) → `accept()` → `is_navigating = true` (:1732) →
+  `stores.navigating.set((navigating.current = nav.navigation))` (:1735) → `await load_route(intent)`
+  (:1738) → `history.pushState` / `history.replaceState` commits the URL (:1855) → `onNavigate`
+  callbacks (:1884) → `is_navigating = false` (:2006) → `afterNavigate` callbacks (:2015) →
+  `stores.navigating.set((navigating.current = null))` (:2023).
+- **`navigating` emits before the URL commits.** `window.location` is still the _old_ URL when
+  `navigating` goes non-null. The destination must be passed explicitly — this is what the seam's
+  `url` override (PR #72) exists for.
+- **The initial load never emits `navigating`**: guarded by `if (started && nav.navigation.type !== 'enter')`
+  at :1734. Pageload therefore stays cleanly separate from navigation, with no `initialized`-style
+  flag needed.
+- **Cancelled navigations never emit `navigating`**: `cancel()` sets `should_block`, `_before_navigate`
+  returns `null` (:1666), and `navigate()` early-returns before :1735. Nothing to strand.
+- **`new URL('a:').origin` is the string `'null'`** (verified in node), so the branch-1 placeholder
+  guard `page.url.origin !== location.origin` is sound.
+- **`beforeNavigate` does not re-fire during redirects**: guarded by `if (!is_navigating)` (:1661).
+  But `navigating` **re-emits a new non-null value with no `null` in between** on a redirect.
+- **Shallow routing does not touch `page.url`.** `pushState` (:2477) sets `page.state` (:2508) and
+  calls `history.pushState` (:2505), but never assigns `page.url`. A `page.url`-keyed fallback
+  therefore cannot fire for shallow routing.
+- **Hash navigation _does_ touch `page.url`.** `update_url()` (:2956) does `current.url = page.url = url`,
+  called from :2766 / :2871 / :2906 for hash-only changes. This is why the fallback key must exclude
+  the hash.
+- **`page` is unpopulated before hydration.** `client/state.svelte.js` initializes `page.url` to
+  `new URL('a:')` (a placeholder) and `page.route` to `{ id: null }`. An effect created in
+  `hooks.client.ts` can run against this placeholder state.
+- **`to.route.id` is `null` for routes SvelteKit does not own**, and `navigation.willUnload` is true
+  for `'leave'` navigations and for `'link'` navigations where `to.route === null` (documented at
+  :2237-2241). Both mean the document is about to unload.
+- **`navigation.type` values**: `'enter' | 'form' | 'leave' | 'link' | 'goto' | 'popstate'`. Both
+  `goto()` and `redirect()` surface as `'goto'`.
+
+## Components
+
+### 1. `packages/sveltekit/src/client/traceSvelteKitRouter.svelte.ts` (new)
+
+The whole integration. The `.svelte.ts` extension is required for runes and matches the existing
+`trackRouteContext.svelte.ts`.
+
+```ts
+import { navigating, page } from '$app/state';
+import { flare } from '@flareapp/js';
+import { insulate, registerNavigationSource, safeInvoke, type RouteName } from '@flareapp/js/browser';
+```
+
+Signature:
+
+```ts
+export function traceSvelteKitRouter(): () => void;
+```
+
+Guards, in order:
+
+1. **Tracing gate.** `if (!flare.config?.enableTracing) return () => {};` — matches the `flareVue`
+   gate added in `fdac544`, so passing tracing-off attaches no dead effect and no dead nav source.
+2. **Idempotence.** A module-level `tracing` flag, mirroring `trackRouteContext`'s `tracking` flag.
+   A second call returns a no-op cleanup.
+3. **Browser only.** No-op when `typeof window === 'undefined'` (SSR import safety).
+
+Internal state:
+
+```ts
+const nav = registerNavigationSource();
+const keyOf = (url: URL): string => url.pathname + url.search; // hash EXCLUDED — see limitations
+let lastKey = location.pathname + location.search; // the last committed location we accounted for
+let inFlight = false;
+```
+
+`lastKey` is mutable and must be re-stamped on every commit the state machine accounts for (branches
+5, 6 and 7 below). Anchoring on a frozen `initialKey` instead would make branch 7 fire on every
+effect re-run after the first navigation, fabricating a spurious navigation root each time `page.data`
+changed. This mirrors `lastLocationKey` in `react-router.ts`.
+
+Route naming:
+
+```ts
+const routeNameFor = (routeId: string | null | undefined, url: URL): RouteName =>
+    routeId ? { name: routeId, source: 'route' } : { name: url.pathname, source: 'url' };
+```
+
+The effect body is wrapped in `insulate`. **All four reactive reads — `navigating.to`,
+`navigating.willUnload`, `page.route?.id`, `page.url` — must happen unconditionally at the top of the
+effect, before any branching.** Svelte tracks dependencies as they are read, so an early `return`
+placed before the `navigating.to` read would silently stop the effect from ever re-running on
+navigation. This is the single easiest way to get this file wrong.
+
+| #   | Condition                                              | Action                                                                                                                                                                                                                                                                                      |
+| --- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1   | `page.url.origin !== location.origin`                  | `return` — Kit's pre-hydration `a:` placeholder                                                                                                                                                                                                                                             |
+| 2   | `to` set, and (`willUnload` or `to.route?.id == null`) | `return` — document will unload; the next document's pageload covers it                                                                                                                                                                                                                     |
+| 3   | `to` set, `!inFlight`                                  | `inFlight = true`; `nav.startNavigation({ path: to.url.pathname, url: to.url.href, hold: true })`; then `nav.setActiveRouteName(routeNameFor(to.route.id, to.url))`                                                                                                                         |
+| 4   | `to` set, `inFlight`                                   | `nav.setActiveRouteName(routeNameFor(to.route.id, to.url))` only — redirect hop, keep the single held root                                                                                                                                                                                  |
+| 5   | `to` null, `inFlight`                                  | `inFlight = false`; `lastKey = keyOf(page.url)`; `nav.settleNavigation(routeNameFor(page.route?.id, page.url))`                                                                                                                                                                             |
+| 6   | `to` null, `!inFlight`, `keyOf(page.url) === lastKey`  | `nav.setActiveRouteName(routeNameFor(page.route?.id, page.url))` — pageload naming; also re-runs harmlessly when `route.id` resolves late, or when `page.data` changes after a settle (the root is either still open and gets the same name, or already closed and `applyRouteName` no-ops) |
+| 7   | `to` null, `!inFlight`, `keyOf(page.url) !== lastKey`  | **coalescing fallback**: `lastKey = keyOf(page.url)`; `nav.startNavigation({ path, url: page.url.href })` un-held, then `nav.settleNavigation(...)` immediately                                                                                                                             |
+
+Branch 7 is the containment described above. It is expected to be dead code in practice; the e2e
+suite is what proves that (see Testing).
+
+Structure:
+
+```ts
+const dispose = $effect.root(() => {
+    $effect(
+        insulate(() => {
+            /* branches 1-7 */
+        }),
+    );
+});
+
+return () => {
+    safeInvoke(dispose);
+    safeInvoke(() => nav.unregister());
+    tracing = false;
+};
+```
+
+`nav.unregister()` releases any outstanding hold (per the seam's contract from PR #72), so a cleanup
+mid-navigation cannot strand a held root until `finalTimeout`.
+
+### 2. `packages/sveltekit/src/client/index.ts` (edit)
+
+Add one line:
+
+```ts
+export { traceSvelteKitRouter } from './traceSvelteKitRouter.svelte.js';
+```
+
+No change to `packages/sveltekit/src/index.ts` — this is client-only, matching how
+`trackRouteContext` is exposed only from `/client`.
+
+### 3. `packages/sveltekit/package.json` (edit, pre-publish)
+
+Raise the `@flareapp/js` peer floor from `^2.6.0` to the version shipping `insulate` / `safeInvoke` /
+the nav seam. See "Pre-publish carry-forward".
+
+## Trace model for this slice
+
+Unchanged from the other router slices — this integration only _names_ roots that already exist:
+
+- One `browser_pageload` root per document, named from `page.route.id` once hydration resolves it.
+- One `browser_navigation` root per SvelteKit client navigation, opened **held** at `navigating`
+  non-null (before load functions run), named from `to.route.id`, settled at `navigating` null.
+- A redirect chain produces **one** navigation root, re-named to the final destination.
+- `browser_fetch` / `browser_xhr` spans nest under whichever root is active, unchanged.
+
+## Route name & attributes
+
+- `flare.entry_point.handler.identifier` and the span name: `page.route.id` / `to.route.id` verbatim,
+  e.g. `/product/[id]`, `/blog/[...slug]`, `/[[lang]]/about`.
+- `flare.route.source`: `'route'` when a route id was available, `'url'` when it was not (falling back
+  to `url.pathname`).
+- No `routeLabel` toggle, no `custom` source, no per-param or per-query span attributes — consistent
+  with the vue-router slice.
+
+## Deliberate divergences from Sentry
+
+| Topic                 | Sentry                                        | This spec                          | Why                                                                                                                                                                          |
+| --------------------- | --------------------------------------------- | ---------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Seam                  | `$app/stores` (deprecated)                    | `$app/state`                       | Sentry supports Svelte 3/4 + Kit 2.0 and _cannot_ use `$app/state`; they have a `TODO(v11)` to switch. Our peers are already Svelte 5 + Kit 2.12+.                           |
+| Redirects             | ends the first span, starts a second          | one held root, re-named            | Sentry's reason is a span-status artifact of their model, which Flare does not share. One root per user-perceived navigation matches the vue-router and react-router slices. |
+| Query-only navigation | no span (pathname-only compare)               | real navigation span               | SvelteKit re-runs load functions for a query change, so it is real work. vue-router (`fullPath`) and react-router (`pathname+search+hash`) already count these.              |
+| Pageload naming       | `page.subscribe` callback, never unsubscribed | scoped effect, disposed by cleanup | Sentry's subscription keeps firing after the pageload span has ended, calling `updateName` on a dead span. Our cleanup disposes the effect root.                             |
+
+Matching Sentry deliberately: bracket-syntax route names, no span for shallow routing, no span for
+hash-only navigation, no span for cancelled navigations, and `type: 'enter'` never producing a
+navigation.
+
+## Error handling
+
+Identical to the vue and react slices — instrumentation must never throw into the host app:
+
+- The effect body is wrapped in `insulate` (from `@flareapp/js/browser`).
+- Cleanup uses `safeInvoke` for both the effect-root dispose and `nav.unregister()`.
+- `routeNameFor` reads are defensive (`page.route?.id`, `to.route?.id`); no assumption that Kit's
+  state is well-formed.
+- The `enableTracing` gate means an app with tracing off attaches nothing at all.
+
+## Testing
+
+### Unit — `packages/sveltekit/tests/client/traceSvelteKitRouter.test.ts` (new)
+
+The existing `packages/sveltekit/tests/__mocks__/app-state.ts` mock exports a static `page` object.
+It must be extended to export a drivable `navigating` and to let tests mutate `page` — and, because
+the mock is aliased for the whole package (`vitest.config.mts` maps `$app/state` to it), the change
+must stay backward-compatible with `getRouteContext.test.ts`, which already depends on it.
+
+Because the production code uses `$effect`, tests drive the state machine directly rather than
+through Svelte's scheduler; `@flareapp/js/browser` is mocked to capture seam calls (the pattern the
+five react test mocks already use — note they had to add `insulate`/`safeInvoke` to their mock
+factory, per the PR #74 carry-forward).
+
+Cases:
+
+1. `enableTracing` falsy → no `registerNavigationSource` call, cleanup is a no-op.
+2. Second call is idempotent (no second nav source).
+3. Pre-hydration placeholder `page.url` (`a:` origin) → no seam calls (branch 1).
+4. Pageload naming from `page.route.id` → `setActiveRouteName({ name: '/product/[id]', source: 'route' })`.
+5. Pageload with `route.id === null` → `source: 'url'`, name is the pathname.
+6. Late-resolving `route.id` at the initial key → re-names the pageload root, opens no nav root.
+7. Navigation start → `startNavigation` with `hold: true`, `url` = destination href, `path` =
+   destination pathname; then named from `to.route.id`.
+8. Navigation settle → `settleNavigation` with the committed `page.route.id`.
+9. Redirect (non-null → non-null, no null between) → exactly **one** `startNavigation`, final name applied.
+10. `willUnload` true → no `startNavigation` (branch 2).
+11. `to.route.id == null` (external / unowned route) → no `startNavigation` (branch 2).
+12. Hash-only `page.url` change while idle → no `startNavigation` (key excludes hash).
+13. Coalescing fallback (branch 7): key changes while idle and not in flight → `startNavigation`
+    **without** `hold`, followed immediately by `settleNavigation`.
+14. **`lastKey` re-stamp regression**: after a navigation settles, a further effect run at the same
+    committed key (e.g. `page.data` changed via `invalidate()`) must **not** call `startNavigation`
+    again. This pins the bug that a frozen `initialKey` would have introduced.
+15. Cleanup → disposes the effect root and calls `nav.unregister()`.
+
+### E2E — `e2e/specs/svelte.spec.ts` (edit)
+
+This is the gate that answers the batching question against real SvelteKit, and it is the reason the
+playground work is in scope rather than optional. Mirrors the react-router specs from PR #73, reusing
+`e2e/specs/otlp.ts` (`spansOf`, `attr`, `hasSpanType`):
+
+1. **Pageload root carries the parameterized route** — deep-link `/product/p01`, assert the
+   `browser_pageload` root is named `/product/[id]` with `flare.route.source === 'route'`.
+2. **Navigation root carries the parameterized route** — load `/`, click through to a product, assert
+   a `browser_navigation` root named `/product/[id]` with `source: 'route'` and a correct `url.full`
+   (this is what proves the `url` override works for Kit's pre-URL-commit emission).
+3. **A hash-only change produces no navigation root.**
+4. **Regression**: the existing svelte error-scenario specs still pass with tracing enabled.
+
+If test 2 shows the fallback shape (an un-held, zero-duration root) instead of a held root spanning
+the load, effect batching is real — we learn it loudly, and the seam decision gets revisited rather
+than silently dropping spans in production.
+
+## Playground
+
+`playgrounds/svelte` currently does **not** enable tracing (`src/lib/flare.client.ts` sets
+`enableLogs` but no `enableTracing`). Two edits:
+
+1. `playgrounds/svelte/src/lib/flare.client.ts` — add `enableTracing: true`, matching
+   `playgrounds/react-router/src/flare.ts:26`.
+2. `playgrounds/svelte/src/hooks.client.ts` — call `traceSvelteKitRouter()` after `initFlareClient()`:
+
+```ts
+import { initFlareClient } from '$lib/flare.client';
+import { handleErrorWithFlare, traceSvelteKitRouter } from '@flareapp/sveltekit/client';
+
+initFlareClient();
+traceSvelteKitRouter();
+
+export const handleError = handleErrorWithFlare();
+```
+
+The existing `/product/[id]` route already provides the parameterized case; no new routes are needed.
+Note that `traceSvelteKitRouter()` must be called after `initFlareClient()`, since the
+`enableTracing` gate is read at call time — this ordering constraint belongs in the export's JSDoc.
+
+## Documented limitations (JSDoc on the export, not README)
+
+- Shallow routing (`pushState` / `replaceState` from `$app/navigation`) produces no navigation root.
+- Hash-only navigation produces no navigation root.
+- Navigations cancelled by a `beforeNavigate` guard produce no navigation root.
+- Navigations to routes SvelteKit does not own produce no navigation root; the resulting full document
+  load surfaces as a pageload instead.
+
+## Items to verify during implementation
+
+1. **Does `$app/state`'s `navigating` actually reach a `$effect` created in `hooks.client.ts`?** The
+   effect root is created outside any component. Confirm it flushes and observes both transitions —
+   this is the core assumption, and the e2e navigation test is the proof.
+2. **Is `page.url.origin !== location.origin` a sound placeholder guard?** `new URL('a:').origin` is
+   the string `'null'`, so the guard should hold. Confirm against a real hydration, and confirm it
+   does not misfire for hash-mode routing.
+3. **Confirm branch 6 does not mis-handle an initial-load redirect.** A `redirect()` thrown from a
+   load during hydration may route through `navigate()` and emit `navigating`, producing a pageload of
+   the original URL plus a navigation root to the target. Decide whether that is acceptable (leaning:
+   yes, it is arguably correct, and Sentry has the same shape) and document it.
+4. **`page.route.id` reactivity vs. Kit's route proxy.** Sentry's server-side `getRouteId()` reads
+   `route.id` via `untrack()` specifically to avoid triggering a proxy that invalidates server `load`
+   data on every navigation. Verify that reading `page.route.id` inside a client `$effect` has no such
+   side effect — the existing `trackRouteContext` already does it, which is reassuring but is not proof.
+5. **Extending the shared `$app/state` mock must not break `getRouteContext.test.ts`.**
+6. **`svelte-package` output**: confirm the new `.svelte.ts` module is emitted and typed correctly, and
+   that `scripts/verify-exports.mjs` still passes. See `.claude/docs/svelte-packaging` for the known
+   ESM-extension and version-generation quirks.
+
+## Pre-publish carry-forward
+
+- **Peer floor.** `@flareapp/sveltekit` peers `@flareapp/js: ^2.6.0`; published `@flareapp/js` is still
+  2.6.0, which does not export `insulate` / `safeInvoke` / the nav seam. The floor must rise before
+  release. This is the same coupling PRs #72 and #74 flagged across react, vue, svelte, and sveltekit —
+  coordinate as one lockstep bump rather than per-slice.
+- **Backend still gated.** `flare.route.source` and parameterized-name semantics need backend
+  agreement (B5/B9/P4). `enableTracing` stays opt-in.
+
+## Out of scope / follow-ups
+
+- **Server-side tracing and server→client correlation.** Blocked on `@flareapp/node` having any
+  tracing at all. When it lands, the SvelteKit side is a `handle` hook injecting traceparent meta tags
+  (Sentry's `addSentryCodeToPage` + `transformPageChunk` shape) plus a client-side pickup in the
+  pageload root. This is the largest remaining gap versus Sentry.
+- **Load-function spans** (`wrapLoadWithSentry` / `wrapServerLoadWithSentry` analogs, and Sentry's
+  acorn-based Vite auto-instrumentation plugin).
+- **Svelte component tracking** — the `@flareapp/react/profiler` analog and Sentry's `trackComponents`
+  preprocessor. Deferred by the vue-router slice for the same reason; needs its own spec. Note Sentry's
+  `ui.svelte.update` span cannot work in Svelte 5 runes mode (no `beforeUpdate`/`afterUpdate`), so a
+  Flare version would be init/mount-only.
+- **Kit ≥ 2.31 native tracing.** SvelteKit now emits its own spans (`sveltekit.load`,
+  `sveltekit.resolve`, …) and Sentry adopts Kit's root span rather than creating its own. Worth
+  evaluating once Flare has server tracing; irrelevant to this client-only slice.
+- **SvelteKit hash-mode routing** (`config.kit.router.type: 'hash'`) is untested by this slice.

--- a/docs/superpowers/specs/2026-07-16-performance-tracing-framework-router-sveltekit-design.md
+++ b/docs/superpowers/specs/2026-07-16-performance-tracing-framework-router-sveltekit-design.md
@@ -450,11 +450,37 @@ playground work is in scope rather than optional. Mirrors the react-router specs
    a `browser_navigation` root named `/product/[id]` with `source: 'route'` and a correct `url.full`
    (this is what proves the `url` override works for Kit's pre-URL-commit emission).
 3. **A hash-only change produces no navigation root.**
-4. **Regression**: the existing svelte error-scenario specs still pass with tracing enabled.
+4. **An effect created at client init observes the non-null `navigating` state** — the batching gate.
+   See below; this is the only one of the four that can fail for the reason this section exists.
+5. **Regression**: the existing svelte error-scenario specs still pass with tracing enabled.
 
-If test 2 shows the fallback shape (an un-held, zero-duration root) instead of a held root spanning
-the load, effect batching is real — we learn it loudly, and the seam decision gets revisited rather
-than silently dropping spans in production.
+#### The span assertions cannot settle the batching question. A probe can.
+
+An earlier draft of this spec claimed test 2 would expose batching, on the theory that a coalesced
+navigation yields "an un-held, zero-duration root" distinguishable from "a held root spanning the
+load". **That is wrong, and the reason is worth recording so nobody re-derives it.**
+
+- **No playground route has a load function.** The whole tree is bare `+page.svelte` (`/`, `/broken`,
+  `/cart`, `/checkout`, `/confirmation`, `/product/[id]`); the only load in the playground is
+  `server-error/+page.server.ts`. So there is no load for a held root to span.
+- **Both shapes therefore emit the same span.** Branch 3→5 and branch 7 produce one root, same name,
+  same `url.full`. Both end via the same idle lifecycle, so their durations differ only by the
+  navigation's load time — which is ~0 here.
+- **`hold` is internal state.** It never reaches the wire, so no assertion can read it.
+
+Note the absence of loads is not a defect to fix: a sub-millisecond non-null window is the _hardest_
+case for batching, so it is the strongest test available. The problem is purely that spans cannot
+report the outcome. So observe the transitions directly, in the playground, never in the SDK:
+a `navProbe.svelte.ts` module with its own `$effect.root` that pushes each `navigating` transition
+onto `window.__navStates`, mirroring the SDK's effect shape (an effect root created from a
+`.svelte.ts` module invoked by `hooks.client.ts`). Test 4 clicks through to a product and asserts
+`__navStates` contains `to:/product/p01` and settles back to `null`.
+
+The probe's effect is not the SDK's effect, so this is evidence rather than proof — but it is the
+only direct read available on the assumption the whole seam choice rests on, and it beats a green
+suite that proves nothing. If the `to:` entry is absent, effect batching is real: branch 7 is
+load-bearing rather than dead code, the span assertions stay green while doing so, and the seam
+decision (`$app/state` vs `$app/stores`) must be revisited rather than silently shipping.
 
 ## Playground
 
@@ -492,14 +518,21 @@ tracesSampleRate: 1, // redundant (Flare.ts:58 already defaults to 1) but explic
 so a manual `npm run playgrounds:svelte` run still exercises the tracer (spans just fail to send,
 exactly as the error reports already do).
 
-2. `playgrounds/svelte/src/hooks.client.ts` — call `traceSvelteKitRouter()`:
+2. `playgrounds/svelte/src/lib/navProbe.svelte.ts` (new) — the batching probe described in the E2E
+   section. An `$effect.root` over `navigating` that pushes each observed transition onto
+   `window.__navStates`. The `.svelte.ts` extension is required for runes, and it must be its own
+   module: `hooks.client.ts` is plain `.ts` and Svelte will not compile runes there.
+
+3. `playgrounds/svelte/src/hooks.client.ts` — call `traceSvelteKitRouter()` and the probe:
 
 ```ts
 import { initFlareClient } from '$lib/flare.client';
+import { startNavProbe } from '$lib/navProbe.svelte';
 import { handleErrorWithFlare, traceSvelteKitRouter } from '@flareapp/sveltekit/client';
 
 initFlareClient();
 traceSvelteKitRouter();
+startNavProbe();
 
 export const handleError = handleErrorWithFlare();
 ```
@@ -507,9 +540,9 @@ export const handleError = handleErrorWithFlare();
 Ordering here is conventional, not required — there is no call-time gate, so an earlier call would
 still work. Keep it after `initFlareClient()` for readability.
 
-3. **Decide whether to expose `globalThis.__flare`.** `playgrounds/react-router/src/flare.ts` ends
+4. **Decide whether to expose `globalThis.__flare`.** `playgrounds/react-router/src/flare.ts` ends
    with `(globalThis as { __flare?: typeof flare }).__flare = flare;` so the suite can drive the
-   tracer directly. The four e2e tests below do not need it; add it only if one turns out to.
+   tracer directly. The e2e tests above do not need it; add it only if one turns out to.
 
 The existing `/product/[id]` route already provides the parameterized case; no new routes are needed.
 

--- a/docs/superpowers/specs/2026-07-16-performance-tracing-framework-router-sveltekit-design.md
+++ b/docs/superpowers/specs/2026-07-16-performance-tracing-framework-router-sveltekit-design.md
@@ -47,7 +47,10 @@ spec diverges from Sentry, the divergence is called out and justified — see
    vue `app.use(plugin, { router })` shape has no analog; a call at client init is the idiomatic
    SvelteKit equivalent, and it sits alongside the existing `trackRouteContext()` rather than changing
    what that already-published API does.
-5. **Deliverables:** implementation + unit tests + playground wiring and e2e. **No README section**
+5. **No call-time `enableTracing` gate.** The call is order-independent with respect to
+   `flare.configure()`, matching `traceReactRouter` ("Safe to call before or after tracing is enabled;
+   no-ops when off"). Rationale in "Why no enableTracing gate" below.
+6. **Deliverables:** implementation + unit tests + playground wiring and e2e. **No README section**
    (explicitly not selected). Limitations are documented in terse JSDoc on the export instead.
 
 ## Seam selection (decided; recorded because the reasoning is load-bearing)
@@ -78,8 +81,11 @@ Three candidate seams were evaluated against SvelteKit 2.67 source.
 
 ### The batching risk, and why it is contained
 
-`$app/state`'s `navigating` is a getter over `_navigating.current`, a `$state.raw` value
-(`client/state.svelte.js`). Reading it requires an `$effect`, and Svelte flushes effects on a
+`$app/state`'s `navigating` is a façade of flattened getters (`from`, `to`, `type`, `willUnload`,
+`delta`, `complete`) defined in `runtime/app/state/client.js:36-54`, each reading `_navigating.current`
+— a `$state.raw(null)` field on a class instance in `runtime/client/state.svelte.js:44-46`. Note the
+façade deliberately exposes **no** `current`: `client.js:59-62` defines a `current` property that
+throws in DEV. Reading any of the getters requires an `$effect`, and Svelte flushes effects on a
 microtask. Kit sets `navigating` non-null at client.js:1735 and null at client.js:2023, with
 `await load_route(intent)` in between — so microtask FIFO ordering means the effect will observe the
 non-null state in practice. But that is a guarantee resting on ordering between two libraries'
@@ -90,6 +96,30 @@ would still have changed while `inFlight` is false. That is exactly the "loader-
 `packages/react/src/react-router.ts:115-122` already handles — open the root un-held and name it
 immediately. Worst case therefore degrades from _a silently dropped span_ to _an instant,
 correctly-named navigation root_.
+
+## Why no `enableTracing` gate (decided; diverges from `flareVue`)
+
+`flareVue` gates `traceVueRouter` on `flare.config?.enableTracing` at call time (`fdac544`). That gate
+does not transfer here, and copying it would be a net loss.
+
+- **Vue's rationale is host mutation.** `fdac544`'s stated reason is that `traceVueRouter` "attaches
+  no-op guards to the host's router". Vue's integration reaches into an object the app owns and
+  installs `beforeEach` / `afterEach` guards on it. SvelteKit has no router object to hand us and
+  nothing to attach to: `traceSvelteKitRouter` owns its own `$effect.root` and touches nothing of the
+  host's. There is no host-mutation cost to avoid, only one dead effect root and one dead nav source.
+- **`traceReactRouter` is the closer analog and deliberately has no gate.** Its JSDoc reads "Safe to
+  call before or after tracing is enabled; no-ops when off." This slice ports its branch logic; it
+  should port its contract too.
+- **The gate's failure mode is silent, and SvelteKit is the worst place for it.** `hooks.client.ts` is
+  module scope, so import-evaluation order decides everything, and this package already does
+  order-sensitive work at module scope (`src/client/handleError.ts:5` calls `trackRouteContext()` as
+  an import side effect). Under a call-time gate, calling `traceSvelteKitRouter()` one line before
+  `flare.configure()` yields no spans, forever, with no error and no warning. Trading a silent
+  permanent misconfiguration for the avoidance of one no-op effect is the wrong way round.
+
+The seam already no-ops when tracing is off, so an ungated call is inert rather than harmful. The
+`enableTracing` check therefore moves **inside** the effect body (branch 0 below), which additionally
+means an app that enables tracing after client init still gets named roots.
 
 ## SvelteKit lifecycle facts (verified against `@sveltejs/kit@2.67.0` source)
 
@@ -149,11 +179,12 @@ export function traceSvelteKitRouter(): () => void;
 
 Guards, in order:
 
-1. **Tracing gate.** `if (!flare.config?.enableTracing) return () => {};` — matches the `flareVue`
-   gate added in `fdac544`, so passing tracing-off attaches no dead effect and no dead nav source.
-2. **Idempotence.** A module-level `tracing` flag, mirroring `trackRouteContext`'s `tracking` flag.
+1. **Idempotence.** A module-level `tracing` flag, mirroring `trackRouteContext`'s `tracking` flag.
    A second call returns a no-op cleanup.
-3. **Browser only.** No-op when `typeof window === 'undefined'` (SSR import safety).
+2. **Browser only.** No-op when `typeof window === 'undefined'` (SSR import safety).
+
+There is deliberately **no call-time `enableTracing` gate** — see "Why no `enableTracing` gate" above.
+The check lives in branch 0 instead.
 
 Internal state:
 
@@ -165,9 +196,12 @@ let inFlight = false;
 ```
 
 `lastKey` is mutable and must be re-stamped on every commit the state machine accounts for (branches
-5, 6 and 7 below). Anchoring on a frozen `initialKey` instead would make branch 7 fire on every
-effect re-run after the first navigation, fabricating a spurious navigation root each time `page.data`
-changed. This mirrors `lastLocationKey` in `react-router.ts`.
+5 and 7 below; branch 6 only fires when the key already matches, so it has nothing to stamp).
+Anchoring on a frozen `initialKey` instead would make branch 7 fire on every effect re-run after the
+first navigation, fabricating a spurious navigation root each time Kit reassigned `page.url`. This
+mirrors `lastLocationKey` in `react-router.ts` — note that file stamps in three places (init,
+`namePageload`, and both settle paths), because its pageload phase can also move the committed
+location via an initial-load redirect.
 
 Route naming:
 
@@ -176,33 +210,77 @@ const routeNameFor = (routeId: string | null | undefined, url: URL): RouteName =
     routeId ? { name: routeId, source: 'route' } : { name: url.pathname, source: 'url' };
 ```
 
-The effect body is wrapped in `insulate`. **All four reactive reads — `navigating.to`,
-`navigating.willUnload`, `page.route?.id`, `page.url` — must happen unconditionally at the top of the
-effect, before any branching.** Svelte tracks dependencies as they are read, so an early `return`
-placed before the `navigating.to` read would silently stop the effect from ever re-running on
-navigation. This is the single easiest way to get this file wrong.
+### Reads and branching are separate functions
 
-| #   | Condition                                              | Action                                                                                                                                                                                                                                                                                      |
-| --- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| 1   | `page.url.origin !== location.origin`                  | `return` — Kit's pre-hydration `a:` placeholder                                                                                                                                                                                                                                             |
-| 2   | `to` set, and (`willUnload` or `to.route?.id == null`) | `return` — document will unload; the next document's pageload covers it                                                                                                                                                                                                                     |
-| 3   | `to` set, `!inFlight`                                  | `inFlight = true`; `nav.startNavigation({ path: to.url.pathname, url: to.url.href, hold: true })`; then `nav.setActiveRouteName(routeNameFor(to.route.id, to.url))`                                                                                                                         |
-| 4   | `to` set, `inFlight`                                   | `nav.setActiveRouteName(routeNameFor(to.route.id, to.url))` only — redirect hop, keep the single held root                                                                                                                                                                                  |
-| 5   | `to` null, `inFlight`                                  | `inFlight = false`; `lastKey = keyOf(page.url)`; `nav.settleNavigation(routeNameFor(page.route?.id, page.url))`                                                                                                                                                                             |
-| 6   | `to` null, `!inFlight`, `keyOf(page.url) === lastKey`  | `nav.setActiveRouteName(routeNameFor(page.route?.id, page.url))` — pageload naming; also re-runs harmlessly when `route.id` resolves late, or when `page.data` changes after a settle (the root is either still open and gets the same name, or already closed and `applyRouteName` no-ops) |
-| 7   | `to` null, `!inFlight`, `keyOf(page.url) !== lastKey`  | **coalescing fallback**: `lastKey = keyOf(page.url)`; `nav.startNavigation({ path, url: page.url.href })` un-held, then `nav.settleNavigation(...)` immediately                                                                                                                             |
+**All four reactive reads — `navigating.to`, `navigating.willUnload`, `page.route?.id`, `page.url` —
+must happen unconditionally, before any branching.** Svelte tracks dependencies as they are read, so
+an early `return` placed before the `navigating.to` read would silently stop the effect from ever
+re-running on navigation. This is the single easiest way to get this file wrong.
+
+Rather than leave that as a comment someone must remember, the structure enforces it: the `$effect`
+does nothing but take a snapshot, and a **pure, exported** function does all the branching.
+
+```ts
+export type NavSnapshot = {
+    to: { url: URL; route?: { id: string | null } } | null;
+    willUnload: boolean;
+    routeId: string | null | undefined;
+    url: URL;
+};
+
+/** Advance the state machine for one observed snapshot. Exported for unit tests; not public API. */
+export function syncNavigation(snapshot: NavSnapshot): void;
+```
+
+The effect reads every field into the snapshot object literal, so the reads are structurally
+unconditional — there is no control flow in the effect to short-circuit them. `syncNavigation` takes
+plain data and never touches `$app/state`, so unit tests drive it directly with no Svelte scheduler,
+no `flushSync`, and no fake runes. This is what makes the sixteen cases below cheap to write.
+
+`syncNavigation` is exported from the module but **not** re-exported from `client/index.ts`, so it is
+not public API.
+
+The branch table below names the reads at their source (`page.url`, `page.route?.id`, `to`,
+`willUnload`) because that is where the behaviour is easiest to reason about. In the implementation
+these are the snapshot fields: `page.url` → `snapshot.url`, `page.route?.id` → `snapshot.routeId`.
+
+| #   | Condition                                              | Action                                                                                                                                                                                                                                                                                                                  |
+| --- | ------------------------------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 0   | `!flare.config?.enableTracing`                         | `return` — tracing off; re-checked every run, so enabling tracing after client init still works                                                                                                                                                                                                                         |
+| 1   | `page.url.origin !== location.origin`                  | `return` — Kit's pre-hydration `a:` placeholder                                                                                                                                                                                                                                                                         |
+| 2   | `to` set, and (`willUnload` or `to.route?.id == null`) | `return` — document will unload; the next document's pageload covers it                                                                                                                                                                                                                                                 |
+| 3   | `to` set, `!inFlight`                                  | `inFlight = true`; `nav.startNavigation({ path: to.url.pathname, url: to.url.href, hold: true })`; then `nav.setActiveRouteName(routeNameFor(to.route.id, to.url))`                                                                                                                                                     |
+| 4   | `to` set, `inFlight`                                   | `nav.setActiveRouteName(routeNameFor(to.route.id, to.url))` only — redirect hop, keep the single held root                                                                                                                                                                                                              |
+| 5   | `to` null, `inFlight`                                  | `inFlight = false`; `lastKey = keyOf(page.url)`; `nav.settleNavigation(routeNameFor(page.route?.id, page.url))`                                                                                                                                                                                                         |
+| 6   | `to` null, `!inFlight`, `keyOf(page.url) === lastKey`  | `nav.setActiveRouteName(routeNameFor(page.route?.id, page.url))` — pageload naming; also re-runs harmlessly when `route.id` resolves late, or when Kit reassigns `page.url` / `page.route` to an equivalent value (the root is either still open and gets the same name, or already closed and `applyRouteName` no-ops) |
+| 7   | `to` null, `!inFlight`, `keyOf(page.url) !== lastKey`  | **coalescing fallback**: `lastKey = keyOf(page.url)`; `nav.startNavigation({ path, url: page.url.href })` un-held, then `nav.settleNavigation(...)` immediately                                                                                                                                                         |
 
 Branch 7 is the containment described above. It is expected to be dead code in practice; the e2e
 suite is what proves that (see Testing).
+
+**Branch 2's two conditions are one condition, not two.** `create_navigation` sets
+`willUnload: !intent` (client.js:3334) and `to.route.id = intent?.route?.id ?? null` (:3329), so
+`willUnload` is true exactly when `to.route.id` is null. The disjunction is belt-and-braces against
+Kit's internals shifting, not two distinct cases; do not read it as covering `type: 'leave'`. Leave
+navigations never reach the branch at all: the `'leave'` navigation object is built locally in the
+`beforeunload` handler (:2641) and passed only to `before_navigate_callbacks` — it is never assigned
+to `navigating.current`. The branch **is** reachable, via a `'link'` navigation to a route Kit does
+not own, which does reach :1735 with `willUnload` true before Kit falls back to a native navigation.
 
 Structure:
 
 ```ts
 const dispose = $effect.root(() => {
     $effect(
-        insulate(() => {
-            /* branches 1-7 */
-        }),
+        insulate(() =>
+            // The reads are the whole effect body. No control flow here — see above.
+            syncNavigation({
+                to: navigating.to,
+                willUnload: navigating.willUnload,
+                routeId: page.route?.id,
+                url: page.url,
+            }),
+        ),
     );
 });
 
@@ -216,7 +294,39 @@ return () => {
 `nav.unregister()` releases any outstanding hold (per the seam's contract from PR #72), so a cleanup
 mid-navigation cannot strand a held root until `finalTimeout`.
 
-### 2. `packages/sveltekit/src/client/index.ts` (edit)
+### 2. `packages/sveltekit/src/client/app-state.d.ts` (edit) — REQUIRED, not optional
+
+This package builds standalone (`svelte-package -i src -o dist`, `tsc --noEmit`) with no SvelteKit app
+around it, so there is no generated `.svelte-kit/ambient.d.ts`. This hand-written shim is the **only**
+type source for `$app/state`, and it currently declares `page` alone:
+
+```ts
+declare module '$app/state' {
+    const page: { url: URL; params: Record<string, string>; route: { id: string | null } };
+}
+```
+
+`import { navigating } from '$app/state'` does not typecheck until `navigating` is added. Extend it to
+match the real façade (`runtime/app/state/client.js:36-54`) — flattened getters, and **no `current`**:
+
+```ts
+declare module '$app/state' {
+    const page: { url: URL; params: Record<string, string>; route: { id: string | null } };
+    const navigating: {
+        from: { url: URL; route: { id: string | null } } | null;
+        to: { url: URL; route: { id: string | null } } | null;
+        type: 'form' | 'leave' | 'link' | 'goto' | 'popstate' | null;
+        willUnload: boolean;
+        delta: number | null;
+        complete: Promise<void> | null;
+    };
+}
+```
+
+Declare only what Kit really exposes. Adding a `current` field here would type-sanction a read that
+throws at runtime in DEV.
+
+### 3. `packages/sveltekit/src/client/index.ts` (edit)
 
 Add one line:
 
@@ -224,10 +334,11 @@ Add one line:
 export { traceSvelteKitRouter } from './traceSvelteKitRouter.svelte.js';
 ```
 
-No change to `packages/sveltekit/src/index.ts` — this is client-only, matching how
-`trackRouteContext` is exposed only from `/client`.
+`syncNavigation` is **not** exported here — it is a test seam, not public API. No change to
+`packages/sveltekit/src/index.ts` either; this is client-only, matching how `trackRouteContext` is
+exposed only from `/client`.
 
-### 3. `packages/sveltekit/package.json` (edit, pre-publish)
+### 4. `packages/sveltekit/package.json` (edit, pre-publish)
 
 Raise the `@flareapp/js` peer floor from `^2.6.0` to the version shipping `insulate` / `safeInvoke` /
 the nav seam. See "Pre-publish carry-forward".
@@ -268,29 +379,41 @@ navigation.
 
 Identical to the vue and react slices — instrumentation must never throw into the host app:
 
-- The effect body is wrapped in `insulate` (from `@flareapp/js/browser`).
+- The effect body is wrapped in `insulate` (from `@flareapp/js/browser`), so a throw from
+  `syncNavigation` can never escape into Kit's effect scheduler.
 - Cleanup uses `safeInvoke` for both the effect-root dispose and `nav.unregister()`.
 - `routeNameFor` reads are defensive (`page.route?.id`, `to.route?.id`); no assumption that Kit's
   state is well-formed.
-- The `enableTracing` gate means an app with tracing off attaches nothing at all.
+- With tracing off, branch 0 returns before any seam call, so the attached effect is inert.
 
 ## Testing
 
 ### Unit — `packages/sveltekit/tests/client/traceSvelteKitRouter.test.ts` (new)
 
-The existing `packages/sveltekit/tests/__mocks__/app-state.ts` mock exports a static `page` object.
-It must be extended to export a drivable `navigating` and to let tests mutate `page` — and, because
-the mock is aliased for the whole package (`vitest.config.mts` maps `$app/state` to it), the change
-must stay backward-compatible with `getRouteContext.test.ts`, which already depends on it.
+The split above is what makes this suite tractable: **cases 3-14 call `syncNavigation(snapshot)`
+directly** with a plain object. No Svelte scheduler, no `flushSync`, no `$effect` in the test, and no
+need to simulate rune reactivity. Only cases 1, 2 and 15 exercise `traceSvelteKitRouter()` itself
+(registration, idempotence, cleanup).
 
-Because the production code uses `$effect`, tests drive the state machine directly rather than
-through Svelte's scheduler; `@flareapp/js/browser` is mocked to capture seam calls (the pattern the
-five react test mocks already use — note they had to add `insulate`/`safeInvoke` to their mock
-factory, per the PR #74 carry-forward).
+`@flareapp/js/browser` is mocked to capture seam calls (the pattern the five react test mocks already
+use — note they had to add `insulate`/`safeInvoke` to their mock factory, per the PR #74
+carry-forward). `flare.config.enableTracing` is mocked true for cases 2-14.
+
+The `tests/__mocks__/app-state.ts` alias mock needs `navigating` added for the cases that mount the
+effect. Shape it as the real flattened façade (`to`, `willUnload`, …), **not** `{ current }`.
+Backward compatibility with `getRouteContext.test.ts` is a non-issue: that file supplies its own
+`vi.mock('$app/state', () => ({ page: mockPage }))` factory exporting only `page`, so it overrides the
+alias entirely and cannot see a new export.
+
+Because `syncNavigation` holds module-level state (`inFlight`, `lastKey`, `tracing`), each test needs
+a fresh module — `vi.resetModules()` plus a dynamic import in `beforeEach`, or an exported reset.
+Pick one and be consistent; a leaked `inFlight` between cases makes 3/4/5 pass or fail in file order.
 
 Cases:
 
-1. `enableTracing` falsy → no `registerNavigationSource` call, cleanup is a no-op.
+1. Tracing off at call time then enabled later → `registerNavigationSource` **is** called at call
+   time, and a snapshot delivered after `enableTracing` flips true still names the root. This pins
+   the order-independence decision; it is the inverse of the vue gate's test.
 2. Second call is idempotent (no second nav source).
 3. Pre-hydration placeholder `page.url` (`a:` origin) → no seam calls (branch 1).
 4. Pageload naming from `page.route.id` → `setActiveRouteName({ name: '/product/[id]', source: 'route' })`.
@@ -305,10 +428,15 @@ Cases:
 12. Hash-only `page.url` change while idle → no `startNavigation` (key excludes hash).
 13. Coalescing fallback (branch 7): key changes while idle and not in flight → `startNavigation`
     **without** `hold`, followed immediately by `settleNavigation`.
-14. **`lastKey` re-stamp regression**: after a navigation settles, a further effect run at the same
-    committed key (e.g. `page.data` changed via `invalidate()`) must **not** call `startNavigation`
-    again. This pins the bug that a frozen `initialKey` would have introduced.
+14. **`lastKey` re-stamp regression**: after a navigation settles, a further snapshot at the same
+    committed key must **not** call `startNavigation` again. This pins the bug that a frozen
+    `initialKey` would have introduced. (In production this re-run arises from Kit reassigning
+    `page.url` / `page.route` as fresh object references into `$state.raw`, not from `page.data`
+    changing — the effect never reads `page.data`, so a data-only change cannot retrigger it.)
 15. Cleanup → disposes the effect root and calls `nav.unregister()`.
+16. **Branch 0 does not consume the transition**: with tracing off, a `to`-set snapshot followed by a
+    `to`-null snapshot must leave `inFlight` false, so the next real navigation still opens a root.
+    Guards against branch 0 returning after `inFlight` was already mutated.
 
 ### E2E — `e2e/specs/svelte.spec.ts` (edit)
 
@@ -331,11 +459,40 @@ than silently dropping spans in production.
 ## Playground
 
 `playgrounds/svelte` currently does **not** enable tracing (`src/lib/flare.client.ts` sets
-`enableLogs` but no `enableTracing`). Two edits:
+`enableLogs` but no `enableTracing`). Enabling it is **not** a one-line change: mirror
+`playgrounds/react-router/src/flare.ts` in full, or the e2e suite cannot pass regardless of whether
+the integration works.
 
-1. `playgrounds/svelte/src/lib/flare.client.ts` — add `enableTracing: true`, matching
-   `playgrounds/react-router/src/flare.ts:26`.
-2. `playgrounds/svelte/src/hooks.client.ts` — call `traceSvelteKitRouter()` after `initFlareClient()`:
+1. `playgrounds/svelte/src/lib/flare.client.ts` — inside the existing `if (url)` block (the
+   fake-server override, e2e only), add the traces ingest and the e2e timing overrides:
+
+```ts
+flare.configure({
+    ingestUrl: url,
+    logsIngestUrl: url.replace('/v1/errors', '/v1/logs'),
+    tracesIngestUrl: url.replace('/v1/errors', '/v1/traces'), // without this, spans go to the
+    // production ingest and the fake server never sees them: every tracing assertion times out.
+    // e2e-only timing: keep the root active long enough for a prompt Playwright click to nest under
+    // it, then flush an ended root fast so arrival assertions don't wait out the 5s default.
+    idleTimeout: 2000,
+    spanFlushIntervalMs: 500,
+});
+```
+
+and in the unconditional `flare.configure({ ... })` block, alongside `enableLogs: true`:
+
+```ts
+enableTracing: true,
+tracesSampleRate: 1, // redundant (Flare.ts:58 already defaults to 1) but explicit, matching
+// react-router: it pins full sampling against a future default change rather than leaving the
+// suite's determinism resting on one.
+```
+
+`enableTracing` and `tracesSampleRate` go in the **unconditional** block, not the `if (url)` one,
+so a manual `npm run playgrounds:svelte` run still exercises the tracer (spans just fail to send,
+exactly as the error reports already do).
+
+2. `playgrounds/svelte/src/hooks.client.ts` — call `traceSvelteKitRouter()`:
 
 ```ts
 import { initFlareClient } from '$lib/flare.client';
@@ -347,11 +504,19 @@ traceSvelteKitRouter();
 export const handleError = handleErrorWithFlare();
 ```
 
+Ordering here is conventional, not required — there is no call-time gate, so an earlier call would
+still work. Keep it after `initFlareClient()` for readability.
+
+3. **Decide whether to expose `globalThis.__flare`.** `playgrounds/react-router/src/flare.ts` ends
+   with `(globalThis as { __flare?: typeof flare }).__flare = flare;` so the suite can drive the
+   tracer directly. The four e2e tests below do not need it; add it only if one turns out to.
+
 The existing `/product/[id]` route already provides the parameterized case; no new routes are needed.
-Note that `traceSvelteKitRouter()` must be called after `initFlareClient()`, since the
-`enableTracing` gate is read at call time — this ordering constraint belongs in the export's JSDoc.
 
 ## Documented limitations (JSDoc on the export, not README)
+
+Lead with the contract, mirroring `traceReactRouter`'s: safe to call before or after tracing is
+enabled, no-ops when off, returns a cleanup. Then the limitations:
 
 - Shallow routing (`pushState` / `replaceState` from `$app/navigation`) produces no navigation root.
 - Hash-only navigation produces no navigation root.
@@ -363,7 +528,10 @@ Note that `traceSvelteKitRouter()` must be called after `initFlareClient()`, sin
 
 1. **Does `$app/state`'s `navigating` actually reach a `$effect` created in `hooks.client.ts`?** The
    effect root is created outside any component. Confirm it flushes and observes both transitions —
-   this is the core assumption, and the e2e navigation test is the proof.
+   this is the core assumption, and the e2e navigation test is the proof. Encouraging precedent:
+   `src/client/handleError.ts:5` already calls `trackRouteContext()` at module scope on import, so an
+   effect root created from `hooks.client.ts` is a shape this package already ships. That proves the
+   root runs; it does not prove `navigating`'s two transitions both survive batching.
 2. **Is `page.url.origin !== location.origin` a sound placeholder guard?** `new URL('a:').origin` is
    the string `'null'`, so the guard should hold. Confirm against a real hydration, and confirm it
    does not misfire for hash-mode routing.
@@ -375,10 +543,17 @@ Note that `traceSvelteKitRouter()` must be called after `initFlareClient()`, sin
    `route.id` via `untrack()` specifically to avoid triggering a proxy that invalidates server `load`
    data on every navigation. Verify that reading `page.route.id` inside a client `$effect` has no such
    side effect — the existing `trackRouteContext` already does it, which is reassuring but is not proof.
-5. **Extending the shared `$app/state` mock must not break `getRouteContext.test.ts`.**
+5. **Is `page.url` fully committed by the time `navigating` goes null?** Branch 5 reads `page.route.id`
+   and `page.url` on the `to`-null run and settles with them, so it depends on Kit having committed
+   both before :2023. The ordering strongly suggests yes (the URL commits at :1855-1856 and the render
+   completes well before :2023), but there is a known skew window earlier in the cycle: the browser
+   URL commits at :1856 while `page.url` updates later via `root.$set`, which is why `onNavigate`
+   at :1884 observes stale `page.url`. Confirm the skew is closed by :2023. If it is not, branch 5
+   must name from `to` rather than `page`.
 6. **`svelte-package` output**: confirm the new `.svelte.ts` module is emitted and typed correctly, and
    that `scripts/verify-exports.mjs` still passes. See `.claude/docs/svelte-packaging` for the known
-   ESM-extension and version-generation quirks.
+   ESM-extension and version-generation quirks. Also confirm the extended `app-state.d.ts` shim does
+   not leak into `dist` in a way that conflicts with a consuming app's real `$app/state` types.
 
 ## Pre-publish carry-forward
 

--- a/e2e/specs/js.spec.ts
+++ b/e2e/specs/js.spec.ts
@@ -1,25 +1,8 @@
 import { testIds } from '../../playgrounds/shared/src';
 import { expect, test } from '../fixtures/fake-flare';
 import { logScenariosFor, runLogScenario } from './logShared';
+import { attr, hasSpanType, spansOf } from './otlp';
 import { runScenario, scenariosFor } from './shared';
-
-type OtlpSpan = {
-    name: string;
-    spanId: string;
-    parentSpanId: string | null;
-    traceId: string;
-    attributes: Array<{ key: string; value: Record<string, unknown> }>;
-};
-
-const spansOf = (bodyJson: unknown): OtlpSpan[] =>
-    ((bodyJson as { resourceSpans?: Array<{ scopeSpans?: Array<{ spans?: OtlpSpan[] }> }> }).resourceSpans ?? [])
-        .flatMap((r) => r.scopeSpans ?? [])
-        .flatMap((s) => s.spans ?? []);
-
-const attr = (span: OtlpSpan, key: string): unknown => span.attributes.find((a) => a.key === key)?.value;
-
-const hasSpanType = (span: OtlpSpan, type: string): boolean =>
-    JSON.stringify(attr(span, 'flare.span_type') ?? '').includes(type);
 
 test.describe('js playground', () => {
     test('renders product grid', async ({ page }) => {

--- a/e2e/specs/otlp.ts
+++ b/e2e/specs/otlp.ts
@@ -26,8 +26,8 @@ export const urlOf = (span: OtlpSpan): string => JSON.stringify(attr(span, 'url.
 
 /**
  * Wait for the envelope carrying a child's parent root. A root holds open for its idle window while
- * request spans flush eagerly, so the parent routinely arrives in a LATER envelope than the child:
- * poll across every captured trace rather than searching the one the child was found in.
+ * request spans flush eagerly, so the parent usually arrives in a later envelope than the child.
+ * Poll across every captured trace rather than searching the one the child was found in.
  */
 export const waitForParentEnvelope = (fakeFlare: FakeFlare, child: OtlpSpan) =>
     fakeFlare.waitForTrace({

--- a/e2e/specs/otlp.ts
+++ b/e2e/specs/otlp.ts
@@ -1,4 +1,4 @@
-// Shared OTLP trace-span parsing helpers for the tracing e2e specs (react, react-router).
+// Shared OTLP trace-span parsing helpers for the tracing e2e specs (react, react-router, svelte).
 
 export type OtlpSpan = {
     name: string;

--- a/e2e/specs/otlp.ts
+++ b/e2e/specs/otlp.ts
@@ -5,6 +5,7 @@ export type OtlpSpan = {
     spanId: string;
     parentSpanId: string | null;
     traceId: string;
+    status?: { code: number; message?: string };
     attributes: Array<{ key: string; value: Record<string, unknown> }>;
 };
 

--- a/e2e/specs/otlp.ts
+++ b/e2e/specs/otlp.ts
@@ -1,4 +1,6 @@
-// Shared OTLP trace-span parsing helpers for the tracing e2e specs (react, react-router, svelte).
+// Shared OTLP trace-span parsing helpers for the tracing e2e specs (js, react, react-router, svelte).
+
+import type { FakeFlare } from '../fixtures/fake-flare';
 
 export type OtlpSpan = {
     name: string;
@@ -18,3 +20,21 @@ export const attr = (span: OtlpSpan, key: string): unknown => span.attributes.fi
 
 export const hasSpanType = (span: OtlpSpan, type: string): boolean =>
     JSON.stringify(attr(span, 'flare.span_type') ?? '').includes(type);
+
+/** A span's `url.full`, JSON-stringified so a missing attribute matches nothing instead of throwing. */
+export const urlOf = (span: OtlpSpan): string => JSON.stringify(attr(span, 'url.full') ?? '');
+
+/**
+ * Wait for the envelope carrying a child's parent root. A root holds open for its idle window while
+ * request spans flush eagerly, so the parent routinely arrives in a LATER envelope than the child:
+ * poll across every captured trace rather than searching the one the child was found in.
+ */
+export const waitForParentEnvelope = (fakeFlare: FakeFlare, child: OtlpSpan) =>
+    fakeFlare.waitForTrace({
+        timeout: 9000,
+        predicate: (r) => spansOf(r.bodyJson).some((s) => s.spanId === child.parentSpanId),
+    });
+
+/** The root a child nests under, or undefined if that envelope has not arrived yet. */
+export const parentOf = async (fakeFlare: FakeFlare, child: OtlpSpan): Promise<OtlpSpan | undefined> =>
+    spansOf((await waitForParentEnvelope(fakeFlare, child)).bodyJson).find((s) => s.spanId === child.parentSpanId);

--- a/e2e/specs/svelte.spec.ts
+++ b/e2e/specs/svelte.spec.ts
@@ -83,8 +83,8 @@ test.describe('svelte tracing', () => {
             stringValue: '/product/[id]',
         });
         expect(nav && attr(nav, 'flare.route.source')).toEqual({ stringValue: 'route' });
-        // The nav root's url.full must be the DESTINATION even though Kit emits `navigating`
-        // before the URL commits. This is what proves the seam's url override is wired.
+        // The nav root's url.full has to be where the navigation went, even though Kit tells us
+        // before the URL changes. This is what proves the url override is wired up.
         expect(JSON.stringify((nav && attr(nav, 'url.full')) ?? '')).toContain('/product/p01');
 
         // registerNavigationSource suppresses the History-based root, so one click => one root.
@@ -94,10 +94,10 @@ test.describe('svelte tracing', () => {
         expect(navSpans).toHaveLength(1);
     });
 
-    // THE BATCHING GATE. The span assertions above cannot distinguish a correctly held root from a
-    // coalesced branch-7 fallback: with no load function on any playground route, both are near-zero
-    // and identically named, and `hold` never reaches the wire. So assert on what the effect actually
-    // observed. A missing 'to:' entry means Svelte batched the non-null state away.
+    // The span assertions above cannot tell a correctly held root apart from the fallback that runs
+    // when no navigation was seen: with no load function on any playground route both are near-zero
+    // and named the same, and `hold` never reaches the wire. So assert on what the effect actually
+    // saw instead. A missing 'to:' entry means Svelte ran the two updates together.
     test('an effect created at client init observes the non-null navigating state', async ({ page }) => {
         // `window.__navStates` is declared by the playground, not by the e2e tsconfig, so read it
         // through a cast rather than adding a global declaration to the suite.
@@ -113,8 +113,8 @@ test.describe('svelte tracing', () => {
         await page.locator('a[href="/product/p01"]').first().click();
         await expect(page).toHaveURL(/\/product\/p01$/);
 
-        // `navigating` returns to null a tick AFTER the URL commits (client.js:1856 then :2023), so
-        // poll rather than reading once.
+        // Kit clears `navigating` a tick after the URL changes, not at the same time, so poll for
+        // it rather than reading once.
         await expect.poll(async () => (await readStates()).at(-1)).toBe('null');
 
         expect(await readStates()).toContain('to:/product/p01'); // survived batching
@@ -209,8 +209,8 @@ test.describe('svelte http tracing', () => {
             (s) => hasSpanType(s, 'browser_fetch') && urlOf(s).includes('fetch-500'),
         );
         expect(span).toBeTruthy();
-        // The 404 test above pins the non-error side; this pins the other half of endHttpRequestSpan's
-        // branch: status >= 500 both records the status AND marks the span an OTel error (code 2).
+        // The 404 test above covers the non-error side. This covers the other half: a status of 500
+        // or more records the status and also marks the span an OTel error (code 2).
         expect(attr(span!, 'http.response.status_code')).toEqual({ intValue: 500 });
         expect(span!.status?.code ?? 0).toBe(2);
     });
@@ -258,13 +258,12 @@ test.describe('svelte http tracing', () => {
         expect(span!.status?.code ?? 0).toBe(0);
     });
 
-    // REGRESSION TEST FOR THE TRACEPARENT INIT REBUILD. Kit's dev_fetch brands the init it hands a
-    // `load` fetch with a NON-ENUMERABLE `__sveltekit_fetch__`, and its dev-mode window.fetch wrapper
-    // warns when the brand is missing. Flare patches window.fetch after Kit's, so rebuilding the init
-    // to inject traceparent used to spread the brand away and make Kit scold the developer for using
-    // `window.fetch` in a load function while they were already using the right one. Unit tests pin
-    // mergeTraceparentHeader in isolation; only this catches the symptom as reported. Needs dev mode
-    // (Kit gates the wrapper on DEV && BROWSER), which is what the default e2e webServer runs.
+    // Kit marks the init it gives a load fetch with a hidden `__sveltekit_fetch__` flag, and its
+    // dev-mode wrapper warns when the flag is missing. We patch window.fetch after Kit does, so
+    // rebuilding the init to add traceparent used to drop the flag and warn the developer about
+    // using window.fetch in a load function while they were already using the right one. The unit
+    // tests cover mergeTraceparentHeader on its own; only this one catches the warning as reported.
+    // Kit only wraps fetch in dev mode, which is what the e2e webServer runs.
     test('Kit does not warn about window.fetch for a traced load fetch', async ({ page }) => {
         const warnings: string[] = [];
         page.on('console', (msg) => {
@@ -280,12 +279,12 @@ test.describe('svelte http tracing', () => {
         expect(warnings.filter((w) => /using `window.fetch`/.test(w))).toEqual([]);
     });
 
-    // PINS VERIFIED FACT 11. Kit's fetcher.js:9 captures `native_fetch = window.fetch` at module
-    // scope, which reads like it pins the unpatched original; it does not (that reference is only
-    // used inside Kit's own wrapper). subsequent_fetch reads window.fetch at CALL time, so Flare's
-    // patch sees a load fetch. If this test fails, the fact is wrong and the JSDoc needs the
-    // limitation after all. Deep-linking would run the load on the SERVER (no patch, no span), so
-    // this MUST be a client navigation.
+    // Kit grabs a reference to window.fetch when its module loads, which looks like it would pin the
+    // unpatched original. It does not: that reference is only used inside Kit's own wrapper, and the
+    // fetch it hands a load function reads window.fetch when it is called, so our patch sees it. If
+    // this test fails, that is no longer true and the JSDoc needs to say so. Deep-linking would run
+    // the load on the server, where there is no patch and no span, so this has to be a client
+    // navigation.
     test("SvelteKit's load-provided fetch produces a browser_fetch span", async ({ page, fakeFlare }) => {
         await page.goto('/');
         await page.waitForLoadState('networkidle');

--- a/e2e/specs/svelte.spec.ts
+++ b/e2e/specs/svelte.spec.ts
@@ -1,6 +1,7 @@
 import { testIds } from '../../playgrounds/shared/src';
 import { expect, test } from '../fixtures/fake-flare';
 import { logScenariosFor, runLogScenario } from './logShared';
+import { attr, hasSpanType, spansOf } from './otlp';
 import { runScenario, scenariosFor } from './shared';
 
 test.describe('svelte playground', () => {
@@ -40,4 +41,96 @@ test.describe('svelte logging', () => {
             await runLogScenario(page, fakeFlare, scenario);
         });
     }
+});
+
+test.describe('svelte tracing', () => {
+    test('pageload root carries the parameterized route and route source', async ({ page, fakeFlare }) => {
+        await page.goto('/product/p01'); // deep-link the initial load
+        await page.waitForLoadState('networkidle');
+
+        const trace = await fakeFlare.waitForTrace({
+            timeout: 9000,
+            predicate: (r) => {
+                const pl = spansOf(r.bodyJson).find((s) => hasSpanType(s, 'browser_pageload'));
+                return !!pl && JSON.stringify(attr(pl, 'flare.route.source') ?? '').includes('route');
+            },
+        });
+        const pageload = spansOf(trace.bodyJson).find((s) => hasSpanType(s, 'browser_pageload'));
+        expect(pageload && attr(pageload, 'flare.entry_point.handler.identifier')).toEqual({
+            stringValue: '/product/[id]',
+        });
+        expect(pageload && attr(pageload, 'flare.route.source')).toEqual({ stringValue: 'route' });
+    });
+
+    test('navigation opens exactly one parameterized browser_navigation root', async ({ page, fakeFlare }) => {
+        await page.goto('/');
+        await page.waitForLoadState('networkidle');
+
+        await page.locator('a[href="/product/p01"]').first().click();
+
+        const trace = await fakeFlare.waitForTrace({
+            timeout: 9000,
+            predicate: (r) => {
+                const nav = spansOf(r.bodyJson).find((s) => hasSpanType(s, 'browser_navigation'));
+                return (
+                    !!nav &&
+                    JSON.stringify(attr(nav, 'flare.entry_point.handler.identifier') ?? '').includes('/product/[id]')
+                );
+            },
+        });
+        const nav = spansOf(trace.bodyJson).find((s) => hasSpanType(s, 'browser_navigation'));
+        expect(nav && attr(nav, 'flare.entry_point.handler.identifier')).toEqual({
+            stringValue: '/product/[id]',
+        });
+        expect(nav && attr(nav, 'flare.route.source')).toEqual({ stringValue: 'route' });
+        // The nav root's url.full must be the DESTINATION even though Kit emits `navigating`
+        // before the URL commits. This is what proves the seam's url override is wired.
+        expect(JSON.stringify(attr(nav!, 'url.full') ?? '')).toContain('/product/p01');
+
+        // registerNavigationSource suppresses the History-based root, so one click => one root.
+        const navSpans = (await fakeFlare.traces())
+            .flatMap((t) => spansOf(t.bodyJson))
+            .filter((s) => hasSpanType(s, 'browser_navigation'));
+        expect(navSpans).toHaveLength(1);
+    });
+
+    // THE BATCHING GATE. The span assertions above cannot distinguish a correctly held root from a
+    // coalesced branch-7 fallback: with no load function on any playground route, both are near-zero
+    // and identically named, and `hold` never reaches the wire. So assert on what the effect actually
+    // observed. A missing 'to:' entry means Svelte batched the non-null state away.
+    test('an effect created at client init observes the non-null navigating state', async ({ page }) => {
+        // `window.__navStates` is declared by the playground, not by the e2e tsconfig, so read it
+        // through a cast rather than adding a global declaration to the suite.
+        const readStates = () =>
+            page.evaluate(() => (window as unknown as { __navStates?: string[] }).__navStates ?? []);
+
+        await page.goto('/');
+        await page.waitForLoadState('networkidle');
+        await page.evaluate(() => {
+            (window as unknown as { __navStates: string[] }).__navStates = [];
+        });
+
+        await page.locator('a[href="/product/p01"]').first().click();
+        await expect(page).toHaveURL(/\/product\/p01$/);
+
+        // `navigating` returns to null a tick AFTER the URL commits (client.js:1856 then :2023), so
+        // poll rather than reading once.
+        await expect.poll(async () => (await readStates()).at(-1)).toBe('null');
+
+        expect(await readStates()).toContain('to:/product/p01'); // survived batching
+    });
+
+    test('a hash-only change opens no navigation root', async ({ page, fakeFlare }) => {
+        await page.goto('/');
+        await page.waitForLoadState('networkidle');
+        await page.evaluate(() => {
+            window.location.hash = 'section-2';
+        });
+        await page.waitForTimeout(2500); // outlive idleTimeout (2000) so any root would have flushed
+
+        const navSpans = (await fakeFlare.traces())
+            .flatMap((t) => spansOf(t.bodyJson))
+            .filter((s) => hasSpanType(s, 'browser_navigation'));
+        expect(navSpans).toHaveLength(0);
+    });
 });

--- a/e2e/specs/svelte.spec.ts
+++ b/e2e/specs/svelte.spec.ts
@@ -207,6 +207,28 @@ test.describe('svelte http tracing', () => {
         expect(span!.status?.code ?? 0).toBe(0);
     });
 
+    test('a 5xx fetch produces a span error, unlike a 4xx', async ({ page, fakeFlare }) => {
+        await page.goto('/http');
+        await page.waitForLoadState('networkidle');
+
+        await page.getByTestId(testIds.httpTrigger('fetch-500')).click();
+        await expect(page.getByTestId(testIds.httpResult)).toHaveText('fetch-500:500');
+
+        const trace = await fakeFlare.waitForTrace({
+            timeout: 9000,
+            predicate: (r) =>
+                spansOf(r.bodyJson).some((s) => hasSpanType(s, 'browser_fetch') && urlOf(s).includes('fetch-500')),
+        });
+        const span = spansOf(trace.bodyJson).find(
+            (s) => hasSpanType(s, 'browser_fetch') && urlOf(s).includes('fetch-500'),
+        );
+        expect(span).toBeTruthy();
+        // The 404 test above pins the non-error side; this pins the other half of endHttpRequestSpan's
+        // branch: status >= 500 both records the status AND marks the span an OTel error (code 2).
+        expect(attr(span!, 'http.response.status_code')).toEqual({ intValue: 500 });
+        expect(span!.status?.code ?? 0).toBe(2);
+    });
+
     test('an XHR fires a browser_xhr span nested under the active root', async ({ page, fakeFlare }) => {
         await page.goto('/http');
         await page.waitForLoadState('networkidle');

--- a/e2e/specs/svelte.spec.ts
+++ b/e2e/specs/svelte.spec.ts
@@ -1,7 +1,7 @@
 import { testIds } from '../../playgrounds/shared/src';
-import { expect, type FakeFlare, test } from '../fixtures/fake-flare';
+import { expect, test } from '../fixtures/fake-flare';
 import { logScenariosFor, runLogScenario } from './logShared';
-import { attr, hasSpanType, type OtlpSpan, spansOf } from './otlp';
+import { attr, hasSpanType, parentOf, spansOf, urlOf } from './otlp';
 import { runScenario, scenariosFor } from './shared';
 
 test.describe('svelte playground', () => {
@@ -143,19 +143,6 @@ test.describe('svelte tracing', () => {
 });
 
 test.describe('svelte http tracing', () => {
-    const urlOf = (span: OtlpSpan) => JSON.stringify(attr(span, 'url.full') ?? '');
-
-    /**
-     * A request span's parent root can flush in an earlier envelope than the request itself (roots
-     * hold open for their idle window; requests flush eagerly), so poll across every captured trace
-     * rather than the single envelope the request span was found in.
-     */
-    const waitForParentEnvelope = (fakeFlare: FakeFlare, child: OtlpSpan) =>
-        fakeFlare.waitForTrace({
-            timeout: 9000,
-            predicate: (r) => spansOf(r.bodyJson).some((s) => s.spanId === child.parentSpanId),
-        });
-
     test('a fetch fires a browser_fetch span nested under the active root', async ({ page, fakeFlare }) => {
         await page.goto('/http');
         await page.waitForLoadState('networkidle');
@@ -174,8 +161,7 @@ test.describe('svelte http tracing', () => {
 
         // The real assertion: it nests under a root, not orphaned at the top level.
         expect(fetchSpan!.parentSpanId).toBeTruthy();
-        const rootTrace = await waitForParentEnvelope(fakeFlare, fetchSpan!);
-        const root = spansOf(rootTrace.bodyJson).find((s) => s.spanId === fetchSpan!.parentSpanId);
+        const root = await parentOf(fakeFlare, fetchSpan!);
         expect(root).toBeTruthy();
         expect(hasSpanType(root!, 'browser_pageload') || hasSpanType(root!, 'browser_navigation')).toBe(true);
     });
@@ -246,10 +232,52 @@ test.describe('svelte http tracing', () => {
         expect(attr(xhrSpan!, 'http.request.method')).toEqual({ stringValue: 'GET' });
 
         expect(xhrSpan!.parentSpanId).toBeTruthy();
-        const rootTrace = await waitForParentEnvelope(fakeFlare, xhrSpan!);
-        const root = spansOf(rootTrace.bodyJson).find((s) => s.spanId === xhrSpan!.parentSpanId);
+        const root = await parentOf(fakeFlare, xhrSpan!);
         expect(root).toBeTruthy();
         expect(hasSpanType(root!, 'browser_pageload') || hasSpanType(root!, 'browser_navigation')).toBe(true);
+    });
+
+    // The fetch 404/500 pair above pins both sides of endHttpRequestSpan's status branch. XHR runs
+    // through the same span helper but a different patch, so pin that its 404 is recorded rather
+    // than assumed to behave like fetch's.
+    test('a failing XHR records its status without marking the span an error', async ({ page, fakeFlare }) => {
+        await page.goto('/http');
+        await page.waitForLoadState('networkidle');
+
+        await page.getByTestId(testIds.httpTrigger('xhr-404')).click();
+        await expect(page.getByTestId(testIds.httpResult)).toHaveText('xhr-404:404');
+
+        const trace = await fakeFlare.waitForTrace({
+            timeout: 9000,
+            predicate: (r) =>
+                spansOf(r.bodyJson).some((s) => hasSpanType(s, 'browser_xhr') && urlOf(s).includes('xhr-404')),
+        });
+        const span = spansOf(trace.bodyJson).find((s) => hasSpanType(s, 'browser_xhr') && urlOf(s).includes('xhr-404'));
+        expect(span).toBeTruthy();
+        expect(attr(span!, 'http.response.status_code')).toEqual({ intValue: 404 });
+        expect(span!.status?.code ?? 0).toBe(0);
+    });
+
+    // REGRESSION TEST FOR THE TRACEPARENT INIT REBUILD. Kit's dev_fetch brands the init it hands a
+    // `load` fetch with a NON-ENUMERABLE `__sveltekit_fetch__`, and its dev-mode window.fetch wrapper
+    // warns when the brand is missing. Flare patches window.fetch after Kit's, so rebuilding the init
+    // to inject traceparent used to spread the brand away and make Kit scold the developer for using
+    // `window.fetch` in a load function while they were already using the right one. Unit tests pin
+    // mergeTraceparentHeader in isolation; only this catches the symptom as reported. Needs dev mode
+    // (Kit gates the wrapper on DEV && BROWSER), which is what the default e2e webServer runs.
+    test('Kit does not warn about window.fetch for a traced load fetch', async ({ page }) => {
+        const warnings: string[] = [];
+        page.on('console', (msg) => {
+            if (msg.type() === 'warning') warnings.push(msg.text());
+        });
+
+        await page.goto('/');
+        await page.waitForLoadState('networkidle');
+        await page.getByRole('link', { name: 'HTTP' }).click(); // client nav => load fetch runs in the browser
+        await expect(page).toHaveURL(/\/http$/);
+        await expect(page.getByTestId(testIds.httpResult)).toBeVisible();
+
+        expect(warnings.filter((w) => /using `window.fetch`/.test(w))).toEqual([]);
     });
 
     // PINS VERIFIED FACT 11. Kit's fetcher.js:9 captures `native_fetch = window.fetch` at module
@@ -276,8 +304,7 @@ test.describe('svelte http tracing', () => {
 
         // It fired during the navigation, so it must nest under the navigation root, not the pageload.
         expect(loadFetch!.parentSpanId).toBeTruthy();
-        const rootTrace = await waitForParentEnvelope(fakeFlare, loadFetch!);
-        const root = spansOf(rootTrace.bodyJson).find((s) => s.spanId === loadFetch!.parentSpanId);
+        const root = await parentOf(fakeFlare, loadFetch!);
         expect(root && hasSpanType(root, 'browser_navigation')).toBe(true);
     });
 });

--- a/e2e/specs/svelte.spec.ts
+++ b/e2e/specs/svelte.spec.ts
@@ -1,7 +1,7 @@
 import { testIds } from '../../playgrounds/shared/src';
-import { expect, test } from '../fixtures/fake-flare';
+import { expect, type FakeFlare, test } from '../fixtures/fake-flare';
 import { logScenariosFor, runLogScenario } from './logShared';
-import { attr, hasSpanType, spansOf } from './otlp';
+import { attr, hasSpanType, type OtlpSpan, spansOf } from './otlp';
 import { runScenario, scenariosFor } from './shared';
 
 test.describe('svelte playground', () => {
@@ -139,5 +139,123 @@ test.describe('svelte tracing', () => {
         // the zero-navigation assertion below is meaningful rather than vacuous.
         expect(pageload && attr(pageload, 'flare.route.source')).toEqual({ stringValue: 'route' });
         expect(all.filter((s) => hasSpanType(s, 'browser_navigation'))).toHaveLength(0);
+    });
+});
+
+test.describe('svelte http tracing', () => {
+    const urlOf = (span: OtlpSpan) => JSON.stringify(attr(span, 'url.full') ?? '');
+
+    /**
+     * A request span's parent root can flush in an earlier envelope than the request itself (roots
+     * hold open for their idle window; requests flush eagerly), so poll across every captured trace
+     * rather than the single envelope the request span was found in.
+     */
+    const waitForParentEnvelope = (fakeFlare: FakeFlare, child: OtlpSpan) =>
+        fakeFlare.waitForTrace({
+            timeout: 9000,
+            predicate: (r) => spansOf(r.bodyJson).some((s) => s.spanId === child.parentSpanId),
+        });
+
+    test('a fetch fires a browser_fetch span nested under the active root', async ({ page, fakeFlare }) => {
+        await page.goto('/http');
+        await page.waitForLoadState('networkidle');
+
+        await page.getByTestId(testIds.httpTrigger('fetch-ok')).click();
+        await expect(page.getByTestId(testIds.httpResult)).toHaveText('fetch-ok:200');
+
+        const trace = await fakeFlare.waitForTrace({
+            timeout: 9000,
+            predicate: (r) => spansOf(r.bodyJson).some((s) => hasSpanType(s, 'browser_fetch')),
+        });
+        const spans = spansOf(trace.bodyJson);
+        const fetchSpan = spans.find((s) => hasSpanType(s, 'browser_fetch') && urlOf(s).includes('fetch-ok'));
+        expect(fetchSpan).toBeTruthy();
+        expect(attr(fetchSpan!, 'http.request.method')).toEqual({ stringValue: 'GET' });
+
+        // The real assertion: it nests under a root, not orphaned at the top level.
+        expect(fetchSpan!.parentSpanId).toBeTruthy();
+        const rootTrace = await waitForParentEnvelope(fakeFlare, fetchSpan!);
+        const root = spansOf(rootTrace.bodyJson).find((s) => s.spanId === fetchSpan!.parentSpanId);
+        expect(root).toBeTruthy();
+        expect(hasSpanType(root!, 'browser_pageload') || hasSpanType(root!, 'browser_navigation')).toBe(true);
+    });
+
+    test('a failing fetch still produces a span with its status recorded, not a span error', async ({
+        page,
+        fakeFlare,
+    }) => {
+        await page.goto('/http');
+        await page.waitForLoadState('networkidle');
+
+        await page.getByTestId(testIds.httpTrigger('fetch-404')).click();
+        await expect(page.getByTestId(testIds.httpResult)).toHaveText('fetch-404:404');
+
+        const trace = await fakeFlare.waitForTrace({
+            timeout: 9000,
+            predicate: (r) =>
+                spansOf(r.bodyJson).some((s) => hasSpanType(s, 'browser_fetch') && urlOf(s).includes('fetch-404')),
+        });
+        const span = spansOf(trace.bodyJson).find(
+            (s) => hasSpanType(s, 'browser_fetch') && urlOf(s).includes('fetch-404'),
+        );
+        expect(span).toBeTruthy();
+        // httpRequestSpan.ts's endHttpRequestSpan records the response status on every completion
+        // via http.response.status_code, and only calls setStatus (span error, OTel code 2) for
+        // status >= 500. A 404 is a completed request, so the status attribute must be 404 and the
+        // span's own OTel status must stay Unset (0), not Error.
+        expect(attr(span!, 'http.response.status_code')).toEqual({ intValue: 404 });
+        expect(span!.status?.code ?? 0).toBe(0);
+    });
+
+    test('an XHR fires a browser_xhr span nested under the active root', async ({ page, fakeFlare }) => {
+        await page.goto('/http');
+        await page.waitForLoadState('networkidle');
+
+        await page.getByTestId(testIds.httpTrigger('xhr-ok')).click();
+        await expect(page.getByTestId(testIds.httpResult)).toHaveText('xhr-ok:200');
+
+        const trace = await fakeFlare.waitForTrace({
+            timeout: 9000,
+            predicate: (r) => spansOf(r.bodyJson).some((s) => hasSpanType(s, 'browser_xhr')),
+        });
+        const spans = spansOf(trace.bodyJson);
+        const xhrSpan = spans.find((s) => hasSpanType(s, 'browser_xhr') && urlOf(s).includes('xhr-ok'));
+        expect(xhrSpan).toBeTruthy();
+        expect(attr(xhrSpan!, 'http.request.method')).toEqual({ stringValue: 'GET' });
+
+        expect(xhrSpan!.parentSpanId).toBeTruthy();
+        const rootTrace = await waitForParentEnvelope(fakeFlare, xhrSpan!);
+        const root = spansOf(rootTrace.bodyJson).find((s) => s.spanId === xhrSpan!.parentSpanId);
+        expect(root).toBeTruthy();
+        expect(hasSpanType(root!, 'browser_pageload') || hasSpanType(root!, 'browser_navigation')).toBe(true);
+    });
+
+    // PINS VERIFIED FACT 11. Kit's fetcher.js:9 captures `native_fetch = window.fetch` at module
+    // scope, which reads like it pins the unpatched original; it does not (that reference is only
+    // used inside Kit's own wrapper). subsequent_fetch reads window.fetch at CALL time, so Flare's
+    // patch sees a load fetch. If this test fails, the fact is wrong and the JSDoc needs the
+    // limitation after all. Deep-linking would run the load on the SERVER (no patch, no span), so
+    // this MUST be a client navigation.
+    test("SvelteKit's load-provided fetch produces a browser_fetch span", async ({ page, fakeFlare }) => {
+        await page.goto('/');
+        await page.waitForLoadState('networkidle');
+
+        await page.getByRole('link', { name: 'HTTP' }).click(); // client nav => load runs in the browser
+        await expect(page).toHaveURL(/\/http$/);
+
+        const trace = await fakeFlare.waitForTrace({
+            timeout: 9000,
+            predicate: (r) =>
+                spansOf(r.bodyJson).some((s) => hasSpanType(s, 'browser_fetch') && urlOf(s).includes('kit-load-fetch')),
+        });
+        const spans = spansOf(trace.bodyJson);
+        const loadFetch = spans.find((s) => hasSpanType(s, 'browser_fetch') && urlOf(s).includes('kit-load-fetch'));
+        expect(loadFetch).toBeTruthy();
+
+        // It fired during the navigation, so it must nest under the navigation root, not the pageload.
+        expect(loadFetch!.parentSpanId).toBeTruthy();
+        const rootTrace = await waitForParentEnvelope(fakeFlare, loadFetch!);
+        const root = spansOf(rootTrace.bodyJson).find((s) => s.spanId === loadFetch!.parentSpanId);
+        expect(root && hasSpanType(root, 'browser_navigation')).toBe(true);
     });
 });

--- a/e2e/specs/svelte.spec.ts
+++ b/e2e/specs/svelte.spec.ts
@@ -85,7 +85,7 @@ test.describe('svelte tracing', () => {
         expect(nav && attr(nav, 'flare.route.source')).toEqual({ stringValue: 'route' });
         // The nav root's url.full must be the DESTINATION even though Kit emits `navigating`
         // before the URL commits. This is what proves the seam's url override is wired.
-        expect(JSON.stringify(attr(nav!, 'url.full') ?? '')).toContain('/product/p01');
+        expect(JSON.stringify((nav && attr(nav, 'url.full')) ?? '')).toContain('/product/p01');
 
         // registerNavigationSource suppresses the History-based root, so one click => one root.
         const navSpans = (await fakeFlare.traces())
@@ -126,11 +126,18 @@ test.describe('svelte tracing', () => {
         await page.evaluate(() => {
             window.location.hash = 'section-2';
         });
-        await page.waitForTimeout(2500); // outlive idleTimeout (2000) so any root would have flushed
+        // Worst case is idleTimeout (2000) + flush timer (500) = 2500ms before the root even POSTs;
+        // add 500ms margin for that POST to reach the fake server.
+        await page.waitForTimeout(3000);
 
-        const navSpans = (await fakeFlare.traces())
-            .flatMap((t) => spansOf(t.bodyJson))
-            .filter((s) => hasSpanType(s, 'browser_navigation'));
-        expect(navSpans).toHaveLength(0);
+        const all = (await fakeFlare.traces()).flatMap((t) => spansOf(t.bodyJson));
+        const pageload = all.find((s) => hasSpanType(s, 'browser_pageload'));
+        // Positive control: browser_pageload roots are opened by the framework-agnostic browser
+        // tracer regardless of traceSvelteKitRouter, so merely finding one proves nothing. Its
+        // route.source only flips from the default 'url' to 'route' once traceSvelteKitRouter's
+        // effect names it, so this is what actually proves the SvelteKit integration is wired and
+        // the zero-navigation assertion below is meaningful rather than vacuous.
+        expect(pageload && attr(pageload, 'flare.route.source')).toEqual({ stringValue: 'route' });
+        expect(all.filter((s) => hasSpanType(s, 'browser_navigation'))).toHaveLength(0);
     });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -17988,9 +17988,11 @@
             "devDependencies": {
                 "@flareapp/js": "file:../js",
                 "@flareapp/svelte": "file:../svelte",
+                "@flareapp/test-helpers": "*",
                 "@sveltejs/kit": "^2.0.0",
                 "@sveltejs/package": "^2.5.7",
                 "@sveltejs/vite-plugin-svelte": "^5.0.0",
+                "jsdom": "^26.1.0",
                 "svelte": "^5.0.0",
                 "typescript": "^5.7.0",
                 "vitest": "^4.0.0"

--- a/packages/js/src/browser.ts
+++ b/packages/js/src/browser.ts
@@ -59,6 +59,7 @@ export { FetchFileReader } from './browser/FetchFileReader';
 export { BrowserFlushScheduler } from './browser/BrowserFlushScheduler';
 export { registerNavigationSource, type NavigationSource, type RouteName } from './tracing/browserTracing';
 export { insulate, safeInvoke } from './tracing/instrumentationGuard';
+export { absoluteHref } from './tracing/absoluteHref';
 export {
     activeComponentRoot,
     reserveSpanId,

--- a/packages/js/src/browser/context/collectBrowserSpanContext.ts
+++ b/packages/js/src/browser/context/collectBrowserSpanContext.ts
@@ -25,14 +25,14 @@ export const collectBrowserSpanContext = (config: Readonly<Config>, hrefOverride
 };
 
 /**
- * The URL-derived subset of a root's context, for re-stamping a root whose destination changed
- * after it opened: a redirect hop, or a navigation superseded by a newer one. Both re-name a root
- * that `startNavigation` already stamped from the FIRST destination, which would otherwise keep
- * reporting a URL the user never landed on.
+ * The url attributes of a root span, so a root can be updated when its destination changes after it
+ * opened. That happens on a redirect, or when a newer navigation replaces this one. `startNavigation`
+ * sets the url from the first destination, so without this the root reports a page the user never
+ * landed on.
  *
- * Deliberately excludes `flare.entry_point.handler.identifier`: on a named root the route template
- * owns it, and re-deriving it from the href would clobber `/product/[id]` back to `/product/p01`.
- * Returns `{}` for an unparseable href, so a bad destination leaves the existing values intact.
+ * Leaves `flare.entry_point.handler.identifier` alone. The route template owns that one, and taking
+ * it from the href would turn `/product/[id]` back into `/product/p01`.
+ * Returns `{}` when the href cannot be parsed, so a bad url leaves the current values as they are.
  */
 export const browserSpanUrlAttributes = (config: Readonly<Config>, href: string): Attributes => {
     if (typeof window === 'undefined') return {};

--- a/packages/js/src/browser/context/collectBrowserSpanContext.ts
+++ b/packages/js/src/browser/context/collectBrowserSpanContext.ts
@@ -1,4 +1,5 @@
 import type { Attributes, Config } from '@flareapp/core';
+import { redactUrlQuery } from '@flareapp/core';
 
 import { browserEntryPoint } from './collectBrowser';
 import request from './request';
@@ -21,6 +22,24 @@ export const collectBrowserSpanContext = (config: Readonly<Config>, hrefOverride
     }
     const href = resolveHref(hrefOverride);
     return { ...browserEntryPoint(config, href), ...request(config.urlDenylist, href) };
+};
+
+/**
+ * The URL-derived subset of a root's context, for re-stamping a root whose destination changed
+ * after it opened: a redirect hop, or a navigation superseded by a newer one. Both re-name a root
+ * that `startNavigation` already stamped from the FIRST destination, which would otherwise keep
+ * reporting a URL the user never landed on.
+ *
+ * Deliberately excludes `flare.entry_point.handler.identifier`: on a named root the route template
+ * owns it, and re-deriving it from the href would clobber `/product/[id]` back to `/product/p01`.
+ * Returns `{}` for an unparseable href, so a bad destination leaves the existing values intact.
+ */
+export const browserSpanUrlAttributes = (config: Readonly<Config>, href: string): Attributes => {
+    if (typeof window === 'undefined') return {};
+    const resolved = resolveHref(href);
+    if (resolved === undefined) return {};
+    const redacted = redactUrlQuery(resolved, config.urlDenylist);
+    return { 'url.full': redacted, 'flare.entry_point.value': redacted };
 };
 
 /** Normalize an override href once; undefined (fall back to live location) when unparseable. */

--- a/packages/js/src/tracing/absoluteHref.ts
+++ b/packages/js/src/tracing/absoluteHref.ts
@@ -1,0 +1,19 @@
+/**
+ * Turn a router-reported href into a full URL, resolved against the page we are on.
+ *
+ * Routers report paths with the app's base path and hash prefix taken off, so building a URL by
+ * hand as `origin + path` gives an address the server does not have: a Vue app on `/app/` reports
+ * `/product/p01` for the real `/app/product/p01`. Pass the href from the router's own `createHref`
+ * or `resolve` instead, which puts the base path and hash back, and this resolves it to a full URL.
+ *
+ * Returns undefined outside a browser, or when the href cannot be parsed, so a caller can leave the
+ * span attribute it would have written alone.
+ */
+export function absoluteHref(href: string | null | undefined): string | undefined {
+    if (href == null || typeof window === 'undefined') return undefined;
+    try {
+        return new URL(href, window.location.href).href;
+    } catch {
+        return undefined;
+    }
+}

--- a/packages/js/src/tracing/browserTracing.ts
+++ b/packages/js/src/tracing/browserTracing.ts
@@ -17,9 +17,10 @@ export type RouteName = {
     name: string;
     source: 'route' | 'url';
     /**
-     * Destination href. When set, re-stamps the root's `url.full` + `flare.entry_point.value` in
-     * lockstep with the name, so a redirected or superseded navigation reports where it actually
-     * landed rather than the destination it opened with. Omit to leave the opening URL alone.
+     * Where the navigation is going. When set, the root's `url.full` and `flare.entry_point.value`
+     * are updated together with the name, so a navigation that was redirected, or replaced by a
+     * newer one, reports the page it ended on rather than the one it opened with. Leave it out to
+     * keep the url the root started with.
      */
     url?: string;
 };
@@ -208,7 +209,7 @@ export function stopBrowserTracing(): void {
     lastPath = '';
 }
 
-/** Rename the current root and keep its identifier + source attribute in lockstep. No-op if it closed. */
+/** Rename the current root and update the attributes that go with the name. No-op once it closed. */
 function applyRouteName(route: RouteName): void {
     if (currentRoot && controller && !controller.isEnded) {
         try {

--- a/packages/js/src/tracing/browserTracing.ts
+++ b/packages/js/src/tracing/browserTracing.ts
@@ -1,6 +1,6 @@
 import { defaultNowNano, type Config, type Span, type SpanOptions, type Tracer } from '@flareapp/core';
 
-import { collectBrowserSpanContext } from '../browser/context/collectBrowserSpanContext';
+import { browserSpanUrlAttributes, collectBrowserSpanContext } from '../browser/context/collectBrowserSpanContext';
 import { fill, unfill } from './fill';
 import { IdleRootController, type IdleTimeouts } from './IdleRootController';
 import { pageloadEndNano, pageloadStartNano, resolvePageloadStartNano } from './navigationTiming';
@@ -13,7 +13,16 @@ export type BrowserTracingFlare = {
     tracer: Pick<Tracer, 'addSpanListener' | 'setActiveRoot' | 'flush' | 'getActiveSpan'>;
 };
 
-export type RouteName = { name: string; source: 'route' | 'url' };
+export type RouteName = {
+    name: string;
+    source: 'route' | 'url';
+    /**
+     * Destination href. When set, re-stamps the root's `url.full` + `flare.entry_point.value` in
+     * lockstep with the name, so a redirected or superseded navigation reports where it actually
+     * landed rather than the destination it opened with. Omit to leave the opening URL alone.
+     */
+    url?: string;
+};
 export type NavigationSource = {
     startNavigation(opts?: { path?: string; url?: string; hold?: boolean }): void;
     setActiveRouteName(route: RouteName): void;
@@ -206,6 +215,10 @@ function applyRouteName(route: RouteName): void {
             currentRoot.name = route.name;
             currentRoot.setAttribute('flare.entry_point.handler.identifier', route.name);
             currentRoot.setAttribute('flare.route.source', route.source);
+            if (route.url !== undefined && activeFlare) {
+                const urlAttrs = browserSpanUrlAttributes(activeFlare.config, route.url);
+                for (const key of Object.keys(urlAttrs)) currentRoot.setAttribute(key, urlAttrs[key]);
+            }
         } catch {
             // instrumentation must never throw into the host app
         }

--- a/packages/js/src/tracing/propagation.ts
+++ b/packages/js/src/tracing/propagation.ts
@@ -87,11 +87,10 @@ export function mergeTraceparentHeader(
         headers = { traceparent };
     }
 
-    // Copy every own descriptor rather than spreading: a spread takes only ENUMERABLE own
-    // properties, and callers brand `init` with non-enumerable markers. SvelteKit tags the init it
-    // hands a `load` function with a non-enumerable `__sveltekit_fetch__`, and its dev-mode
-    // `window.fetch` wrapper tells the developer to "use the `fetch` passed to your load function"
-    // when the tag is missing, so dropping it makes Flare scold them for code that is already right.
+    // Copy the property descriptors instead of spreading. A spread only copies enumerable
+    // properties, and SvelteKit marks the init it gives a `load` function with a hidden
+    // `__sveltekit_fetch__` flag. If we drop that flag, SvelteKit's dev-mode fetch wrapper warns the
+    // developer to use the `fetch` from their load function, which is what they were already doing.
     const result: RequestInit = { headers };
     if (init) {
         const descriptors = Object.getOwnPropertyDescriptors(init);

--- a/packages/js/src/tracing/propagation.ts
+++ b/packages/js/src/tracing/propagation.ts
@@ -87,7 +87,17 @@ export function mergeTraceparentHeader(
         headers = { traceparent };
     }
 
-    const result: RequestInit = { ...init, headers };
+    // Copy every own descriptor rather than spreading: a spread takes only ENUMERABLE own
+    // properties, and callers brand `init` with non-enumerable markers. SvelteKit tags the init it
+    // hands a `load` function with a non-enumerable `__sveltekit_fetch__`, and its dev-mode
+    // `window.fetch` wrapper tells the developer to "use the `fetch` passed to your load function"
+    // when the tag is missing, so dropping it makes Flare scold them for code that is already right.
+    const result: RequestInit = { headers };
+    if (init) {
+        const descriptors = Object.getOwnPropertyDescriptors(init);
+        delete descriptors.headers; // the merged headers above win
+        Object.defineProperties(result, descriptors);
+    }
     // A Request with a ReadableStream body requires `duplex` when re-issued with an init;
     // without it fetch throws and breaks a host request that worked pre-tracing.
     if (

--- a/packages/js/tests/absoluteHref.test.ts
+++ b/packages/js/tests/absoluteHref.test.ts
@@ -1,0 +1,41 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { absoluteHref } from '../src/tracing/absoluteHref';
+
+beforeEach(() => {
+    window.history.replaceState({}, '', '/');
+});
+
+describe('absoluteHref', () => {
+    it('resolves a root-relative href against the current origin', () => {
+        expect(absoluteHref('/product/p01')).toBe(`${window.location.origin}/product/p01`);
+    });
+
+    it('keeps a base path the router already applied', () => {
+        expect(absoluteHref('/app/product/p01')).toBe(`${window.location.origin}/app/product/p01`);
+    });
+
+    // The href a hash-history router hands us has no leading slash, so it only resolves correctly
+    // against the current page. Building it as origin + href would give a URL with no path at all.
+    it('resolves a hash-history href against the current page', () => {
+        window.history.replaceState({}, '', '/index.html');
+        expect(absoluteHref('#/product/p01')).toBe(`${window.location.origin}/index.html#/product/p01`);
+    });
+
+    it('passes an already absolute href through', () => {
+        expect(absoluteHref('https://other.example/x')).toBe('https://other.example/x');
+    });
+
+    it('keeps the query string', () => {
+        expect(absoluteHref('/product/p01?tab=specs')).toBe(`${window.location.origin}/product/p01?tab=specs`);
+    });
+
+    // Callers use undefined to mean "leave the url attribute alone", so a bad href must not become
+    // a url that is merely wrong.
+    it('returns undefined rather than a wrong url', () => {
+        expect(absoluteHref('http://[')).toBeUndefined();
+        expect(absoluteHref(undefined)).toBeUndefined();
+        expect(absoluteHref(null)).toBeUndefined();
+    });
+});

--- a/packages/js/tests/navigationSource.test.ts
+++ b/packages/js/tests/navigationSource.test.ts
@@ -114,10 +114,10 @@ describe('registerNavigationSource', () => {
         src.unregister();
     });
 
-    // THE REDIRECT CASE. `startNavigation` stamps url.full from the FIRST destination, but a redirect
-    // hop (or a newer nav superseding this one) re-names the SAME held root. Without the re-stamp the
-    // root reports the parameterized name of where it landed next to the URL it never landed on.
-    it('setActiveRouteName re-stamps url.full + entry_point.value when a url rides along', () => {
+    // `startNavigation` sets url.full from the first destination, but a redirect, or a newer
+    // navigation replacing this one, renames the same held root. Without updating the url too, the
+    // root shows the name of the page it landed on next to the url of the one it never reached.
+    it('setActiveRouteName updates url.full and entry_point.value when a name carries a url', () => {
         vi.useFakeTimers();
         window.history.replaceState({}, '', '/');
         const { flare, spans } = fakeFlare();
@@ -130,14 +130,14 @@ describe('registerNavigationSource', () => {
         const nav = spans[1];
         expect(nav.attrs['url.full']).toBe('https://app.example/cart');
         expect(nav.attrs['flare.entry_point.value']).toBe('https://app.example/cart');
-        // The route template still owns the identifier: re-deriving it from the href would clobber
-        // '/cart' back to a URL-shaped name.
+        // The route template still owns the identifier. Taking it from the href would turn '/cart'
+        // back into a url-shaped name.
         expect(nav.attrs['flare.entry_point.handler.identifier']).toBe('/cart');
         src.unregister();
     });
 
-    // `attrs` records only setAttribute calls, so an absent key here means no re-stamp was attempted
-    // and the root keeps whatever startNavigation stamped at creation.
+    // `attrs` only records setAttribute calls, so a missing key here means we never tried to update
+    // it and the root keeps whatever startNavigation set when it was created.
     it('omitting url leaves the url the root opened with untouched', () => {
         vi.useFakeTimers();
         const { flare, startSpan, spans } = fakeFlare();
@@ -152,7 +152,7 @@ describe('registerNavigationSource', () => {
         src.unregister();
     });
 
-    it('an unparseable url leaves the existing url.full intact rather than poisoning it', () => {
+    it('a url that will not parse leaves the existing url.full alone', () => {
         vi.useFakeTimers();
         const { flare, startSpan, spans } = fakeFlare();
         startBrowserTracing(flare);
@@ -167,7 +167,7 @@ describe('registerNavigationSource', () => {
         src.unregister();
     });
 
-    it('the re-stamped url is redacted by urlDenylist like the opening one', () => {
+    it('the updated url is redacted by urlDenylist like the opening one', () => {
         vi.useFakeTimers();
         const { flare, spans } = fakeFlare();
         (flare.config as { urlDenylist: RegExp }).urlDenylist = /token/;

--- a/packages/js/tests/navigationSource.test.ts
+++ b/packages/js/tests/navigationSource.test.ts
@@ -114,6 +114,73 @@ describe('registerNavigationSource', () => {
         src.unregister();
     });
 
+    // THE REDIRECT CASE. `startNavigation` stamps url.full from the FIRST destination, but a redirect
+    // hop (or a newer nav superseding this one) re-names the SAME held root. Without the re-stamp the
+    // root reports the parameterized name of where it landed next to the URL it never landed on.
+    it('setActiveRouteName re-stamps url.full + entry_point.value when a url rides along', () => {
+        vi.useFakeTimers();
+        window.history.replaceState({}, '', '/');
+        const { flare, spans } = fakeFlare();
+        startBrowserTracing(flare);
+        const src = registerNavigationSource();
+
+        src.startNavigation({ path: '/old', url: 'https://app.example/old', hold: true });
+        src.setActiveRouteName({ name: '/cart', source: 'route', url: 'https://app.example/cart' });
+
+        const nav = spans[1];
+        expect(nav.attrs['url.full']).toBe('https://app.example/cart');
+        expect(nav.attrs['flare.entry_point.value']).toBe('https://app.example/cart');
+        // The route template still owns the identifier: re-deriving it from the href would clobber
+        // '/cart' back to a URL-shaped name.
+        expect(nav.attrs['flare.entry_point.handler.identifier']).toBe('/cart');
+        src.unregister();
+    });
+
+    // `attrs` records only setAttribute calls, so an absent key here means no re-stamp was attempted
+    // and the root keeps whatever startNavigation stamped at creation.
+    it('omitting url leaves the url the root opened with untouched', () => {
+        vi.useFakeTimers();
+        const { flare, startSpan, spans } = fakeFlare();
+        startBrowserTracing(flare);
+        const src = registerNavigationSource();
+
+        src.startNavigation({ path: '/old', url: 'https://app.example/old', hold: true });
+        src.settleNavigation({ name: '/old', source: 'route' }); // no url
+
+        expect(spans[1].attrs['url.full']).toBeUndefined(); // no re-stamp
+        expect(startSpan.mock.calls[1]![1]!.attributes?.['url.full']).toBe('https://app.example/old');
+        src.unregister();
+    });
+
+    it('an unparseable url leaves the existing url.full intact rather than poisoning it', () => {
+        vi.useFakeTimers();
+        const { flare, startSpan, spans } = fakeFlare();
+        startBrowserTracing(flare);
+        const src = registerNavigationSource();
+
+        src.startNavigation({ path: '/old', url: 'https://app.example/old', hold: true });
+        src.setActiveRouteName({ name: '/cart', source: 'route', url: 'http://[' });
+
+        expect(spans[1].attrs['url.full']).toBeUndefined(); // rejected, not written
+        expect(startSpan.mock.calls[1]![1]!.attributes?.['url.full']).toBe('https://app.example/old');
+        expect(spans[1].span.name).toBe('/cart'); // the rename still lands
+        src.unregister();
+    });
+
+    it('the re-stamped url is redacted by urlDenylist like the opening one', () => {
+        vi.useFakeTimers();
+        const { flare, spans } = fakeFlare();
+        (flare.config as { urlDenylist: RegExp }).urlDenylist = /token/;
+        startBrowserTracing(flare);
+        const src = registerNavigationSource();
+
+        src.startNavigation({ path: '/old', url: 'https://app.example/old', hold: true });
+        src.settleNavigation({ name: '/cart', source: 'route', url: 'https://app.example/cart?token=secret' });
+
+        expect(spans[1].attrs['url.full']).not.toContain('secret');
+        src.unregister();
+    });
+
     it('setActiveRouteName no-ops once the active root has ended', () => {
         vi.useFakeTimers();
         const { flare, spans } = fakeFlare();

--- a/packages/js/tests/propagation.test.ts
+++ b/packages/js/tests/propagation.test.ts
@@ -230,13 +230,11 @@ describe('mergeTraceparentHeader', () => {
         expect((init as RequestInit & { duplex?: string })!.duplex).toBeUndefined();
     });
 
-    // A spread copies only ENUMERABLE own properties. Callers brand `init` with non-enumerable
-    // markers: SvelteKit's `dev_fetch` tags the init it hands a `load` function with a
-    // non-enumerable `__sveltekit_fetch__`, and its dev-mode `window.fetch` wrapper warns the
-    // developer to "use the `fetch` passed to your load function" when the tag is missing. Rebuilding
-    // the init to inject `traceparent` must not strip it, or Flare makes SvelteKit scold developers
-    // for something they are already doing correctly.
-    it('preserves a NON-ENUMERABLE own property on the caller init (regression)', () => {
+    // A spread only copies enumerable properties. SvelteKit's `dev_fetch` marks the init it gives a
+    // `load` function with a hidden `__sveltekit_fetch__` flag, and its dev-mode fetch wrapper warns
+    // the developer to use the `fetch` from their load function when the flag is missing. Rebuilding
+    // the init to add `traceparent` must keep the flag, or we warn people about code that is fine.
+    it('keeps a hidden property the caller put on the init (regression)', () => {
         const callerInit: RequestInit = { method: 'GET' };
         Object.defineProperty(callerInit, '__sveltekit_fetch__', {
             value: true,
@@ -251,7 +249,7 @@ describe('mergeTraceparentHeader', () => {
         expect(init!.method).toBe('GET');
     });
 
-    it('keeps a preserved non-enumerable property non-enumerable (regression)', () => {
+    it('keeps that property hidden rather than making it enumerable (regression)', () => {
         const callerInit: RequestInit = {};
         Object.defineProperty(callerInit, '__sveltekit_fetch__', {
             value: true,
@@ -261,7 +259,7 @@ describe('mergeTraceparentHeader', () => {
 
         const init = mergeTraceparentHeader('https://app.example/x', callerInit, TP);
 
-        // Re-enumerating it would leak the marker into anything that spreads or serializes the init.
+        // Making it enumerable would leak the flag into anything that spreads or serializes the init.
         expect(Object.keys(init!)).not.toContain('__sveltekit_fetch__');
         expect(Object.getOwnPropertyDescriptor(init!, '__sveltekit_fetch__')?.enumerable).toBe(false);
     });

--- a/packages/js/tests/propagation.test.ts
+++ b/packages/js/tests/propagation.test.ts
@@ -229,4 +229,49 @@ describe('mergeTraceparentHeader', () => {
         const init = mergeTraceparentHeader(req, undefined, TP);
         expect((init as RequestInit & { duplex?: string })!.duplex).toBeUndefined();
     });
+
+    // A spread copies only ENUMERABLE own properties. Callers brand `init` with non-enumerable
+    // markers: SvelteKit's `dev_fetch` tags the init it hands a `load` function with a
+    // non-enumerable `__sveltekit_fetch__`, and its dev-mode `window.fetch` wrapper warns the
+    // developer to "use the `fetch` passed to your load function" when the tag is missing. Rebuilding
+    // the init to inject `traceparent` must not strip it, or Flare makes SvelteKit scold developers
+    // for something they are already doing correctly.
+    it('preserves a NON-ENUMERABLE own property on the caller init (regression)', () => {
+        const callerInit: RequestInit = { method: 'GET' };
+        Object.defineProperty(callerInit, '__sveltekit_fetch__', {
+            value: true,
+            writable: true,
+            configurable: true,
+        });
+
+        const init = mergeTraceparentHeader('https://app.example/x', callerInit, TP);
+
+        expect((init as Record<string, unknown>).__sveltekit_fetch__).toBe(true);
+        expect((init!.headers as Record<string, string>).traceparent).toBe(TP);
+        expect(init!.method).toBe('GET');
+    });
+
+    it('keeps a preserved non-enumerable property non-enumerable (regression)', () => {
+        const callerInit: RequestInit = {};
+        Object.defineProperty(callerInit, '__sveltekit_fetch__', {
+            value: true,
+            writable: true,
+            configurable: true,
+        });
+
+        const init = mergeTraceparentHeader('https://app.example/x', callerInit, TP);
+
+        // Re-enumerating it would leak the marker into anything that spreads or serializes the init.
+        expect(Object.keys(init!)).not.toContain('__sveltekit_fetch__');
+        expect(Object.getOwnPropertyDescriptor(init!, '__sveltekit_fetch__')?.enumerable).toBe(false);
+    });
+
+    it('does not mutate the caller init when preserving its own properties', () => {
+        const callerInit: RequestInit = { method: 'POST', headers: { a: '1' } };
+
+        const init = mergeTraceparentHeader('https://app.example/x', callerInit, TP);
+
+        expect(init).not.toBe(callerInit);
+        expect(callerInit.headers).toEqual({ a: '1' }); // no traceparent leaked back
+    });
 });

--- a/packages/react/src/react-router.ts
+++ b/packages/react/src/react-router.ts
@@ -1,7 +1,7 @@
 // Electron-safe entry: NO @flareapp/js root import. The navigation-source seam comes from
 // @flareapp/js/browser (side-effect-free). NO runtime dependency on react-router — the router is
 // consumed structurally (see ./vendor/reactRouterTypes).
-import { insulate, registerNavigationSource, safeInvoke, type RouteName } from '@flareapp/js/browser';
+import { absoluteHref, insulate, registerNavigationSource, safeInvoke, type RouteName } from '@flareapp/js/browser';
 
 import type { RRDataRouter, RRLocation, RRMatch, RRRouterState } from './vendor/reactRouterTypes';
 
@@ -34,8 +34,9 @@ export function routeNameFromMatches(matches: RRMatch[] | undefined): string | u
 export function traceReactRouter(router: RRDataRouter): () => void {
     const nav = registerNavigationSource();
 
-    // `url` rides along on every name so a redirect hop re-stamps the root's url.full in lockstep:
-    // the root was opened from the FIRST destination and would otherwise report a URL never landed on.
+    // Every name carries the destination url so the root's url.full is updated together with it.
+    // The root opens with the first destination, so after a redirect it would otherwise report a
+    // page the user never landed on.
     const routeNameFor = (state: RRRouterState): RouteName => {
         const url = hrefOf(state.location);
         try {
@@ -47,11 +48,18 @@ export function traceReactRouter(router: RRDataRouter): () => void {
         return { name: state.location.pathname, source: 'url', url };
     };
 
-    // Same-origin SPA: reconstruct the destination href for the nav root's url.full. NOTE: for
-    // createHashRouter this does not reconstruct the fragment-encoded URL (known limitation).
-    const hrefOf = (loc: RRLocation): string => {
-        const origin = typeof window !== 'undefined' ? window.location.origin : '';
-        return origin + (loc.pathname || '') + (loc.search || '') + (loc.hash || '');
+    // `createHref` is what puts the router's `basename` back on, and what turns a hash router's
+    // location into the `#`-prefixed URL the address bar actually shows. `location.pathname` has
+    // both stripped. Fall back to the bare parts only if the router has no `createHref`.
+    const hrefOf = (loc: RRLocation): string | undefined => {
+        const bare = (loc.pathname || '') + (loc.search || '') + (loc.hash || '');
+        let href = bare;
+        try {
+            href = router.createHref?.(loc) ?? bare;
+        } catch {
+            // a router that throws on createHref still gets a url, just without the basename
+        }
+        return absoluteHref(href);
     };
 
     const keyOf = (loc: RRLocation): string => (loc.pathname || '') + (loc.search || '') + (loc.hash || '');

--- a/packages/react/src/react-router.ts
+++ b/packages/react/src/react-router.ts
@@ -34,14 +34,17 @@ export function routeNameFromMatches(matches: RRMatch[] | undefined): string | u
 export function traceReactRouter(router: RRDataRouter): () => void {
     const nav = registerNavigationSource();
 
+    // `url` rides along on every name so a redirect hop re-stamps the root's url.full in lockstep:
+    // the root was opened from the FIRST destination and would otherwise report a URL never landed on.
     const routeNameFor = (state: RRRouterState): RouteName => {
+        const url = hrefOf(state.location);
         try {
             const name = routeNameFromMatches(state.matches);
-            if (name) return { name, source: 'route' };
+            if (name) return { name, source: 'route', url };
         } catch {
             // fall through to the URL name
         }
-        return { name: state.location.pathname, source: 'url' };
+        return { name: state.location.pathname, source: 'url', url };
     };
 
     // Same-origin SPA: reconstruct the destination href for the nav root's url.full. NOTE: for

--- a/packages/react/src/tanstack-router.ts
+++ b/packages/react/src/tanstack-router.ts
@@ -14,17 +14,27 @@ import type { TsrLocation, TsrNavEvent, TsrRouter } from './vendor/tanstackRoute
 export function traceTanStackRouter(router: TsrRouter): () => void {
     const nav = registerNavigationSource();
 
+    // Same-origin SPA: TanStack's `href` is origin-relative, so prepend the origin to get a full one.
+    const hrefOf = (loc: TsrLocation): string | undefined => {
+        if (typeof window === 'undefined') return undefined;
+        return window.location.origin + (loc.href ?? loc.pathname ?? '');
+    };
+
+    // `url` rides along on every name so it re-stamps the root's url.full in lockstep. This slice
+    // opens roots without a url override (TanStack reports the destination only as a parsed
+    // location), so without the re-stamp a nav root keeps the url of the page it left.
     const routeNameFor = (loc: TsrLocation): RouteName => {
+        const url = hrefOf(loc);
         try {
             const matches = router.matchRoutes(loc.pathname, loc.search, { preload: false, throwOnError: false });
             const last = matches[matches.length - 1];
             const matched = matches.some((m) => m.routeId !== '__root__');
             const name = matched ? last?.fullPath || last?.routeId : undefined;
-            if (name) return { name, source: 'route' };
+            if (name) return { name, source: 'route', url };
         } catch {
             // fall through to the URL name
         }
-        return { name: loc.pathname, source: 'url' };
+        return { name: loc.pathname, source: 'url', url };
     };
 
     // Enrich the pageload root immediately from the current (already-resolved) location.

--- a/packages/react/src/tanstack-router.ts
+++ b/packages/react/src/tanstack-router.ts
@@ -1,7 +1,7 @@
 // Electron-safe entry: NO @flareapp/js root import. The navigation-source seam
 // comes from @flareapp/js/browser (side-effect-free). NO runtime dependency on
 // @tanstack/react-router — the router is consumed structurally (see ./vendor).
-import { insulate, registerNavigationSource, safeInvoke, type RouteName } from '@flareapp/js/browser';
+import { absoluteHref, insulate, registerNavigationSource, safeInvoke, type RouteName } from '@flareapp/js/browser';
 
 import type { TsrLocation, TsrNavEvent, TsrRouter } from './vendor/tanstackRouterTypes';
 
@@ -14,15 +14,14 @@ import type { TsrLocation, TsrNavEvent, TsrRouter } from './vendor/tanstackRoute
 export function traceTanStackRouter(router: TsrRouter): () => void {
     const nav = registerNavigationSource();
 
-    // Same-origin SPA: TanStack's `href` is origin-relative, so prepend the origin to get a full one.
-    const hrefOf = (loc: TsrLocation): string | undefined => {
-        if (typeof window === 'undefined') return undefined;
-        return window.location.origin + (loc.href ?? loc.pathname ?? '');
-    };
+    // `publicHref` is the one that matches the address bar: a `basepath` is applied as a rewrite, so
+    // an app served from `/app/` has it stripped from `href` but kept on `publicHref`. Falling back
+    // to `href` costs the basepath, which is what we reported before, so it never makes things worse.
+    const hrefOf = (loc: TsrLocation): string | undefined => absoluteHref(loc.publicHref ?? loc.href ?? loc.pathname);
 
-    // `url` rides along on every name so it re-stamps the root's url.full in lockstep. This slice
-    // opens roots without a url override (TanStack reports the destination only as a parsed
-    // location), so without the re-stamp a nav root keeps the url of the page it left.
+    // Every name carries the destination url so the root's url.full is updated together with it.
+    // Roots here open without a url of their own (TanStack reports the destination only as a parsed
+    // location), so without this a nav root would keep the url of the page it left.
     const routeNameFor = (loc: TsrLocation): RouteName => {
         const url = hrefOf(loc);
         try {

--- a/packages/react/src/vendor/reactRouterTypes.ts
+++ b/packages/react/src/vendor/reactRouterTypes.ts
@@ -18,4 +18,9 @@ export type RRRouterState = {
 export type RRDataRouter = {
     subscribe(cb: (state: RRRouterState) => void): () => void;
     state: RRRouterState;
+    /**
+     * Applies the router's `basename` (and, for a hash router, the `#` prefix) to a location.
+     * `state.location.pathname` has both stripped. Optional so a hand-built router still types.
+     */
+    createHref?(location: RRLocation): string;
 };

--- a/packages/react/src/vendor/tanstackRouterTypes.ts
+++ b/packages/react/src/vendor/tanstackRouterTypes.ts
@@ -3,9 +3,18 @@
 // the router and non-TanStack consumers of @flareapp/react type-check cleanly.
 // Verify against the pinned router version if these shapes drift.
 
-// `href` is ParsedLocation.href: pathname + search + hash, WITHOUT the origin (verified against
-// @tanstack/react-router 1.170.10). Optional so a caller passing a hand-built location still types.
-export type TsrLocation = { pathname: string; search: unknown; href?: string; state?: unknown };
+// `href` is ParsedLocation.href: pathname + search + hash, without the origin. A `basepath` is
+// applied as a rewrite, so it is stripped from `href` but kept on `publicHref`, which is the one
+// that matches the address bar. TanStack marks publicHref internal, so treat it as optional and
+// fall back to `href`; the fallback loses the basepath, which is what we did before it existed.
+// Both are optional so a caller passing a hand-built location still types.
+export type TsrLocation = {
+    pathname: string;
+    search: unknown;
+    href?: string;
+    publicHref?: string;
+    state?: unknown;
+};
 export type TsrNavEvent = { fromLocation?: TsrLocation; toLocation: TsrLocation };
 export type TsrMatch = { routeId?: string; fullPath?: string };
 

--- a/packages/react/src/vendor/tanstackRouterTypes.ts
+++ b/packages/react/src/vendor/tanstackRouterTypes.ts
@@ -3,7 +3,9 @@
 // the router and non-TanStack consumers of @flareapp/react type-check cleanly.
 // Verify against the pinned router version if these shapes drift.
 
-export type TsrLocation = { pathname: string; search: unknown; state?: unknown };
+// `href` is ParsedLocation.href: pathname + search + hash, WITHOUT the origin (verified against
+// @tanstack/react-router 1.170.10). Optional so a caller passing a hand-built location still types.
+export type TsrLocation = { pathname: string; search: unknown; href?: string; state?: unknown };
 export type TsrNavEvent = { fromLocation?: TsrLocation; toLocation: TsrLocation };
 export type TsrMatch = { routeId?: string; fullPath?: string };
 

--- a/packages/react/tests/react-router.integration.test.ts
+++ b/packages/react/tests/react-router.integration.test.ts
@@ -1,4 +1,4 @@
-import { createMemoryRouter } from 'react-router';
+import { createBrowserRouter, createHashRouter, createMemoryRouter } from 'react-router';
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -8,7 +8,9 @@ const nav = vi.hoisted(() => ({
     settleNavigation: vi.fn(),
     unregister: vi.fn(),
 }));
-vi.mock('@flareapp/js/browser', async () => (await import('@flareapp/test-helpers')).browserSeamMock(nav));
+vi.mock('@flareapp/js/browser', async (importOriginal) =>
+    (await import('@flareapp/test-helpers')).browserSeamMock(nav, await importOriginal()),
+);
 
 import { traceReactRouter } from '../src/react-router';
 import type { RRDataRouter } from '../src/vendor/reactRouterTypes';
@@ -178,5 +180,58 @@ describe('traceReactRouter against a real react-router data router', () => {
         await router.navigate('/slow');
         expect(nav.startNavigation.mock.calls.at(-1)![0]).toMatchObject({ hold: true });
         expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/slow', source: 'route', url: u('/slow') });
+    });
+});
+
+// A hash router's `location` says nothing about the `#` the address bar shows, so building the url
+// from its parts gives an address the server does not have. It has to come from `createHref`.
+// Basename routers are fine either way, because `router.state.location.pathname` keeps the basename
+// (unlike `useLocation()` in a component, which strips it) — pinned below so the fix cannot regress it.
+describe('traceReactRouter url.full follows the router', () => {
+    const baseRoutes = [{ path: '/', children: [{ index: true }, { path: 'product/:id' }] }];
+
+    it('keeps the basename an app is served from', async () => {
+        window.history.replaceState({}, '', '/app/');
+        const router = createBrowserRouter(baseRoutes, { basename: '/app' });
+        traceReactRouter(router as unknown as RRDataRouter);
+        await router.navigate('/product/p01');
+
+        expect(nav.settleNavigation).toHaveBeenLastCalledWith({
+            name: '/product/:id',
+            source: 'route',
+            url: u('/app/product/p01'),
+        });
+        expect(nav.startNavigation.mock.calls.at(-1)![0].url).toBe(u('/app/product/p01'));
+        router.dispose();
+    });
+
+    it('keeps the # of a hash-router app', async () => {
+        window.history.replaceState({}, '', '/#/');
+        const router = createHashRouter(baseRoutes);
+        traceReactRouter(router as unknown as RRDataRouter);
+        await router.navigate('/product/p01');
+
+        expect(nav.settleNavigation).toHaveBeenLastCalledWith({
+            name: '/product/:id',
+            source: 'route',
+            url: u('/#/product/p01'),
+        });
+        router.dispose();
+    });
+
+    // The pageload root opens with no url of its own, so url.full starts out as the live
+    // window.location.href, which is already right. Naming it must not replace that with a
+    // reconstruction that has the # missing.
+    it('does not damage the pageload root of a hash-router app', () => {
+        window.history.replaceState({}, '', '/#/product/p01');
+        const router = createHashRouter(baseRoutes);
+        traceReactRouter(router as unknown as RRDataRouter);
+
+        expect(nav.setActiveRouteName).toHaveBeenCalledWith({
+            name: '/product/:id',
+            source: 'route',
+            url: u('/#/product/p01'),
+        });
+        router.dispose();
     });
 });

--- a/packages/react/tests/react-router.integration.test.ts
+++ b/packages/react/tests/react-router.integration.test.ts
@@ -8,25 +8,7 @@ const nav = vi.hoisted(() => ({
     settleNavigation: vi.fn(),
     unregister: vi.fn(),
 }));
-vi.mock('@flareapp/js/browser', () => ({
-    registerNavigationSource: vi.fn(() => nav),
-    insulate:
-        (fn: (...a: unknown[]) => void) =>
-        (...a: unknown[]) => {
-            try {
-                fn(...a);
-            } catch {
-                /* swallow */
-            }
-        },
-    safeInvoke: (fn?: (() => void) | null) => {
-        try {
-            fn?.();
-        } catch {
-            /* swallow */
-        }
-    },
-}));
+vi.mock('@flareapp/js/browser', async () => (await import('@flareapp/test-helpers')).browserSeamMock(nav));
 
 import { traceReactRouter } from '../src/react-router';
 import type { RRDataRouter } from '../src/vendor/reactRouterTypes';

--- a/packages/react/tests/react-router.integration.test.ts
+++ b/packages/react/tests/react-router.integration.test.ts
@@ -45,10 +45,14 @@ beforeEach(() => {
     nav.unregister.mockClear();
 });
 
+// Every RouteName now carries the destination url, so the root's url.full tracks a redirect hop
+// instead of keeping the URL the navigation opened with. Same-origin SPA: origin + path.
+const u = (path: string): string => `${window.location.origin}${path}`;
+
 describe('traceReactRouter against a real react-router data router', () => {
     it('names the pageload index route at registration', async () => {
         await boot(['/']);
-        expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/', source: 'route' });
+        expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/', source: 'route', url: u('/') });
     });
 
     it('opens a nav root on a loader-less push and settles it with the parameterized name', async () => {
@@ -58,7 +62,11 @@ describe('traceReactRouter against a real react-router data router', () => {
         expect(nav.startNavigation.mock.calls[0]![0].path).toBe('/product/p01');
         expect(nav.startNavigation.mock.calls[0]![0].hold).toBeFalsy(); // no loader window -> no hold
         expect(nav.startNavigation.mock.calls[0]![0].url).toContain('/product/p01');
-        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/product/:id', source: 'route' });
+        expect(nav.settleNavigation).toHaveBeenLastCalledWith({
+            name: '/product/:id',
+            source: 'route',
+            url: u('/product/p01'),
+        });
     });
 
     it('stamps the exact destination url (origin + path + search) on a query-string navigation', async () => {
@@ -66,7 +74,11 @@ describe('traceReactRouter against a real react-router data router', () => {
         await router.navigate('/product/p01?tab=specs');
         expect(nav.startNavigation).toHaveBeenCalledTimes(1);
         expect(nav.startNavigation.mock.calls[0]![0].url).toBe(`${window.location.origin}/product/p01?tab=specs`);
-        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/product/:id', source: 'route' });
+        expect(nav.settleNavigation).toHaveBeenLastCalledWith({
+            name: '/product/:id',
+            source: 'route',
+            url: u('/product/p01?tab=specs'),
+        });
     });
 
     it('detects a same-pathname search-only change as a navigation', async () => {
@@ -97,19 +109,28 @@ describe('traceReactRouter against a real react-router data router', () => {
         expect(nav.settleNavigation).toHaveBeenLastCalledWith({
             name: '/stores/:storeId/products/:productId',
             source: 'route',
+            url: u('/stores/s1/products/p9'),
         });
     });
 
     it('keeps splats', async () => {
         const { router } = await boot();
         await router.navigate('/files/a/b');
-        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/files/*', source: 'route' });
+        expect(nav.settleNavigation).toHaveBeenLastCalledWith({
+            name: '/files/*',
+            source: 'route',
+            url: u('/files/a/b'),
+        });
     });
 
     it('resolves an absolute-path child route', async () => {
         const { router } = await boot();
         await router.navigate('/dashboard/settings');
-        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/dashboard/settings', source: 'route' });
+        expect(nav.settleNavigation).toHaveBeenLastCalledWith({
+            name: '/dashboard/settings',
+            source: 'route',
+            url: u('/dashboard/settings'),
+        });
     });
 
     it('handles a REPLACE navigation (not dropped)', async () => {
@@ -117,7 +138,11 @@ describe('traceReactRouter against a real react-router data router', () => {
         nav.startNavigation.mockClear();
         await router.navigate('/product/p02', { replace: true });
         expect(nav.startNavigation).toHaveBeenCalledTimes(1);
-        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/product/:id', source: 'route' });
+        expect(nav.settleNavigation).toHaveBeenLastCalledWith({
+            name: '/product/:id',
+            source: 'route',
+            url: u('/product/p02'),
+        });
     });
 
     it('handles a POP back-navigation', async () => {
@@ -126,7 +151,7 @@ describe('traceReactRouter against a real react-router data router', () => {
         nav.startNavigation.mockClear();
         await router.navigate(-1); // back to the index route
         expect(nav.startNavigation).toHaveBeenCalledTimes(1);
-        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/', source: 'route' });
+        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/', source: 'route', url: u('/') });
     });
 
     it('handles a form-action submission (submitting state) as one held root named for its destination', async () => {
@@ -134,7 +159,7 @@ describe('traceReactRouter against a real react-router data router', () => {
         await router.navigate('/submit', { formMethod: 'post', formData: new FormData() });
         expect(nav.startNavigation).toHaveBeenCalledTimes(1);
         expect(nav.startNavigation.mock.calls[0]![0].hold).toBe(true); // submitting is a non-idle, loader-shape nav
-        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/submit', source: 'route' });
+        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/submit', source: 'route', url: u('/submit') });
     });
 
     it('names a navigation with an async loader (hold is requested)', async () => {
@@ -152,6 +177,6 @@ describe('traceReactRouter against a real react-router data router', () => {
         router.initialize(); // loader-less index settles synchronously
         await router.navigate('/slow');
         expect(nav.startNavigation.mock.calls.at(-1)![0]).toMatchObject({ hold: true });
-        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/slow', source: 'route' });
+        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/slow', source: 'route', url: u('/slow') });
     });
 });

--- a/packages/react/tests/react-router.test.ts
+++ b/packages/react/tests/react-router.test.ts
@@ -7,25 +7,7 @@ const nav = vi.hoisted(() => ({
     settleNavigation: vi.fn(),
     unregister: vi.fn(),
 }));
-vi.mock('@flareapp/js/browser', () => ({
-    registerNavigationSource: vi.fn(() => nav),
-    insulate:
-        (fn: (...a: unknown[]) => void) =>
-        (...a: unknown[]) => {
-            try {
-                fn(...a);
-            } catch {
-                /* swallow */
-            }
-        },
-    safeInvoke: (fn?: (() => void) | null) => {
-        try {
-            fn?.();
-        } catch {
-            /* swallow */
-        }
-    },
-}));
+vi.mock('@flareapp/js/browser', async () => (await import('@flareapp/test-helpers')).browserSeamMock(nav));
 
 import { routeNameFromMatches, traceReactRouter } from '../src/react-router';
 import type { RRMatch, RRRouterState } from '../src/vendor/reactRouterTypes';

--- a/packages/react/tests/react-router.test.ts
+++ b/packages/react/tests/react-router.test.ts
@@ -7,7 +7,9 @@ const nav = vi.hoisted(() => ({
     settleNavigation: vi.fn(),
     unregister: vi.fn(),
 }));
-vi.mock('@flareapp/js/browser', async () => (await import('@flareapp/test-helpers')).browserSeamMock(nav));
+vi.mock('@flareapp/js/browser', async (importOriginal) =>
+    (await import('@flareapp/test-helpers')).browserSeamMock(nav, await importOriginal()),
+);
 
 import { routeNameFromMatches, traceReactRouter } from '../src/react-router';
 import type { RRMatch, RRRouterState } from '../src/vendor/reactRouterTypes';

--- a/packages/react/tests/react-router.test.ts
+++ b/packages/react/tests/react-router.test.ts
@@ -87,11 +87,19 @@ describe('routeNameFromMatches', () => {
     });
 });
 
+// Every RouteName now carries the destination url so a redirect hop re-stamps the root's url.full.
+// These fake locations carry only a pathname, so hrefOf reconstructs origin + pathname.
+const u = (path: string): string => `${window.location.origin}${path}`;
+
 describe('traceReactRouter', () => {
     it('names the pageload root from the current matches at registration', () => {
         const { router } = fakeRouter({ matches: PRODUCT_MATCHES, location: { pathname: '/product/p01' } });
         traceReactRouter(router);
-        expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/product/:id', source: 'route' });
+        expect(nav.setActiveRouteName).toHaveBeenCalledWith({
+            name: '/product/:id',
+            source: 'route',
+            url: u('/product/p01'),
+        });
     });
 
     it('defers pageload naming to the settle when matches are empty at registration, opening no nav root', () => {
@@ -99,7 +107,11 @@ describe('traceReactRouter', () => {
         traceReactRouter(router);
         expect(nav.setActiveRouteName).not.toHaveBeenCalled();
         emit({ initialized: true, matches: PRODUCT_MATCHES, location: { pathname: '/product/p01' } });
-        expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/product/:id', source: 'route' });
+        expect(nav.setActiveRouteName).toHaveBeenCalledWith({
+            name: '/product/:id',
+            source: 'route',
+            url: u('/product/p01'),
+        });
         expect(nav.startNavigation).not.toHaveBeenCalled();
     });
 
@@ -111,7 +123,11 @@ describe('traceReactRouter', () => {
         });
         traceReactRouter(router);
         // Named now from the synchronously-resolved matches, not deferred to a later fire.
-        expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/product/:id', source: 'route' });
+        expect(nav.setActiveRouteName).toHaveBeenCalledWith({
+            name: '/product/:id',
+            source: 'route',
+            url: u('/product/p01'),
+        });
         nav.setActiveRouteName.mockClear();
         // The initialize settle (same location) may re-name but must open no navigation root.
         emit({ initialized: true, matches: PRODUCT_MATCHES, location: { pathname: '/product/p01' } });
@@ -128,7 +144,11 @@ describe('traceReactRouter', () => {
             matches: PRODUCT_MATCHES,
             location: { pathname: '/product/p01' },
         });
-        expect(nav.setActiveRouteName).toHaveBeenLastCalledWith({ name: '/product/:id', source: 'route' });
+        expect(nav.setActiveRouteName).toHaveBeenLastCalledWith({
+            name: '/product/:id',
+            source: 'route',
+            url: u('/product/p01'),
+        });
         expect(nav.startNavigation).not.toHaveBeenCalled();
     });
 
@@ -149,7 +169,11 @@ describe('traceReactRouter', () => {
             matches: PRODUCT_MATCHES,
             location: { pathname: '/product/p01' },
         });
-        expect(nav.settleNavigation).toHaveBeenCalledWith({ name: '/product/:id', source: 'route' });
+        expect(nav.settleNavigation).toHaveBeenCalledWith({
+            name: '/product/:id',
+            source: 'route',
+            url: u('/product/p01'),
+        });
     });
 
     it('detects a loader-less navigation (single idle fire, no loading state) via the committed location', () => {
@@ -164,7 +188,11 @@ describe('traceReactRouter', () => {
         expect(nav.startNavigation).toHaveBeenCalledTimes(1);
         expect(nav.startNavigation.mock.calls[0]![0].path).toBe('/product/p01');
         expect(nav.startNavigation.mock.calls[0]![0].hold).toBeFalsy(); // no loader window -> no hold
-        expect(nav.settleNavigation).toHaveBeenCalledWith({ name: '/product/:id', source: 'route' });
+        expect(nav.settleNavigation).toHaveBeenCalledWith({
+            name: '/product/:id',
+            source: 'route',
+            url: u('/product/p01'),
+        });
     });
 
     it('does not double-open on a follow-up same-location fire (scroll restoration etc.)', () => {
@@ -193,7 +221,7 @@ describe('traceReactRouter', () => {
             location: { pathname: '/b' },
         });
         expect(nav.settleNavigation).toHaveBeenCalledTimes(1);
-        expect(nav.settleNavigation).toHaveBeenCalledWith({ name: '/b', source: 'route' });
+        expect(nav.settleNavigation).toHaveBeenCalledWith({ name: '/b', source: 'route', url: u('/b') });
     });
 
     it('falls back to the URL name when matches yield nothing', () => {
@@ -205,7 +233,7 @@ describe('traceReactRouter', () => {
             matches: [{ route: {}, pathname: '/nope' }],
             location: { pathname: '/nope' },
         });
-        expect(nav.settleNavigation).toHaveBeenCalledWith({ name: '/nope', source: 'url' });
+        expect(nav.settleNavigation).toHaveBeenCalledWith({ name: '/nope', source: 'url', url: u('/nope') });
     });
 
     it('opens no nav root for revalidation (navigation.state stays idle)', () => {

--- a/packages/react/tests/tanstack-router.test.ts
+++ b/packages/react/tests/tanstack-router.test.ts
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const nav = vi.hoisted(() => ({
     startNavigation: vi.fn(),
     setActiveRouteName: vi.fn(),
+    settleNavigation: vi.fn(),
     unregister: vi.fn(),
 }));
 vi.mock('@flareapp/js/browser', async () => (await import('@flareapp/test-helpers')).browserSeamMock(nav));

--- a/packages/react/tests/tanstack-router.test.ts
+++ b/packages/react/tests/tanstack-router.test.ts
@@ -34,11 +34,20 @@ beforeEach(() => {
     nav.unregister.mockClear();
 });
 
+// Every RouteName now carries the destination url so the root's url.full tracks redirect hops. These
+// fakes omit TanStack's `href`, so hrefOf falls back to origin + pathname (the `href` shape is
+// pinned separately below).
+const u = (path: string): string => `${window.location.origin}${path}`;
+
 describe('traceTanStackRouter', () => {
     it('enriches the pageload root from the current location at registration', () => {
         const { router } = fakeRouter({ location: { pathname: '/product/p01', search: {} } });
         traceTanStackRouter(router);
-        expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/product/$id', source: 'route' });
+        expect(nav.setActiveRouteName).toHaveBeenCalledWith({
+            name: '/product/$id',
+            source: 'route',
+            url: u('/product/p01'),
+        });
     });
 
     it('corrects the pageload name on the initial onResolved (loader redirect), no nav root', () => {
@@ -50,7 +59,7 @@ describe('traceTanStackRouter', () => {
             { routeId: '/login', fullPath: '/login' },
         ]);
         emit('onResolved', { fromLocation: undefined, toLocation: { pathname: '/login', search: {} } });
-        expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/login', source: 'route' });
+        expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/login', source: 'route', url: u('/login') });
         expect(nav.startNavigation).not.toHaveBeenCalled();
     });
 
@@ -62,9 +71,17 @@ describe('traceTanStackRouter', () => {
         const to = { pathname: '/product/p01', search: {}, state: {} };
         emit('onBeforeLoad', { fromLocation: from, toLocation: to });
         expect(nav.startNavigation).toHaveBeenCalledWith({ path: '/product/p01' });
-        expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/product/$id', source: 'route' });
+        expect(nav.setActiveRouteName).toHaveBeenCalledWith({
+            name: '/product/$id',
+            source: 'route',
+            url: u('/product/p01'),
+        });
         emit('onResolved', { fromLocation: from, toLocation: to });
-        expect(nav.setActiveRouteName).toHaveBeenLastCalledWith({ name: '/product/$id', source: 'route' });
+        expect(nav.setActiveRouteName).toHaveBeenLastCalledWith({
+            name: '/product/$id',
+            source: 'route',
+            url: u('/product/p01'),
+        });
     });
 
     it('skips the initial pageload onBeforeLoad', () => {
@@ -102,7 +119,7 @@ describe('traceTanStackRouter', () => {
         emit('onBeforeLoad', { fromLocation: from, toLocation: { pathname: '/b', search: {}, state: {} } });
         expect(nav.startNavigation).toHaveBeenCalledTimes(1);
         emit('onResolved', { fromLocation: from, toLocation: { pathname: '/b', search: {}, state: {} } });
-        expect(nav.setActiveRouteName).toHaveBeenLastCalledWith({ name: '/b', source: 'route' });
+        expect(nav.setActiveRouteName).toHaveBeenLastCalledWith({ name: '/b', source: 'route', url: u('/b') });
     });
 
     it('falls back to the URL name when only __root__ matches', () => {
@@ -114,7 +131,7 @@ describe('traceTanStackRouter', () => {
             fromLocation: { pathname: '/', search: {}, state: {} },
             toLocation: { pathname: '/nope', search: {}, state: {} },
         });
-        expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/nope', source: 'url' });
+        expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/nope', source: 'url', url: u('/nope') });
     });
 
     it('falls back to routeId when fullPath is empty', () => {
@@ -129,7 +146,29 @@ describe('traceTanStackRouter', () => {
             fromLocation: { pathname: '/', search: {}, state: {} },
             toLocation: { pathname: '/layout', search: {}, state: {} },
         });
-        expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/layout', source: 'route' });
+        expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/layout', source: 'route', url: u('/layout') });
+    });
+
+    // TanStack's real ParsedLocation.href is pathname + search + hash WITHOUT the origin, so the
+    // integration must prepend it. Taking `pathname` instead would silently drop the query string.
+    it("builds the url from TanStack's origin-relative href, not the bare pathname", () => {
+        const { router, emit } = fakeRouter();
+        traceTanStackRouter(router);
+        nav.setActiveRouteName.mockClear();
+        emit('onBeforeLoad', {
+            fromLocation: { pathname: '/', search: {}, href: '/', state: {} },
+            toLocation: {
+                pathname: '/product/p01',
+                search: { tab: 'specs' },
+                href: '/product/p01?tab=specs',
+                state: {},
+            },
+        });
+        expect(nav.setActiveRouteName).toHaveBeenCalledWith({
+            name: '/product/$id',
+            source: 'route',
+            url: u('/product/p01?tab=specs'),
+        });
     });
 
     it('cleanup unsubscribes and unregisters', () => {
@@ -154,6 +193,6 @@ describe('traceTanStackRouter', () => {
                 toLocation: { pathname: '/kaboom', search: {}, state: {} },
             }),
         ).not.toThrow();
-        expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/kaboom', source: 'url' });
+        expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/kaboom', source: 'url', url: u('/kaboom') });
     });
 });

--- a/packages/react/tests/tanstack-router.test.ts
+++ b/packages/react/tests/tanstack-router.test.ts
@@ -7,7 +7,9 @@ const nav = vi.hoisted(() => ({
     settleNavigation: vi.fn(),
     unregister: vi.fn(),
 }));
-vi.mock('@flareapp/js/browser', async () => (await import('@flareapp/test-helpers')).browserSeamMock(nav));
+vi.mock('@flareapp/js/browser', async (importOriginal) =>
+    (await import('@flareapp/test-helpers')).browserSeamMock(nav, await importOriginal()),
+);
 
 import { traceTanStackRouter } from '../src/tanstack-router';
 import type { TsrMatch } from '../src/vendor/tanstackRouterTypes';
@@ -149,8 +151,8 @@ describe('traceTanStackRouter', () => {
         expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/layout', source: 'route', url: u('/layout') });
     });
 
-    // TanStack's real ParsedLocation.href is pathname + search + hash WITHOUT the origin, so the
-    // integration must prepend it. Taking `pathname` instead would silently drop the query string.
+    // TanStack's real ParsedLocation.href is pathname + search + hash without the origin. Taking
+    // `pathname` instead would silently drop the query string.
     it("builds the url from TanStack's origin-relative href, not the bare pathname", () => {
         const { router, emit } = fakeRouter();
         traceTanStackRouter(router);
@@ -194,5 +196,54 @@ describe('traceTanStackRouter', () => {
             }),
         ).not.toThrow();
         expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/kaboom', source: 'url', url: u('/kaboom') });
+    });
+});
+
+// A `basepath` is applied as a rewrite, so it is stripped from `href` and kept only on `publicHref`.
+// Reading `href` for an app served from `/app/` reports `/product/p01` for the real
+// `/app/product/p01`: an address the server does not have, and one that overwrites the correct
+// url.full the pageload root already had.
+describe('traceTanStackRouter url.full keeps the basepath', () => {
+    it('prefers publicHref over the rewritten href', () => {
+        const { router, emit } = fakeRouter();
+        traceTanStackRouter(router);
+        nav.setActiveRouteName.mockClear();
+        emit('onBeforeLoad', {
+            fromLocation: { pathname: '/', search: {}, href: '/', publicHref: '/app/', state: {} },
+            toLocation: {
+                pathname: '/product/p01',
+                search: {},
+                href: '/product/p01',
+                publicHref: '/app/product/p01',
+                state: {},
+            },
+        });
+        expect(nav.setActiveRouteName).toHaveBeenCalledWith({
+            name: '/product/$id',
+            source: 'route',
+            url: u('/app/product/p01'),
+        });
+    });
+
+    // No basepath means no rewrite, and then TanStack sets publicHref and href to the same value.
+    it('is unchanged when the two agree', () => {
+        const { router, emit } = fakeRouter();
+        traceTanStackRouter(router);
+        nav.setActiveRouteName.mockClear();
+        emit('onBeforeLoad', {
+            fromLocation: { pathname: '/', search: {}, href: '/', publicHref: '/', state: {} },
+            toLocation: {
+                pathname: '/product/p01',
+                search: {},
+                href: '/product/p01',
+                publicHref: '/product/p01',
+                state: {},
+            },
+        });
+        expect(nav.setActiveRouteName).toHaveBeenCalledWith({
+            name: '/product/$id',
+            source: 'route',
+            url: u('/product/p01'),
+        });
     });
 });

--- a/packages/react/tests/tanstack-router.test.ts
+++ b/packages/react/tests/tanstack-router.test.ts
@@ -6,25 +6,7 @@ const nav = vi.hoisted(() => ({
     setActiveRouteName: vi.fn(),
     unregister: vi.fn(),
 }));
-vi.mock('@flareapp/js/browser', () => ({
-    registerNavigationSource: vi.fn(() => nav),
-    insulate:
-        (fn: (...a: unknown[]) => void) =>
-        (...a: unknown[]) => {
-            try {
-                fn(...a);
-            } catch {
-                /* swallow */
-            }
-        },
-    safeInvoke: (fn?: (() => void) | null) => {
-        try {
-            fn?.();
-        } catch {
-            /* swallow */
-        }
-    },
-}));
+vi.mock('@flareapp/js/browser', async () => (await import('@flareapp/test-helpers')).browserSeamMock(nav));
 
 import { traceTanStackRouter } from '../src/tanstack-router';
 import type { TsrMatch } from '../src/vendor/tanstackRouterTypes';

--- a/packages/sveltekit/package.json
+++ b/packages/sveltekit/package.json
@@ -63,9 +63,11 @@
     "devDependencies": {
         "@flareapp/js": "file:../js",
         "@flareapp/svelte": "file:../svelte",
+        "@flareapp/test-helpers": "*",
         "@sveltejs/kit": "^2.0.0",
         "@sveltejs/package": "^2.5.7",
         "@sveltejs/vite-plugin-svelte": "^5.0.0",
+        "jsdom": "^26.1.0",
         "svelte": "^5.0.0",
         "typescript": "^5.7.0",
         "vitest": "^4.0.0"

--- a/packages/sveltekit/src/client/app-state.d.ts
+++ b/packages/sveltekit/src/client/app-state.d.ts
@@ -4,4 +4,12 @@ declare module '$app/state' {
         params: Record<string, string>;
         route: { id: string | null };
     };
+    const navigating: {
+        from: { url: URL; route: { id: string | null } } | null;
+        to: { url: URL; route: { id: string | null } } | null;
+        type: 'form' | 'leave' | 'link' | 'goto' | 'popstate' | null;
+        willUnload: boolean;
+        delta: number | null;
+        complete: Promise<void> | null;
+    };
 }

--- a/packages/sveltekit/src/client/index.ts
+++ b/packages/sveltekit/src/client/index.ts
@@ -1,5 +1,6 @@
 export { handleErrorWithFlare } from './handleError.js';
 export { captureError } from './captureError.js';
 export { trackRouteContext } from './trackRouteContext.svelte.js';
+export { traceSvelteKitRouter } from './traceSvelteKitRouter.svelte.js';
 export type { CaptureErrorOptions } from '../captureError.js';
 export type { HandleErrorWithFlareOptions } from '../types.js';

--- a/packages/sveltekit/src/client/traceSvelteKitRouter.svelte.ts
+++ b/packages/sveltekit/src/client/traceSvelteKitRouter.svelte.ts
@@ -1,0 +1,72 @@
+import { navigating, page } from '$app/state';
+import { flare } from '@flareapp/js';
+import {
+    insulate,
+    registerNavigationSource,
+    safeInvoke,
+    type NavigationSource,
+    type RouteName,
+} from '@flareapp/js/browser';
+
+/** One observation of Kit's router state. Plain data: no runes, no `$app/state` coupling. */
+export type NavSnapshot = {
+    to: { url: URL; route?: { id: string | null } } | null;
+    willUnload: boolean;
+    routeId: string | null | undefined;
+    url: URL;
+};
+
+let tracing = false;
+let nav: NavigationSource | null = null;
+// oxlint-disable-next-line no-unused-vars
+let inFlight = false;
+// oxlint-disable-next-line no-unused-vars
+let lastKey = '';
+
+// Hash excluded on purpose: Kit's hash navigation reassigns `page.url` without running a real
+// navigation, and a hash-keyed comparison would fabricate a root for it.
+// oxlint-disable-next-line no-unused-vars
+const keyOf = (url: URL): string => url.pathname + url.search;
+
+// oxlint-disable-next-line no-unused-vars
+const routeNameFor = (routeId: string | null | undefined, url: URL): RouteName =>
+    routeId ? { name: routeId, source: 'route' } : { name: url.pathname, source: 'url' };
+
+/** Advance the state machine for one observed snapshot. Exported for unit tests; not public API. */
+export function syncNavigation(snapshot: NavSnapshot): void {
+    if (!nav) return;
+    if (!flare.config?.enableTracing) return; // branch 0
+    if (snapshot.url.origin !== location.origin) return; // branch 1: Kit's `a:` placeholder
+    // branches 2-7 arrive in Task 3
+}
+
+export function traceSvelteKitRouter(): () => void {
+    if (tracing || typeof window === 'undefined') return () => {};
+    tracing = true;
+
+    nav = registerNavigationSource();
+    inFlight = false;
+    lastKey = location.pathname + location.search;
+
+    const dispose = $effect.root(() => {
+        $effect(
+            insulate(() =>
+                // The reads ARE the body. No control flow here: Svelte tracks dependencies as they
+                // are read, so an early return above any read would stop the effect re-running.
+                syncNavigation({
+                    to: navigating.to,
+                    willUnload: navigating.willUnload,
+                    routeId: page.route?.id,
+                    url: page.url,
+                }),
+            ),
+        );
+    });
+
+    return () => {
+        safeInvoke(dispose);
+        safeInvoke(() => nav?.unregister());
+        nav = null;
+        tracing = false;
+    };
+}

--- a/packages/sveltekit/src/client/traceSvelteKitRouter.svelte.ts
+++ b/packages/sveltekit/src/client/traceSvelteKitRouter.svelte.ts
@@ -18,17 +18,13 @@ export type NavSnapshot = {
 
 let tracing = false;
 let nav: NavigationSource | null = null;
-// oxlint-disable-next-line no-unused-vars
 let inFlight = false;
-// oxlint-disable-next-line no-unused-vars
 let lastKey = '';
 
 // Hash excluded on purpose: Kit's hash navigation reassigns `page.url` without running a real
 // navigation, and a hash-keyed comparison would fabricate a root for it.
-// oxlint-disable-next-line no-unused-vars
 const keyOf = (url: URL): string => url.pathname + url.search;
 
-// oxlint-disable-next-line no-unused-vars
 const routeNameFor = (routeId: string | null | undefined, url: URL): RouteName =>
     routeId ? { name: routeId, source: 'route' } : { name: url.pathname, source: 'url' };
 
@@ -37,7 +33,45 @@ export function syncNavigation(snapshot: NavSnapshot): void {
     if (!nav) return;
     if (!flare.config?.enableTracing) return; // branch 0
     if (snapshot.url.origin !== location.origin) return; // branch 1: Kit's `a:` placeholder
-    // branches 2-7 arrive in Task 3
+
+    const to = snapshot.to;
+    if (to) {
+        const toRouteId = to.route?.id;
+        // branch 2: `willUnload` is `!intent` and `to.route.id` is `intent?.route?.id ?? null`, so
+        // these are one condition. The document is about to unload; its pageload will cover it.
+        if (snapshot.willUnload || toRouteId == null) return;
+
+        if (!inFlight) {
+            // branch 3: Kit emits this BEFORE the URL commits, so pass the destination explicitly.
+            inFlight = true;
+            nav.startNavigation({ path: to.url.pathname, url: to.url.href, hold: true });
+        }
+        // branch 3 + 4: re-set across redirect hops, which re-emit without an intervening null.
+        nav.setActiveRouteName(routeNameFor(toRouteId, to.url));
+        return;
+    }
+
+    if (inFlight) {
+        // branch 5: `page` is fully committed by now (Kit calls update() at client.js:1941, well
+        // before it nulls `navigating` at :2023), so name from the committed route.
+        inFlight = false;
+        lastKey = keyOf(snapshot.url);
+        nav.settleNavigation(routeNameFor(snapshot.routeId, snapshot.url));
+        return;
+    }
+
+    const key = keyOf(snapshot.url);
+    if (key === lastKey) {
+        // branch 6: pageload naming, and late-resolving route ids.
+        nav.setActiveRouteName(routeNameFor(snapshot.routeId, snapshot.url));
+        return;
+    }
+
+    // branch 7: the committed location moved with no observed `navigating` emission. Expected to be
+    // dead code; it exists so a coalesced effect degrades to an instant root instead of no root.
+    lastKey = key;
+    nav.startNavigation({ path: snapshot.url.pathname, url: snapshot.url.href });
+    nav.settleNavigation(routeNameFor(snapshot.routeId, snapshot.url));
 }
 
 export function traceSvelteKitRouter(): () => void {

--- a/packages/sveltekit/src/client/traceSvelteKitRouter.svelte.ts
+++ b/packages/sveltekit/src/client/traceSvelteKitRouter.svelte.ts
@@ -31,7 +31,12 @@ const routeNameFor = (routeId: string | null | undefined, url: URL): RouteName =
 /** Advance the state machine for one observed snapshot. Exported for unit tests; not public API. */
 export function syncNavigation(snapshot: NavSnapshot): void {
     if (!nav) return;
-    if (!flare.config?.enableTracing) return; // branch 0
+    if (!flare.config?.enableTracing) {
+        // A settle can never arrive while tracing is off, so the latch must not persist across the
+        // toggle: otherwise a held root is stranded and the next navigation opens no root at all.
+        inFlight = false;
+        return; // branch 0
+    }
     if (snapshot.url.origin !== location.origin) return; // branch 1: Kit's `a:` placeholder
 
     const to = snapshot.to;

--- a/packages/sveltekit/src/client/traceSvelteKitRouter.svelte.ts
+++ b/packages/sveltekit/src/client/traceSvelteKitRouter.svelte.ts
@@ -21,53 +21,55 @@ let nav: NavigationSource | null = null;
 let inFlight = false;
 let lastKey = '';
 
-// Hash excluded on purpose: Kit's hash navigation reassigns `page.url` without running a real
-// navigation, and a hash-keyed comparison would fabricate a root for it.
+// The hash is left out on purpose. A hash change updates `page.url` without a real navigation, so
+// including it would open a root for a page that never moved.
 const keyOf = (url: URL): string => url.pathname + url.search;
 
-// `url` rides along on every name so a redirect hop re-stamps the root's url.full in lockstep: the
-// root was opened from the FIRST destination and would otherwise report a URL never landed on.
+// Every name carries the destination url so the root's url.full is updated together with it. The
+// root opens with the first destination, so after a redirect it would otherwise report a page the
+// user never landed on.
 const routeNameFor = (routeId: string | null | undefined, url: URL): RouteName =>
     routeId ? { name: routeId, source: 'route', url: url.href } : { name: url.pathname, source: 'url', url: url.href };
 
 /** Advance the state machine for one observed snapshot. Exported for unit tests; not public API. */
 export function syncNavigation(snapshot: NavSnapshot): void {
     if (!nav) return;
-    // branch 1: Kit's `a:` placeholder. Checked BEFORE the tracing gate because it is not a real
-    // location: its pathname is empty, so letting it reach the lastKey stamp below would poison the
-    // key and make the next real snapshot look like a move.
+    // Kit's `a:` placeholder url, which it uses before hydration. Its origin is not ours, and it has
+    // no pathname. Checked before the tracing gate because it is not a real page: storing it as
+    // lastKey would make the next real snapshot look like a navigation.
     if (snapshot.url.origin !== location.origin) return;
     if (!flare.config?.enableTracing) {
-        // A settle can never arrive while tracing is off, so the latch must not persist across the
-        // toggle: otherwise a held root is stranded and the next navigation opens no root at all.
+        // No settle can arrive while tracing is off, so clear the flag. If it stayed set, the next
+        // navigation would think one was already running and open no root.
         inFlight = false;
-        // Keep tracking the committed location too. Without this the key goes stale for every
-        // navigation made while tracing was off, and the first idle snapshot after it flips back on
-        // reads as a move and fabricates a branch-7 root for a page that never navigated.
+        // Keep following the current page as well. Otherwise the key goes stale during every
+        // navigation made while tracing was off, and the first snapshot after it comes back on looks
+        // like a navigation and opens a root for a page that never moved.
         lastKey = keyOf(snapshot.url);
-        return; // branch 0
+        return;
     }
 
     const to = snapshot.to;
     if (to) {
         const toRouteId = to.route?.id;
-        // branch 2: `willUnload` is `!intent` and `to.route.id` is `intent?.route?.id ?? null`, so
-        // these are one condition. The document is about to unload; its pageload will cover it.
+        // The document is about to unload, so the next pageload will cover this. Kit derives both of
+        // these from the same missing intent, which is why one check covers both.
         if (snapshot.willUnload || toRouteId == null) return;
 
         if (!inFlight) {
-            // branch 3: Kit emits this BEFORE the URL commits, so pass the destination explicitly.
+            // Kit tells us where it is going before the URL changes, so pass the destination along.
             inFlight = true;
             nav.startNavigation({ path: to.url.pathname, url: to.url.href, hold: true });
         }
-        // branch 3 + 4: re-set across redirect hops, which re-emit without an intervening null.
+        // Set again on every hop of a redirect. Kit gives each hop a new destination without going
+        // back to null in between, so the same root just gets renamed.
         nav.setActiveRouteName(routeNameFor(toRouteId, to.url));
         return;
     }
 
     if (inFlight) {
-        // branch 5: `page` is fully committed by now (Kit calls update() at client.js:1941, well
-        // before it nulls `navigating` at :2023), so name from the committed route.
+        // `page` has caught up by now: Kit updates it before it clears `navigating`, so name the
+        // root from the route we landed on.
         inFlight = false;
         lastKey = keyOf(snapshot.url);
         nav.settleNavigation(routeNameFor(snapshot.routeId, snapshot.url));
@@ -76,13 +78,13 @@ export function syncNavigation(snapshot: NavSnapshot): void {
 
     const key = keyOf(snapshot.url);
     if (key === lastKey) {
-        // branch 6: pageload naming, and late-resolving route ids.
+        // Naming the pageload, and picking up a route id that resolved late.
         nav.setActiveRouteName(routeNameFor(snapshot.routeId, snapshot.url));
         return;
     }
 
-    // branch 7: the committed location moved with no observed `navigating` emission. Expected to be
-    // dead code; it exists so a coalesced effect degrades to an instant root instead of no root.
+    // The page moved without us seeing a navigation. This is here so that if Svelte ever runs the
+    // two updates together we still report a root, even though it will have no duration.
     lastKey = key;
     nav.startNavigation({ path: snapshot.url.pathname, url: snapshot.url.href });
     nav.settleNavigation(routeNameFor(snapshot.routeId, snapshot.url));
@@ -105,8 +107,8 @@ export function traceSvelteKitRouter(): () => void {
     tracing = true;
 
     let dispose: (() => void) | undefined;
-    // Wiring runs inside the guard because hooks.client.ts calls this at module scope: a throw here
-    // would take down client boot, not just tracing. The effect body has its own `insulate`.
+    // hooks.client.ts calls this while the module loads, so a throw here would take down the whole
+    // client, not just tracing. The effect body guards itself with `insulate`.
     safeInvoke(() => {
         nav = registerNavigationSource();
         inFlight = false;
@@ -122,13 +124,14 @@ export function traceSvelteKitRouter(): () => void {
     };
 }
 
-/** The reactive half: one `$effect.root` feeding observed snapshots to the pure state machine. */
+/** The reactive half: one `$effect.root` feeding what it sees to the state machine above. */
 function startEffect(): () => void {
     return $effect.root(() => {
         $effect(
             insulate(() =>
-                // The reads ARE the body. No control flow here: Svelte tracks dependencies as they
-                // are read, so an early return above any read would stop the effect re-running.
+                // The reads are the whole body on purpose. Svelte only re-runs an effect for the
+                // values it saw it read, so an early return above any of these would stop it
+                // running again.
                 syncNavigation({
                     to: navigating.to,
                     willUnload: navigating.willUnload,

--- a/packages/sveltekit/src/client/traceSvelteKitRouter.svelte.ts
+++ b/packages/sveltekit/src/client/traceSvelteKitRouter.svelte.ts
@@ -25,19 +25,28 @@ let lastKey = '';
 // navigation, and a hash-keyed comparison would fabricate a root for it.
 const keyOf = (url: URL): string => url.pathname + url.search;
 
+// `url` rides along on every name so a redirect hop re-stamps the root's url.full in lockstep: the
+// root was opened from the FIRST destination and would otherwise report a URL never landed on.
 const routeNameFor = (routeId: string | null | undefined, url: URL): RouteName =>
-    routeId ? { name: routeId, source: 'route' } : { name: url.pathname, source: 'url' };
+    routeId ? { name: routeId, source: 'route', url: url.href } : { name: url.pathname, source: 'url', url: url.href };
 
 /** Advance the state machine for one observed snapshot. Exported for unit tests; not public API. */
 export function syncNavigation(snapshot: NavSnapshot): void {
     if (!nav) return;
+    // branch 1: Kit's `a:` placeholder. Checked BEFORE the tracing gate because it is not a real
+    // location: its pathname is empty, so letting it reach the lastKey stamp below would poison the
+    // key and make the next real snapshot look like a move.
+    if (snapshot.url.origin !== location.origin) return;
     if (!flare.config?.enableTracing) {
         // A settle can never arrive while tracing is off, so the latch must not persist across the
         // toggle: otherwise a held root is stranded and the next navigation opens no root at all.
         inFlight = false;
+        // Keep tracking the committed location too. Without this the key goes stale for every
+        // navigation made while tracing was off, and the first idle snapshot after it flips back on
+        // reads as a move and fabricates a branch-7 root for a page that never navigated.
+        lastKey = keyOf(snapshot.url);
         return; // branch 0
     }
-    if (snapshot.url.origin !== location.origin) return; // branch 1: Kit's `a:` placeholder
 
     const to = snapshot.to;
     if (to) {
@@ -95,11 +104,27 @@ export function traceSvelteKitRouter(): () => void {
     if (tracing || typeof window === 'undefined') return () => {};
     tracing = true;
 
-    nav = registerNavigationSource();
-    inFlight = false;
-    lastKey = location.pathname + location.search;
+    let dispose: (() => void) | undefined;
+    // Wiring runs inside the guard because hooks.client.ts calls this at module scope: a throw here
+    // would take down client boot, not just tracing. The effect body has its own `insulate`.
+    safeInvoke(() => {
+        nav = registerNavigationSource();
+        inFlight = false;
+        lastKey = location.pathname + location.search;
+        dispose = startEffect();
+    });
 
-    const dispose = $effect.root(() => {
+    return () => {
+        safeInvoke(dispose);
+        safeInvoke(() => nav?.unregister());
+        nav = null;
+        tracing = false;
+    };
+}
+
+/** The reactive half: one `$effect.root` feeding observed snapshots to the pure state machine. */
+function startEffect(): () => void {
+    return $effect.root(() => {
         $effect(
             insulate(() =>
                 // The reads ARE the body. No control flow here: Svelte tracks dependencies as they
@@ -113,11 +138,4 @@ export function traceSvelteKitRouter(): () => void {
             ),
         );
     });
-
-    return () => {
-        safeInvoke(dispose);
-        safeInvoke(() => nav?.unregister());
-        nav = null;
-        tracing = false;
-    };
 }

--- a/packages/sveltekit/src/client/traceSvelteKitRouter.svelte.ts
+++ b/packages/sveltekit/src/client/traceSvelteKitRouter.svelte.ts
@@ -74,6 +74,18 @@ export function syncNavigation(snapshot: NavSnapshot): void {
     nav.settleNavigation(routeNameFor(snapshot.routeId, snapshot.url));
 }
 
+/**
+ * Trace SvelteKit's client router: name the `browser_pageload` root from the initial route, and open
+ * a parameterized, held `browser_navigation` root per client navigation. Names come from
+ * `page.route.id` verbatim (e.g. `/product/[id]`). Call once from `hooks.client.ts`. Safe to call
+ * before or after tracing is enabled; no-ops when off. Returns a cleanup that disposes the effect and
+ * unregisters.
+ *
+ * No navigation root is opened for: shallow routing (`pushState`/`replaceState` from
+ * `$app/navigation`), hash-only navigation, navigations cancelled by a `beforeNavigate` guard, or
+ * navigations to routes SvelteKit does not own (those unload the document; the next pageload covers
+ * them).
+ */
 export function traceSvelteKitRouter(): () => void {
     if (tracing || typeof window === 'undefined') return () => {};
     tracing = true;

--- a/packages/sveltekit/tests/__mocks__/app-state.svelte.ts
+++ b/packages/sveltekit/tests/__mocks__/app-state.svelte.ts
@@ -1,12 +1,15 @@
+// Stand-in for `$app/state`, aliased in vitest.config.mts. A `.svelte.ts` module so the fields are
+// real runes: a plain object would let the module under test read them, but nothing would ever
+// re-run its `$effect`, and the reads-are-the-body contract could not be tested at all.
 export const page: {
     url: URL;
     params: Record<string, string>;
     route: { id: string | null };
-} = {
+} = $state({
     url: new URL('http://localhost/'),
     params: {},
     route: { id: null },
-};
+});
 
 export const navigating: {
     from: { url: URL; route: { id: string | null } } | null;
@@ -15,11 +18,11 @@ export const navigating: {
     willUnload: boolean;
     delta: number | null;
     complete: Promise<void> | null;
-} = {
+} = $state({
     from: null,
     to: null,
     type: null,
     willUnload: false,
     delta: null,
     complete: null,
-};
+});

--- a/packages/sveltekit/tests/__mocks__/app-state.ts
+++ b/packages/sveltekit/tests/__mocks__/app-state.ts
@@ -7,3 +7,19 @@ export const page: {
     params: {},
     route: { id: null },
 };
+
+export const navigating: {
+    from: { url: URL; route: { id: string | null } } | null;
+    to: { url: URL; route: { id: string | null } } | null;
+    type: 'form' | 'leave' | 'link' | 'goto' | 'popstate' | null;
+    willUnload: boolean;
+    delta: number | null;
+    complete: Promise<void> | null;
+} = {
+    from: null,
+    to: null,
+    type: null,
+    willUnload: false,
+    delta: null,
+    complete: null,
+};

--- a/packages/sveltekit/tests/client/getRouteContext.test.ts
+++ b/packages/sveltekit/tests/client/getRouteContext.test.ts
@@ -8,7 +8,7 @@ vi.mock('@flareapp/js', () => ({
 }));
 
 const mockPage = await vi.hoisted(async () => {
-    const mod = await import('../../tests/__mocks__/app-state');
+    const mod = await import('../../tests/__mocks__/app-state.svelte');
     return mod.page;
 });
 

--- a/packages/sveltekit/tests/client/traceSvelteKitRouter.test.ts
+++ b/packages/sveltekit/tests/client/traceSvelteKitRouter.test.ts
@@ -10,8 +10,8 @@ const nav = vi.hoisted(() => ({
     unregister: vi.fn(),
 }));
 const registerNavigationSource = vi.hoisted(() => vi.fn(() => nav));
-vi.mock('@flareapp/js/browser', async () => ({
-    ...(await import('@flareapp/test-helpers')).browserSeamMock(nav),
+vi.mock('@flareapp/js/browser', async (importOriginal) => ({
+    ...(await import('@flareapp/test-helpers')).browserSeamMock(nav, await importOriginal()),
     registerNavigationSource,
 }));
 

--- a/packages/sveltekit/tests/client/traceSvelteKitRouter.test.ts
+++ b/packages/sveltekit/tests/client/traceSvelteKitRouter.test.ts
@@ -2,6 +2,8 @@
 import { flushSync } from 'svelte';
 import { beforeEach, expect, test, vi } from 'vitest';
 
+import type { NavSnapshot } from '../../src/client/traceSvelteKitRouter.svelte';
+
 const nav = vi.hoisted(() => ({
     startNavigation: vi.fn(),
     setActiveRouteName: vi.fn(),
@@ -82,4 +84,143 @@ test('cleanup disposes the effect and unregisters', async () => {
     flushSync();
     stop();
     expect(nav.unregister).toHaveBeenCalledTimes(1);
+});
+
+const PRODUCT = new URL(location.origin + '/product/p01');
+const snap = (over: Partial<NavSnapshot> = {}): NavSnapshot => ({
+    to: null,
+    willUnload: false,
+    routeId: '/',
+    url: HERE,
+    ...over,
+});
+
+async function started() {
+    const mod = await load();
+    const stop = mod.traceSvelteKitRouter();
+    vi.clearAllMocks();
+    return { ...mod, stop };
+}
+
+// NOTE ON `url` IN THESE SNAPSHOTS: `started()` initialises `lastKey` from jsdom's `location`, i.e.
+// `/`. A snapshot whose url is anything else has `key !== lastKey` and therefore hits branch 7 (the
+// fallback), NOT branch 6. So pageload-naming cases MUST use `url: HERE`. `routeId` is what names the
+// root; the url only decides the key and the fallback name. Getting this wrong makes a branch-6 test
+// silently assert branch-7 behaviour.
+
+test('names the pageload root from the committed route id', async () => {
+    const { syncNavigation, stop } = await started();
+    syncNavigation(snap({ routeId: '/product/[id]', url: HERE })); // url: HERE => branch 6
+    expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/product/[id]', source: 'route' });
+    expect(nav.startNavigation).not.toHaveBeenCalled();
+    stop();
+});
+
+test('falls back to the pathname when there is no route id', async () => {
+    const { syncNavigation, stop } = await started();
+    syncNavigation(snap({ routeId: null }));
+    expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/', source: 'url' });
+    stop();
+});
+
+test('a late-resolving route id renames the pageload root and opens no nav root', async () => {
+    const { syncNavigation, stop } = await started();
+
+    // Kit's `page.route.id` is null until hydration resolves it, so the first snapshot at the
+    // initial key can only name from the url. Both snapshots sit at `lastKey`, so both take
+    // branch 6 and neither may open a navigation root. The re-name is a `source` flip, not a
+    // name change: that IS the observable here.
+    syncNavigation(snap({ routeId: null }));
+    expect(nav.setActiveRouteName).toHaveBeenLastCalledWith({ name: '/', source: 'url' });
+
+    syncNavigation(snap({ routeId: '/' }));
+    expect(nav.setActiveRouteName).toHaveBeenLastCalledWith({ name: '/', source: 'route' });
+    expect(nav.startNavigation).not.toHaveBeenCalled();
+    stop();
+});
+
+test('opens a held navigation root named from the destination', async () => {
+    const { syncNavigation, stop } = await started();
+    syncNavigation(snap({ to: { url: PRODUCT, route: { id: '/product/[id]' } } }));
+    expect(nav.startNavigation).toHaveBeenCalledWith({
+        path: '/product/p01',
+        url: PRODUCT.href,
+        hold: true,
+    });
+    expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/product/[id]', source: 'route' });
+    stop();
+});
+
+test('settles the navigation from the committed page', async () => {
+    const { syncNavigation, stop } = await started();
+    syncNavigation(snap({ to: { url: PRODUCT, route: { id: '/product/[id]' } } }));
+    syncNavigation(snap({ routeId: '/product/[id]', url: PRODUCT }));
+    expect(nav.settleNavigation).toHaveBeenCalledWith({ name: '/product/[id]', source: 'route' });
+    stop();
+});
+
+test('a redirect keeps ONE held root and renames it to the final destination', async () => {
+    const { syncNavigation, stop } = await started();
+    const OLD = new URL(location.origin + '/old');
+    syncNavigation(snap({ to: { url: OLD, route: { id: '/old' } } }));
+    syncNavigation(snap({ to: { url: PRODUCT, route: { id: '/product/[id]' } } })); // redirect hop
+    expect(nav.startNavigation).toHaveBeenCalledTimes(1);
+    expect(nav.setActiveRouteName).toHaveBeenLastCalledWith({ name: '/product/[id]', source: 'route' });
+    stop();
+});
+
+test('skips a navigation that will unload the document', async () => {
+    const { syncNavigation, stop } = await started();
+    syncNavigation(snap({ to: { url: PRODUCT, route: { id: null } }, willUnload: true }));
+    expect(nav.startNavigation).not.toHaveBeenCalled();
+    stop();
+});
+
+test('skips a navigation to a route SvelteKit does not own', async () => {
+    const { syncNavigation, stop } = await started();
+    syncNavigation(snap({ to: { url: PRODUCT, route: { id: null } } }));
+    expect(nav.startNavigation).not.toHaveBeenCalled();
+    stop();
+});
+
+test('a hash-only change opens no navigation root', async () => {
+    const { syncNavigation, stop } = await started();
+    syncNavigation(snap({ url: new URL(location.origin + '/#section-2') }));
+    expect(nav.startNavigation).not.toHaveBeenCalled();
+    stop();
+});
+
+test('fallback: a committed key change while idle opens an un-held root and settles it at once', async () => {
+    const { syncNavigation, stop } = await started();
+    // Same snapshot as the pageload test above EXCEPT `url: PRODUCT`, which moves the key off
+    // `lastKey` ('/') and is precisely what selects branch 7 over branch 6.
+    syncNavigation(snap({ routeId: '/product/[id]', url: PRODUCT }));
+    expect(nav.startNavigation).toHaveBeenCalledWith({ path: '/product/p01', url: PRODUCT.href });
+    expect(nav.startNavigation.mock.calls[0][0]).not.toHaveProperty('hold');
+    expect(nav.settleNavigation).toHaveBeenCalledWith({ name: '/product/[id]', source: 'route' });
+    stop();
+});
+
+test('lastKey re-stamp: a repeat snapshot after a settle opens no second root', async () => {
+    const { syncNavigation, stop } = await started();
+    syncNavigation(snap({ to: { url: PRODUCT, route: { id: '/product/[id]' } } }));
+    syncNavigation(snap({ routeId: '/product/[id]', url: PRODUCT })); // settle
+    vi.clearAllMocks();
+    syncNavigation(snap({ routeId: '/product/[id]', url: PRODUCT })); // Kit reassigns page.url
+    expect(nav.startNavigation).not.toHaveBeenCalled();
+    stop();
+});
+
+test('branch 0 does not consume the transition when tracing is off', async () => {
+    const { syncNavigation, stop } = await started();
+    flareConfig.enableTracing = false;
+    syncNavigation(snap({ to: { url: PRODUCT, route: { id: '/product/[id]' } } }));
+    syncNavigation(snap({ routeId: '/product/[id]', url: PRODUCT }));
+    flareConfig.enableTracing = true;
+
+    // inFlight must still be false, so a real navigation afterwards still opens a root.
+    syncNavigation(snap({ to: { url: PRODUCT, route: { id: '/product/[id]' } } }));
+    expect(nav.startNavigation).toHaveBeenCalledTimes(1);
+    expect(nav.startNavigation).toHaveBeenCalledWith({ path: '/product/p01', url: PRODUCT.href, hold: true });
+    stop();
 });

--- a/packages/sveltekit/tests/client/traceSvelteKitRouter.test.ts
+++ b/packages/sveltekit/tests/client/traceSvelteKitRouter.test.ts
@@ -1,5 +1,4 @@
 // @vitest-environment jsdom
-import { flushSync } from 'svelte';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import type { NavSnapshot } from '../../src/client/traceSvelteKitRouter.svelte';
@@ -37,7 +36,11 @@ async function load() {
     page.route = { id: '/' };
     navigating.to = null;
     navigating.willUnload = false;
-    return import('../../src/client/traceSvelteKitRouter.svelte');
+    // `flushSync` MUST come from the post-reset `svelte` instance: resetModules gives the module
+    // under test a brand-new svelte runtime with its own effect queue, and the copy imported at the
+    // top of this file flushes the OLD queue, which is a silent no-op.
+    const { flushSync } = await import('svelte');
+    return { ...(await import('../../src/client/traceSvelteKitRouter.svelte')), page, navigating, flushSync };
 }
 
 beforeEach(() => {
@@ -79,7 +82,7 @@ test('ignores the pre-hydration placeholder page', async () => {
 });
 
 test('cleanup disposes the effect and unregisters', async () => {
-    const { traceSvelteKitRouter } = await load();
+    const { traceSvelteKitRouter, flushSync } = await load();
     const stop = traceSvelteKitRouter();
     flushSync();
     stop();
@@ -113,10 +116,54 @@ async function started() {
 // root; the url only decides the key and the fallback name. Getting this wrong makes a branch-6 test
 // silently assert branch-7 behaviour.
 
+// EVERY OTHER CASE BELOW CALLS `syncNavigation` DIRECTLY, so none of them touch the effect body.
+// That body is the fragile half: it must read `navigating.to` (not `.from`), `page.route.id` and
+// `page.url`, and it must re-run when any of them change. Swap a field for the wrong one and every
+// other unit test here still passes. So drive one full navigation through the reactive state.
+test('the effect reads $app/state and re-runs, feeding the state machine', async () => {
+    const { traceSvelteKitRouter, page, navigating, flushSync } = await load();
+    const stop = traceSvelteKitRouter();
+    flushSync();
+    vi.clearAllMocks();
+
+    navigating.to = { url: PRODUCT, route: { id: '/product/[id]' } };
+    flushSync();
+    expect(nav.startNavigation).toHaveBeenCalledWith({ path: '/product/p01', url: PRODUCT.href, hold: true });
+    expect(nav.setActiveRouteName).toHaveBeenCalledWith({
+        name: '/product/[id]',
+        source: 'route',
+        url: PRODUCT.href,
+    });
+
+    // Kit commits `page` before it nulls `navigating`, so the settle names from the committed route.
+    navigating.to = null;
+    page.url = PRODUCT;
+    page.route = { id: '/product/[id]' };
+    flushSync();
+    expect(nav.settleNavigation).toHaveBeenCalledWith({
+        name: '/product/[id]',
+        source: 'route',
+        url: PRODUCT.href,
+    });
+    stop();
+});
+
+test('the disposed effect stops observing $app/state', async () => {
+    const { traceSvelteKitRouter, navigating, flushSync } = await load();
+    const stop = traceSvelteKitRouter();
+    flushSync();
+    stop();
+    vi.clearAllMocks();
+
+    navigating.to = { url: PRODUCT, route: { id: '/product/[id]' } };
+    flushSync();
+    expect(nav.startNavigation).not.toHaveBeenCalled();
+});
+
 test('names the pageload root from the committed route id', async () => {
     const { syncNavigation, stop } = await started();
     syncNavigation(snap({ routeId: '/product/[id]', url: HERE })); // url: HERE => branch 6
-    expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/product/[id]', source: 'route' });
+    expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/product/[id]', source: 'route', url: HERE.href });
     expect(nav.startNavigation).not.toHaveBeenCalled();
     stop();
 });
@@ -124,7 +171,7 @@ test('names the pageload root from the committed route id', async () => {
 test('falls back to the pathname when there is no route id', async () => {
     const { syncNavigation, stop } = await started();
     syncNavigation(snap({ routeId: null }));
-    expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/', source: 'url' });
+    expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/', source: 'url', url: HERE.href });
     stop();
 });
 
@@ -136,10 +183,10 @@ test('a late-resolving route id renames the pageload root and opens no nav root'
     // branch 6 and neither may open a navigation root. The re-name is a `source` flip, not a
     // name change: that IS the observable here.
     syncNavigation(snap({ routeId: null }));
-    expect(nav.setActiveRouteName).toHaveBeenLastCalledWith({ name: '/', source: 'url' });
+    expect(nav.setActiveRouteName).toHaveBeenLastCalledWith({ name: '/', source: 'url', url: HERE.href });
 
     syncNavigation(snap({ routeId: '/' }));
-    expect(nav.setActiveRouteName).toHaveBeenLastCalledWith({ name: '/', source: 'route' });
+    expect(nav.setActiveRouteName).toHaveBeenLastCalledWith({ name: '/', source: 'route', url: HERE.href });
     expect(nav.startNavigation).not.toHaveBeenCalled();
     stop();
 });
@@ -152,7 +199,7 @@ test('opens a held navigation root named from the destination', async () => {
         url: PRODUCT.href,
         hold: true,
     });
-    expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/product/[id]', source: 'route' });
+    expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/product/[id]', source: 'route', url: PRODUCT.href });
     stop();
 });
 
@@ -160,7 +207,7 @@ test('settles the navigation from the committed page', async () => {
     const { syncNavigation, stop } = await started();
     syncNavigation(snap({ to: { url: PRODUCT, route: { id: '/product/[id]' } } }));
     syncNavigation(snap({ routeId: '/product/[id]', url: PRODUCT }));
-    expect(nav.settleNavigation).toHaveBeenCalledWith({ name: '/product/[id]', source: 'route' });
+    expect(nav.settleNavigation).toHaveBeenCalledWith({ name: '/product/[id]', source: 'route', url: PRODUCT.href });
     stop();
 });
 
@@ -170,7 +217,11 @@ test('a redirect keeps ONE held root and renames it to the final destination', a
     syncNavigation(snap({ to: { url: OLD, route: { id: '/old' } } }));
     syncNavigation(snap({ to: { url: PRODUCT, route: { id: '/product/[id]' } } })); // redirect hop
     expect(nav.startNavigation).toHaveBeenCalledTimes(1);
-    expect(nav.setActiveRouteName).toHaveBeenLastCalledWith({ name: '/product/[id]', source: 'route' });
+    expect(nav.setActiveRouteName).toHaveBeenLastCalledWith({
+        name: '/product/[id]',
+        source: 'route',
+        url: PRODUCT.href,
+    });
     stop();
 });
 
@@ -204,7 +255,7 @@ test('fallback: a committed key change while idle opens an un-held root and sett
     syncNavigation(snap({ routeId: '/product/[id]', url: PRODUCT }));
     expect(nav.startNavigation).toHaveBeenCalledWith({ path: '/product/p01', url: PRODUCT.href });
     expect(nav.startNavigation.mock.calls[0][0]).not.toHaveProperty('hold');
-    expect(nav.settleNavigation).toHaveBeenCalledWith({ name: '/product/[id]', source: 'route' });
+    expect(nav.settleNavigation).toHaveBeenCalledWith({ name: '/product/[id]', source: 'route', url: PRODUCT.href });
     stop();
 });
 
@@ -238,6 +289,45 @@ test('branch 0 does not consume the transition when tracing is off', async () =>
     syncNavigation(snap({ to: { url: PRODUCT, route: { id: '/product/[id]' } } }));
     expect(nav.startNavigation).toHaveBeenCalledTimes(1);
     expect(nav.startNavigation).toHaveBeenCalledWith({ path: '/product/p01', url: PRODUCT.href, hold: true });
+    stop();
+});
+
+// Branch 0 must keep tracking the committed location, not just eat the snapshot. Without the
+// lastKey stamp the key goes stale for every navigation made while tracing was off, and the first
+// idle snapshot after it flips back on reads as a move and fabricates a branch-7 root for a page
+// that never navigated.
+test('a navigation made while tracing was off does not fabricate a root when it comes back on', async () => {
+    const { syncNavigation, stop } = await started();
+    flareConfig.enableTracing = false;
+    syncNavigation(snap({ to: { url: PRODUCT, route: { id: '/product/[id]' } } }));
+    syncNavigation(snap({ routeId: '/product/[id]', url: PRODUCT })); // committed at /product/p01
+    flareConfig.enableTracing = true;
+
+    vi.clearAllMocks();
+    // An idle snapshot at the SAME committed location (e.g. Kit reassigning page.url on a hash
+    // change). It is not a move, so it must take branch 6 and name, never branch 7 and open a root.
+    syncNavigation(snap({ routeId: '/product/[id]', url: PRODUCT }));
+
+    expect(nav.startNavigation).not.toHaveBeenCalled();
+    expect(nav.settleNavigation).not.toHaveBeenCalled();
+    expect(nav.setActiveRouteName).toHaveBeenCalledWith({
+        name: '/product/[id]',
+        source: 'route',
+        url: PRODUCT.href,
+    });
+    stop();
+});
+
+// The `a:` placeholder is checked before the tracing gate precisely so it cannot reach that stamp:
+// its pathname is empty, and stamping '' would make the next real snapshot look like a move.
+test('the pre-hydration placeholder does not poison lastKey while tracing is off', async () => {
+    const { syncNavigation, stop } = await started();
+    flareConfig.enableTracing = false;
+    syncNavigation({ to: null, willUnload: false, routeId: null, url: new URL('a:') });
+    flareConfig.enableTracing = true;
+
+    syncNavigation(snap({ routeId: '/', url: HERE })); // still the initial location => branch 6
+    expect(nav.startNavigation).not.toHaveBeenCalled();
     stop();
 });
 

--- a/packages/sveltekit/tests/client/traceSvelteKitRouter.test.ts
+++ b/packages/sveltekit/tests/client/traceSvelteKitRouter.test.ts
@@ -27,8 +27,8 @@ vi.mock('@flareapp/js', () => ({
 const HERE = new URL(location.origin + '/');
 
 // The module holds state (tracing/inFlight/lastKey), so every test needs a fresh copy. `$app/state`
-// must be re-seeded AFTER resetModules: the reset gives the module under test a brand-new mock
-// instance, so anything written to a pre-reset instance is silently discarded.
+// has to be seeded again after resetModules: the reset gives the module under test a brand-new mock
+// instance, so anything written to the old one is quietly thrown away.
 async function load() {
     vi.resetModules();
     const { page, navigating } = await import('$app/state');
@@ -36,9 +36,9 @@ async function load() {
     page.route = { id: '/' };
     navigating.to = null;
     navigating.willUnload = false;
-    // `flushSync` MUST come from the post-reset `svelte` instance: resetModules gives the module
-    // under test a brand-new svelte runtime with its own effect queue, and the copy imported at the
-    // top of this file flushes the OLD queue, which is a silent no-op.
+    // `flushSync` has to come from the svelte instance created after the reset. resetModules gives
+    // the module under test its own svelte runtime with its own effect queue, and a copy imported at
+    // the top of this file would flush the old queue, which does nothing at all.
     const { flushSync } = await import('svelte');
     return { ...(await import('../../src/client/traceSvelteKitRouter.svelte')), page, navigating, flushSync };
 }
@@ -56,7 +56,7 @@ test('registers a navigation source even when tracing is off at call time', asyn
 
     // The whole point of having no call-time gate: registration happens regardless, so a later
     // flare.configure({ enableTracing: true }) still produces named roots. That tracing-flips-on-later
-    // behaviour needs branch 6, so it is asserted in Task 3 (case 16), not here.
+    // behaviour needs a naming snapshot, which the pageload tests below cover instead.
     expect(registerNavigationSource).toHaveBeenCalledTimes(1);
     stop();
 });
@@ -110,13 +110,13 @@ async function started() {
     return { ...mod, stop };
 }
 
-// NOTE ON `url` IN THESE SNAPSHOTS: `started()` initialises `lastKey` from jsdom's `location`, i.e.
-// `/`. A snapshot whose url is anything else has `key !== lastKey` and therefore hits branch 7 (the
-// fallback), NOT branch 6. So pageload-naming cases MUST use `url: HERE`. `routeId` is what names the
-// root; the url only decides the key and the fallback name. Getting this wrong makes a branch-6 test
-// silently assert branch-7 behaviour.
+// About `url` in these snapshots: `started()` takes the starting key from jsdom's location, which is
+// `/`. A snapshot with any other url looks like the page moved, and then it opens a root instead of
+// naming one. So a test about naming the pageload has to pass `url: HERE`. The name comes from
+// `routeId`; the url only decides whether we read it as a move. Get this wrong and a naming test
+// quietly asserts the behaviour of the fallback instead.
 
-// EVERY OTHER CASE BELOW CALLS `syncNavigation` DIRECTLY, so none of them touch the effect body.
+// Every other case below calls `syncNavigation` directly, so none of them touch the effect body.
 // That body is the fragile half: it must read `navigating.to` (not `.from`), `page.route.id` and
 // `page.url`, and it must re-run when any of them change. Swap a field for the wrong one and every
 // other unit test here still passes. So drive one full navigation through the reactive state.
@@ -162,7 +162,7 @@ test('the disposed effect stops observing $app/state', async () => {
 
 test('names the pageload root from the committed route id', async () => {
     const { syncNavigation, stop } = await started();
-    syncNavigation(snap({ routeId: '/product/[id]', url: HERE })); // url: HERE => branch 6
+    syncNavigation(snap({ routeId: '/product/[id]', url: HERE })); // url: HERE, so this only names
     expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/product/[id]', source: 'route', url: HERE.href });
     expect(nav.startNavigation).not.toHaveBeenCalled();
     stop();
@@ -178,10 +178,9 @@ test('falls back to the pathname when there is no route id', async () => {
 test('a late-resolving route id renames the pageload root and opens no nav root', async () => {
     const { syncNavigation, stop } = await started();
 
-    // Kit's `page.route.id` is null until hydration resolves it, so the first snapshot at the
-    // initial key can only name from the url. Both snapshots sit at `lastKey`, so both take
-    // branch 6 and neither may open a navigation root. The re-name is a `source` flip, not a
-    // name change: that IS the observable here.
+    // Kit's `page.route.id` is null until hydration resolves it, so the first snapshot can only
+    // name from the url. Neither snapshot moves the page, so neither may open a navigation root.
+    // The second one changes `source`, not the name, and that is what this asserts.
     syncNavigation(snap({ routeId: null }));
     expect(nav.setActiveRouteName).toHaveBeenLastCalledWith({ name: '/', source: 'url', url: HERE.href });
 
@@ -250,8 +249,8 @@ test('a hash-only change opens no navigation root', async () => {
 
 test('fallback: a committed key change while idle opens an un-held root and settles it at once', async () => {
     const { syncNavigation, stop } = await started();
-    // Same snapshot as the pageload test above EXCEPT `url: PRODUCT`, which moves the key off
-    // `lastKey` ('/') and is precisely what selects branch 7 over branch 6.
+    // The same snapshot as the pageload test above apart from `url: PRODUCT`, which moves the page
+    // off the starting location and is what makes this read as a navigation rather than a naming.
     syncNavigation(snap({ routeId: '/product/[id]', url: PRODUCT }));
     expect(nav.startNavigation).toHaveBeenCalledWith({ path: '/product/p01', url: PRODUCT.href });
     expect(nav.startNavigation.mock.calls[0][0]).not.toHaveProperty('hold');
@@ -269,16 +268,16 @@ test('lastKey re-stamp: a repeat snapshot after a settle opens no second root', 
     stop();
 });
 
-test('branch 7 re-stamp: a repeat snapshot after the fallback opens no second root', async () => {
+test('a repeat snapshot after the fallback opens no second root', async () => {
     const { syncNavigation, stop } = await started();
-    syncNavigation(snap({ routeId: '/product/[id]', url: PRODUCT })); // branch 7 fallback
+    syncNavigation(snap({ routeId: '/product/[id]', url: PRODUCT })); // the fallback
     vi.clearAllMocks();
     syncNavigation(snap({ routeId: '/product/[id]', url: PRODUCT })); // same snapshot again
     expect(nav.startNavigation).not.toHaveBeenCalled();
     stop();
 });
 
-test('branch 0 does not consume the transition when tracing is off', async () => {
+test('a snapshot seen while tracing is off is not treated as a navigation', async () => {
     const { syncNavigation, stop } = await started();
     flareConfig.enableTracing = false;
     syncNavigation(snap({ to: { url: PRODUCT, route: { id: '/product/[id]' } } }));
@@ -292,11 +291,10 @@ test('branch 0 does not consume the transition when tracing is off', async () =>
     stop();
 });
 
-// Branch 0 must keep tracking the committed location, not just eat the snapshot. Without the
-// lastKey stamp the key goes stale for every navigation made while tracing was off, and the first
-// idle snapshot after it flips back on reads as a move and fabricates a branch-7 root for a page
-// that never navigated.
-test('a navigation made while tracing was off does not fabricate a root when it comes back on', async () => {
+// While tracing is off we still have to follow the current page, not just drop the snapshot.
+// Without that the key goes stale during every navigation made while tracing was off, and the first
+// snapshot after it comes back on reads as a move and opens a root for a page that never moved.
+test('a navigation made while tracing was off does not open a root when it comes back on', async () => {
     const { syncNavigation, stop } = await started();
     flareConfig.enableTracing = false;
     syncNavigation(snap({ to: { url: PRODUCT, route: { id: '/product/[id]' } } }));
@@ -304,8 +302,8 @@ test('a navigation made while tracing was off does not fabricate a root when it 
     flareConfig.enableTracing = true;
 
     vi.clearAllMocks();
-    // An idle snapshot at the SAME committed location (e.g. Kit reassigning page.url on a hash
-    // change). It is not a move, so it must take branch 6 and name, never branch 7 and open a root.
+    // A snapshot at the same location (for example Kit reassigning page.url on a hash
+    // change). The page did not move, so it must name the root and never open a new one.
     syncNavigation(snap({ routeId: '/product/[id]', url: PRODUCT }));
 
     expect(nav.startNavigation).not.toHaveBeenCalled();
@@ -320,23 +318,23 @@ test('a navigation made while tracing was off does not fabricate a root when it 
 
 // The `a:` placeholder is checked before the tracing gate precisely so it cannot reach that stamp:
 // its pathname is empty, and stamping '' would make the next real snapshot look like a move.
-test('the pre-hydration placeholder does not poison lastKey while tracing is off', async () => {
+test('the pre-hydration placeholder is not mistaken for a page while tracing is off', async () => {
     const { syncNavigation, stop } = await started();
     flareConfig.enableTracing = false;
     syncNavigation({ to: null, willUnload: false, routeId: null, url: new URL('a:') });
     flareConfig.enableTracing = true;
 
-    syncNavigation(snap({ routeId: '/', url: HERE })); // still the initial location => branch 6
+    syncNavigation(snap({ routeId: '/', url: HERE })); // still the initial location, so just name it
     expect(nav.startNavigation).not.toHaveBeenCalled();
     stop();
 });
 
-test('a to-null settle stranded by tracing going off does not desync the next navigation', async () => {
+test('a settle lost because tracing went off does not break the next navigation', async () => {
     const { syncNavigation, stop } = await started();
     // Navigation starts while tracing is on: held root opens, inFlight = true.
     syncNavigation(snap({ to: { url: PRODUCT, route: { id: '/product/[id]' } } }));
     flareConfig.enableTracing = false;
-    // The to-null settle snapshot arrives while tracing is off; branch 0 must eat it AND clear
+    // The settle snapshot arrives while tracing is off, so it must be dropped and also clear
     // inFlight, or the next navigation below finds inFlight already true and opens no root.
     syncNavigation(snap({ routeId: '/product/[id]', url: PRODUCT }));
     flareConfig.enableTracing = true;

--- a/packages/sveltekit/tests/client/traceSvelteKitRouter.test.ts
+++ b/packages/sveltekit/tests/client/traceSvelteKitRouter.test.ts
@@ -218,6 +218,15 @@ test('lastKey re-stamp: a repeat snapshot after a settle opens no second root', 
     stop();
 });
 
+test('branch 7 re-stamp: a repeat snapshot after the fallback opens no second root', async () => {
+    const { syncNavigation, stop } = await started();
+    syncNavigation(snap({ routeId: '/product/[id]', url: PRODUCT })); // branch 7 fallback
+    vi.clearAllMocks();
+    syncNavigation(snap({ routeId: '/product/[id]', url: PRODUCT })); // same snapshot again
+    expect(nav.startNavigation).not.toHaveBeenCalled();
+    stop();
+});
+
 test('branch 0 does not consume the transition when tracing is off', async () => {
     const { syncNavigation, stop } = await started();
     flareConfig.enableTracing = false;
@@ -228,6 +237,22 @@ test('branch 0 does not consume the transition when tracing is off', async () =>
     // inFlight must still be false, so a real navigation afterwards still opens a root.
     syncNavigation(snap({ to: { url: PRODUCT, route: { id: '/product/[id]' } } }));
     expect(nav.startNavigation).toHaveBeenCalledTimes(1);
+    expect(nav.startNavigation).toHaveBeenCalledWith({ path: '/product/p01', url: PRODUCT.href, hold: true });
+    stop();
+});
+
+test('a to-null settle stranded by tracing going off does not desync the next navigation', async () => {
+    const { syncNavigation, stop } = await started();
+    // Navigation starts while tracing is on: held root opens, inFlight = true.
+    syncNavigation(snap({ to: { url: PRODUCT, route: { id: '/product/[id]' } } }));
+    flareConfig.enableTracing = false;
+    // The to-null settle snapshot arrives while tracing is off; branch 0 must eat it AND clear
+    // inFlight, or the next navigation below finds inFlight already true and opens no root.
+    syncNavigation(snap({ routeId: '/product/[id]', url: PRODUCT }));
+    flareConfig.enableTracing = true;
+
+    vi.clearAllMocks();
+    syncNavigation(snap({ to: { url: PRODUCT, route: { id: '/product/[id]' } } }));
     expect(nav.startNavigation).toHaveBeenCalledWith({ path: '/product/p01', url: PRODUCT.href, hold: true });
     stop();
 });

--- a/packages/sveltekit/tests/client/traceSvelteKitRouter.test.ts
+++ b/packages/sveltekit/tests/client/traceSvelteKitRouter.test.ts
@@ -1,0 +1,85 @@
+// @vitest-environment jsdom
+import { flushSync } from 'svelte';
+import { beforeEach, expect, test, vi } from 'vitest';
+
+const nav = vi.hoisted(() => ({
+    startNavigation: vi.fn(),
+    setActiveRouteName: vi.fn(),
+    settleNavigation: vi.fn(),
+    unregister: vi.fn(),
+}));
+const registerNavigationSource = vi.hoisted(() => vi.fn(() => nav));
+vi.mock('@flareapp/js/browser', async () => ({
+    ...(await import('@flareapp/test-helpers')).browserSeamMock(nav),
+    registerNavigationSource,
+}));
+
+const flareConfig = vi.hoisted(() => ({ enableTracing: true }));
+vi.mock('@flareapp/js', () => ({
+    flare: {
+        get config() {
+            return flareConfig;
+        },
+    },
+}));
+
+const HERE = new URL(location.origin + '/');
+
+// The module holds state (tracing/inFlight/lastKey), so every test needs a fresh copy. `$app/state`
+// must be re-seeded AFTER resetModules: the reset gives the module under test a brand-new mock
+// instance, so anything written to a pre-reset instance is silently discarded.
+async function load() {
+    vi.resetModules();
+    const { page, navigating } = await import('$app/state');
+    page.url = HERE;
+    page.route = { id: '/' };
+    navigating.to = null;
+    navigating.willUnload = false;
+    return import('../../src/client/traceSvelteKitRouter.svelte');
+}
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    flareConfig.enableTracing = true;
+});
+
+test('registers a navigation source even when tracing is off at call time', async () => {
+    flareConfig.enableTracing = false;
+    const { traceSvelteKitRouter } = await load();
+
+    const stop = traceSvelteKitRouter();
+
+    // The whole point of having no call-time gate: registration happens regardless, so a later
+    // flare.configure({ enableTracing: true }) still produces named roots. That tracing-flips-on-later
+    // behaviour needs branch 6, so it is asserted in Task 3 (case 16), not here.
+    expect(registerNavigationSource).toHaveBeenCalledTimes(1);
+    stop();
+});
+
+test('is idempotent: a second call registers no second source', async () => {
+    const { traceSvelteKitRouter } = await load();
+    const stop = traceSvelteKitRouter();
+    traceSvelteKitRouter();
+    expect(registerNavigationSource).toHaveBeenCalledTimes(1);
+    stop();
+});
+
+test('ignores the pre-hydration placeholder page', async () => {
+    const { traceSvelteKitRouter, syncNavigation } = await load();
+    const stop = traceSvelteKitRouter();
+    vi.clearAllMocks();
+
+    syncNavigation({ to: null, willUnload: false, routeId: null, url: new URL('a:') });
+
+    expect(nav.startNavigation).not.toHaveBeenCalled();
+    expect(nav.setActiveRouteName).not.toHaveBeenCalled();
+    stop();
+});
+
+test('cleanup disposes the effect and unregisters', async () => {
+    const { traceSvelteKitRouter } = await load();
+    const stop = traceSvelteKitRouter();
+    flushSync();
+    stop();
+    expect(nav.unregister).toHaveBeenCalledTimes(1);
+});

--- a/packages/sveltekit/tests/client/traceSvelteKitRouter.test.ts
+++ b/packages/sveltekit/tests/client/traceSvelteKitRouter.test.ts
@@ -98,6 +98,11 @@ const snap = (over: Partial<NavSnapshot> = {}): NavSnapshot => ({
 async function started() {
     const mod = await load();
     const stop = mod.traceSvelteKitRouter();
+    // The mount effect's first run (pageload naming off the seeded `$app/state`) is scheduled on a
+    // microtask, not run synchronously by `$effect.root`. Without this tick it fires later, after
+    // `vi.clearAllMocks()`, and leaks a `setActiveRouteName` call into whichever test happens to await
+    // this helper. Let it settle before clearing so every test starts from a clean mock history.
+    await Promise.resolve();
     vi.clearAllMocks();
     return { ...mod, stop };
 }
@@ -171,8 +176,9 @@ test('a redirect keeps ONE held root and renames it to the final destination', a
 
 test('skips a navigation that will unload the document', async () => {
     const { syncNavigation, stop } = await started();
-    syncNavigation(snap({ to: { url: PRODUCT, route: { id: null } }, willUnload: true }));
+    syncNavigation(snap({ to: { url: PRODUCT, route: { id: '/product/[id]' } }, willUnload: true }));
     expect(nav.startNavigation).not.toHaveBeenCalled();
+    expect(nav.setActiveRouteName).not.toHaveBeenCalled();
     stop();
 });
 
@@ -180,6 +186,7 @@ test('skips a navigation to a route SvelteKit does not own', async () => {
     const { syncNavigation, stop } = await started();
     syncNavigation(snap({ to: { url: PRODUCT, route: { id: null } } }));
     expect(nav.startNavigation).not.toHaveBeenCalled();
+    expect(nav.setActiveRouteName).not.toHaveBeenCalled();
     stop();
 });
 

--- a/packages/sveltekit/vitest.config.mts
+++ b/packages/sveltekit/vitest.config.mts
@@ -10,7 +10,7 @@ export default defineConfig({
         // no-op: runes modules still compile, effects just silently never run.
         conditions: ['browser'],
         alias: {
-            '$app/state': path.resolve('./tests/__mocks__/app-state.ts'),
+            '$app/state': path.resolve('./tests/__mocks__/app-state.svelte.ts'),
         },
     },
     test: {

--- a/packages/sveltekit/vitest.config.mts
+++ b/packages/sveltekit/vitest.config.mts
@@ -6,6 +6,9 @@ import { defineConfig } from 'vitest/config';
 export default defineConfig({
     plugins: [svelte({ hot: false })],
     resolve: {
+        // Without the browser condition, `svelte` resolves to its server build where `$effect` is a
+        // no-op: runes modules still compile, effects just silently never run.
+        conditions: ['browser'],
         alias: {
             '$app/state': path.resolve('./tests/__mocks__/app-state.ts'),
         },

--- a/packages/test-helpers/src/index.ts
+++ b/packages/test-helpers/src/index.ts
@@ -2,3 +2,4 @@ export * from './FakeApi';
 export * from './tracing';
 export * from './factories';
 export * from './globals';
+export * from './navigationSource';

--- a/packages/test-helpers/src/navigationSource.ts
+++ b/packages/test-helpers/src/navigationSource.ts
@@ -1,0 +1,47 @@
+import { vi } from 'vitest';
+
+export type FakeNavigationSource = {
+    startNavigation: ReturnType<typeof vi.fn>;
+    setActiveRouteName: ReturnType<typeof vi.fn>;
+    settleNavigation: ReturnType<typeof vi.fn>;
+    unregister: ReturnType<typeof vi.fn>;
+};
+
+/**
+ * A recording stand-in for `registerNavigationSource()`'s handle. Must be created inside
+ * `vi.hoisted` so a `vi.mock` factory can close over it.
+ */
+export function fakeNavigationSource(): FakeNavigationSource {
+    return {
+        startNavigation: vi.fn(),
+        setActiveRouteName: vi.fn(),
+        settleNavigation: vi.fn(),
+        unregister: vi.fn(),
+    };
+}
+
+/**
+ * The `@flareapp/js/browser` mock factory used by every nav-seam suite: the seam plus the two
+ * instrumentation guards, which swallow throws exactly as the real ones do.
+ */
+export function browserSeamMock(nav: Partial<FakeNavigationSource>) {
+    return {
+        registerNavigationSource: vi.fn(() => nav),
+        insulate:
+            (fn: (...a: unknown[]) => void) =>
+            (...a: unknown[]) => {
+                try {
+                    fn(...a);
+                } catch {
+                    /* swallow */
+                }
+            },
+        safeInvoke: (fn?: (() => void) | null) => {
+            try {
+                fn?.();
+            } catch {
+                /* swallow */
+            }
+        },
+    };
+}

--- a/packages/test-helpers/src/navigationSource.ts
+++ b/packages/test-helpers/src/navigationSource.ts
@@ -8,19 +8,6 @@ export type FakeNavigationSource = {
 };
 
 /**
- * A recording stand-in for `registerNavigationSource()`'s handle. Must be created inside
- * `vi.hoisted` so a `vi.mock` factory can close over it.
- */
-export function fakeNavigationSource(): FakeNavigationSource {
-    return {
-        startNavigation: vi.fn(),
-        setActiveRouteName: vi.fn(),
-        settleNavigation: vi.fn(),
-        unregister: vi.fn(),
-    };
-}
-
-/**
  * The `@flareapp/js/browser` mock factory used by every nav-seam suite: the seam plus the two
  * instrumentation guards, which swallow throws exactly as the real ones do.
  */

--- a/packages/test-helpers/src/navigationSource.ts
+++ b/packages/test-helpers/src/navigationSource.ts
@@ -8,27 +8,18 @@ export type FakeNavigationSource = {
 };
 
 /**
- * The `@flareapp/js/browser` mock factory used by every nav-seam suite: the seam plus the two
- * instrumentation guards, which swallow throws exactly as the real ones do.
+ * The `@flareapp/js/browser` mock used by every nav-seam suite. Only the seam itself is faked; pass
+ * the real module as `original` and everything else stays real, so a suite cannot pass against a
+ * hand-written stand-in that has drifted from the code it stands in for.
+ *
+ * Call it with vitest's `importOriginal`:
+ *
+ *     vi.mock('@flareapp/js/browser', async (importOriginal) =>
+ *         (await import('@flareapp/test-helpers')).browserSeamMock(nav, await importOriginal()));
  */
-export function browserSeamMock(nav: FakeNavigationSource) {
+export function browserSeamMock(nav: FakeNavigationSource, original: Record<string, unknown>) {
     return {
+        ...original,
         registerNavigationSource: vi.fn(() => nav),
-        insulate:
-            (fn: (...a: unknown[]) => void) =>
-            (...a: unknown[]) => {
-                try {
-                    fn(...a);
-                } catch {
-                    /* swallow */
-                }
-            },
-        safeInvoke: (fn?: (() => void) | null) => {
-            try {
-                fn?.();
-            } catch {
-                /* swallow */
-            }
-        },
     };
 }

--- a/packages/test-helpers/src/navigationSource.ts
+++ b/packages/test-helpers/src/navigationSource.ts
@@ -24,7 +24,7 @@ export function fakeNavigationSource(): FakeNavigationSource {
  * The `@flareapp/js/browser` mock factory used by every nav-seam suite: the seam plus the two
  * instrumentation guards, which swallow throws exactly as the real ones do.
  */
-export function browserSeamMock(nav: Partial<FakeNavigationSource>) {
+export function browserSeamMock(nav: FakeNavigationSource) {
     return {
         registerNavigationSource: vi.fn(() => nav),
         insulate:

--- a/packages/vue/src/traceVueRouter.ts
+++ b/packages/vue/src/traceVueRouter.ts
@@ -1,4 +1,4 @@
-import { insulate, registerNavigationSource, safeInvoke, type RouteName } from '@flareapp/js/browser';
+import { absoluteHref, insulate, registerNavigationSource, safeInvoke, type RouteName } from '@flareapp/js/browser';
 
 import type { NavigationFailureLike, VueRouteLocationLike, VueRouterLike } from './vendor/vueRouterTypes';
 
@@ -25,8 +25,9 @@ export function traceVueRouter(router: unknown): () => void {
 
     const nav = registerNavigationSource();
 
-    // `url` rides along on every name so a redirect hop re-stamps the root's url.full in lockstep:
-    // the root was opened from the FIRST destination and would otherwise report a URL never landed on.
+    // Every name carries the destination url so the root's url.full is updated together with it.
+    // The root opens with the first destination, so after a redirect it would otherwise report a
+    // page the user never landed on.
     const routeNameFor = (loc: VueRouteLocationLike): RouteName => {
         const url = hrefOf(loc);
         try {
@@ -39,9 +40,19 @@ export function traceVueRouter(router: unknown): () => void {
         return { name: loc.path, source: 'url', url };
     };
 
-    const hrefOf = (loc: VueRouteLocationLike): string => {
-        const origin = typeof window !== 'undefined' ? window.location.origin : '';
-        return origin + (loc.fullPath ?? loc.path ?? '');
+    // `resolve` is what puts the app's base path or `#` prefix back on: `fullPath` has them
+    // stripped, so an app served from `/app/` would report `/product/p01` for the real
+    // `/app/product/p01`. Fall back to the bare path only if the router has no `resolve`.
+    const hrefOf = (loc: VueRouteLocationLike): string | undefined => {
+        const path = loc.fullPath ?? loc.path;
+        if (!path) return undefined;
+        let href = path;
+        try {
+            href = r.resolve?.(path)?.href ?? path;
+        } catch {
+            // a router that throws on resolve still gets a url, just without the base path
+        }
+        return absoluteHref(href);
     };
 
     const isInitial = (from: VueRouteLocationLike | undefined): boolean =>

--- a/packages/vue/src/traceVueRouter.ts
+++ b/packages/vue/src/traceVueRouter.ts
@@ -25,15 +25,18 @@ export function traceVueRouter(router: unknown): () => void {
 
     const nav = registerNavigationSource();
 
+    // `url` rides along on every name so a redirect hop re-stamps the root's url.full in lockstep:
+    // the root was opened from the FIRST destination and would otherwise report a URL never landed on.
     const routeNameFor = (loc: VueRouteLocationLike): RouteName => {
+        const url = hrefOf(loc);
         try {
             const matched = loc.matched;
             const template = matched && matched.length > 0 ? matched[matched.length - 1]?.path : undefined;
-            if (template) return { name: template, source: 'route' };
+            if (template) return { name: template, source: 'route', url };
         } catch {
             // fall through to the URL name
         }
-        return { name: loc.path, source: 'url' };
+        return { name: loc.path, source: 'url', url };
     };
 
     const hrefOf = (loc: VueRouteLocationLike): string => {

--- a/packages/vue/src/vendor/vueRouterTypes.ts
+++ b/packages/vue/src/vendor/vueRouterTypes.ts
@@ -13,6 +13,11 @@ export type NavigationFailureLike = { type?: number } | undefined;
 
 export type VueRouterLike = {
     currentRoute?: { value?: VueRouteLocationLike };
+    /**
+     * `href` here already has the app's base path (or `#` prefix) applied, which `fullPath` does
+     * not. Optional because a caller can pass any router-shaped object; we fall back to `fullPath`.
+     */
+    resolve?(to: string): { href?: string };
     beforeEach(guard: (to: VueRouteLocationLike, from: VueRouteLocationLike) => unknown): () => void;
     afterEach(
         guard: (to: VueRouteLocationLike, from: VueRouteLocationLike, failure?: NavigationFailureLike) => unknown,

--- a/packages/vue/tests/vue-router.integration.test.ts
+++ b/packages/vue/tests/vue-router.integration.test.ts
@@ -39,13 +39,17 @@ beforeEach(() => {
     nav.unregister.mockClear();
 });
 
+// Every RouteName now carries the destination url so the root's url.full follows a redirect hop to
+// its final target instead of keeping the URL the navigation opened with. Same-origin SPA: origin + fullPath.
+const u = (path: string): string => `${window.location.origin}${path}`;
+
 describe('traceVueRouter against a real vue-router', () => {
     it('names the pageload root from the initial route and opens no nav root', async () => {
         const router = makeRouter();
         traceVueRouter(router);
         mountWith(router);
         await router.isReady();
-        expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/', source: 'route' });
+        expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/', source: 'route', url: u('/') });
         expect(nav.startNavigation).not.toHaveBeenCalled();
     });
 
@@ -59,7 +63,11 @@ describe('traceVueRouter against a real vue-router', () => {
         expect(nav.startNavigation).toHaveBeenCalledTimes(1);
         expect(nav.startNavigation.mock.calls[0]![0]).toMatchObject({ path: '/product/p01', hold: true });
         expect(nav.startNavigation.mock.calls[0]![0].url).toBe(`${window.location.origin}/product/p01`);
-        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/product/:id', source: 'route' });
+        expect(nav.settleNavigation).toHaveBeenLastCalledWith({
+            name: '/product/:id',
+            source: 'route',
+            url: u('/product/p01'),
+        });
     });
 
     it('names a nested child route with the absolute parameterized template', async () => {
@@ -71,7 +79,11 @@ describe('traceVueRouter against a real vue-router', () => {
         await router.push('/user/u01/profile');
         // Confirms vue-router normalizes the child's relative `path` to the full absolute template —
         // the one runtime behavior the spec flagged as unpinned (matched[last].path, not chain-joined).
-        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/user/:id/profile', source: 'route' });
+        expect(nav.settleNavigation).toHaveBeenLastCalledWith({
+            name: '/user/:id/profile',
+            source: 'route',
+            url: u('/user/u01/profile'),
+        });
     });
 
     it('names a truly unmatched route from its path with url source', async () => {
@@ -81,7 +93,11 @@ describe('traceVueRouter against a real vue-router', () => {
         await router.isReady();
         nav.settleNavigation.mockClear();
         await router.push('/does/not/exist').catch(() => {});
-        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/does/not/exist', source: 'url' });
+        expect(nav.settleNavigation).toHaveBeenLastCalledWith({
+            name: '/does/not/exist',
+            source: 'url',
+            url: u('/does/not/exist'),
+        });
     });
 
     it('follows a route-config redirect and settles the final target (one nav root)', async () => {
@@ -92,7 +108,7 @@ describe('traceVueRouter against a real vue-router', () => {
         nav.startNavigation.mockClear();
         await router.push('/old');
         expect(nav.startNavigation).toHaveBeenCalledTimes(1);
-        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/cart', source: 'route' });
+        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/cart', source: 'route', url: u('/cart') });
     });
 
     it('follows a guard-returned redirect (one nav root, final name)', async () => {
@@ -104,7 +120,7 @@ describe('traceVueRouter against a real vue-router', () => {
         nav.startNavigation.mockClear();
         await router.push('/product/p01');
         expect(nav.startNavigation).toHaveBeenCalledTimes(1);
-        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/cart', source: 'route' });
+        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/cart', source: 'route', url: u('/cart') });
     });
 
     it('settles an aborted navigation to the current location', async () => {
@@ -117,7 +133,7 @@ describe('traceVueRouter against a real vue-router', () => {
         nav.settleNavigation.mockClear();
         await router.push('/blocked');
         expect(nav.startNavigation).toHaveBeenCalledTimes(1);
-        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/', source: 'route' });
+        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/', source: 'route', url: u('/') });
     });
 
     it('emits no nav span for a plain duplicated navigation', async () => {
@@ -160,7 +176,7 @@ describe('traceVueRouter against a real vue-router', () => {
         await router.push('/product/p01').catch(() => {});
         expect(nav.startNavigation).toHaveBeenCalledTimes(1);
         expect(nav.settleNavigation).toHaveBeenCalledTimes(1);
-        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/', source: 'route' });
+        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/', source: 'route', url: u('/') });
     });
 
     it('names the pageload immediately when installed after the router is ready', async () => {
@@ -168,7 +184,7 @@ describe('traceVueRouter against a real vue-router', () => {
         mountWith(router);
         await router.isReady();
         traceVueRouter(router);
-        expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/', source: 'route' });
+        expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/', source: 'route', url: u('/') });
         nav.startNavigation.mockClear();
         await router.push('/cart');
         expect(nav.startNavigation).toHaveBeenCalledTimes(1);

--- a/packages/vue/tests/vue-router.integration.test.ts
+++ b/packages/vue/tests/vue-router.integration.test.ts
@@ -9,25 +9,7 @@ const nav = vi.hoisted(() => ({
     settleNavigation: vi.fn(),
     unregister: vi.fn(),
 }));
-vi.mock('@flareapp/js/browser', () => ({
-    registerNavigationSource: vi.fn(() => nav),
-    insulate:
-        (fn: (...a: unknown[]) => void) =>
-        (...a: unknown[]) => {
-            try {
-                fn(...a);
-            } catch {
-                /* swallow */
-            }
-        },
-    safeInvoke: (fn?: (() => void) | null) => {
-        try {
-            fn?.();
-        } catch {
-            /* swallow */
-        }
-    },
-}));
+vi.mock('@flareapp/js/browser', async () => (await import('@flareapp/test-helpers')).browserSeamMock(nav));
 
 import { traceVueRouter } from '../src/traceVueRouter';
 

--- a/packages/vue/tests/vue-router.integration.test.ts
+++ b/packages/vue/tests/vue-router.integration.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createApp } from 'vue';
-import { createMemoryHistory, createRouter, type Router } from 'vue-router';
+import { createMemoryHistory, createRouter, createWebHashHistory, createWebHistory, type Router } from 'vue-router';
 
 const nav = vi.hoisted(() => ({
     startNavigation: vi.fn(),
@@ -9,7 +9,9 @@ const nav = vi.hoisted(() => ({
     settleNavigation: vi.fn(),
     unregister: vi.fn(),
 }));
-vi.mock('@flareapp/js/browser', async () => (await import('@flareapp/test-helpers')).browserSeamMock(nav));
+vi.mock('@flareapp/js/browser', async (importOriginal) =>
+    (await import('@flareapp/test-helpers')).browserSeamMock(nav, await importOriginal()),
+);
 
 import { traceVueRouter } from '../src/traceVueRouter';
 
@@ -39,8 +41,9 @@ beforeEach(() => {
     nav.unregister.mockClear();
 });
 
-// Every RouteName now carries the destination url so the root's url.full follows a redirect hop to
-// its final target instead of keeping the URL the navigation opened with. Same-origin SPA: origin + fullPath.
+// Every RouteName carries the destination url so the root's url.full follows a redirect to its
+// final target instead of keeping the URL the navigation opened with. These routers have no base
+// path, so the url is just origin + path. The two suites below cover the routers that do.
 const u = (path: string): string => `${window.location.origin}${path}`;
 
 describe('traceVueRouter against a real vue-router', () => {
@@ -200,5 +203,73 @@ describe('traceVueRouter against a real vue-router', () => {
         nav.startNavigation.mockClear();
         await router.push('/cart');
         expect(nav.startNavigation).not.toHaveBeenCalled();
+    });
+});
+
+// vue-router reports `fullPath` with the app's base path and `#` prefix taken off, so building the
+// url as origin + fullPath gives an address the server does not have. The url must match the
+// address bar, because it is what a user pastes into a browser to reach the page the span reports.
+describe('traceVueRouter url.full follows the router history', () => {
+    it('keeps the base path an app is served from', async () => {
+        window.history.replaceState({}, '', '/app/');
+        const router = createRouter({
+            history: createWebHistory('/app/'),
+            routes: [
+                { path: '/', component: stub },
+                { path: '/product/:id', component: stub },
+            ],
+        });
+        traceVueRouter(router);
+        mountWith(router);
+        await router.isReady();
+        await router.push('/product/p01');
+
+        expect(nav.settleNavigation).toHaveBeenLastCalledWith({
+            name: '/product/:id',
+            source: 'route',
+            url: u('/app/product/p01'),
+        });
+        expect(nav.startNavigation.mock.calls.at(-1)![0].url).toBe(u('/app/product/p01'));
+    });
+
+    it('keeps the # of a hash-history app', async () => {
+        window.history.replaceState({}, '', '/#/');
+        const router = createRouter({
+            history: createWebHashHistory(),
+            routes: [
+                { path: '/', component: stub },
+                { path: '/product/:id', component: stub },
+            ],
+        });
+        traceVueRouter(router);
+        mountWith(router);
+        await router.isReady();
+        await router.push('/product/p01');
+
+        expect(nav.settleNavigation).toHaveBeenLastCalledWith({
+            name: '/product/:id',
+            source: 'route',
+            url: u('/#/product/p01'),
+        });
+    });
+
+    // The pageload root opens with no url of its own, so url.full starts out as the live
+    // window.location.href, which is already correct. Naming it must not replace that with a
+    // reconstruction that has the base path missing.
+    it('does not damage the pageload root of a base-path app', async () => {
+        window.history.replaceState({}, '', '/app/product/p01');
+        const router = createRouter({
+            history: createWebHistory('/app/'),
+            routes: [{ path: '/product/:id', component: stub }],
+        });
+        traceVueRouter(router);
+        mountWith(router);
+        await router.isReady();
+
+        expect(nav.setActiveRouteName).toHaveBeenCalledWith({
+            name: '/product/:id',
+            source: 'route',
+            url: u('/app/product/p01'),
+        });
     });
 });

--- a/packages/vue/tests/vue-router.test.ts
+++ b/packages/vue/tests/vue-router.test.ts
@@ -63,6 +63,10 @@ beforeEach(() => {
     registerNavigationSource.mockClear();
 });
 
+// Every RouteName now carries the destination url so the root's url.full follows a redirect hop to
+// its final target instead of keeping the URL the navigation opened with. Same-origin SPA: origin + fullPath.
+const u = (path: string): string => `${window.location.origin}${path}`;
+
 describe('traceVueRouter edge cases', () => {
     it('is inert for a non-router value (no registration, no-op cleanup)', () => {
         const stop = traceVueRouter({});
@@ -79,7 +83,7 @@ describe('traceVueRouter edge cases', () => {
         router.fireAfter(cart, home, undefined); // success → settle cart
         expect(nav.startNavigation).toHaveBeenCalledTimes(1);
         expect(nav.settleNavigation).toHaveBeenCalledTimes(1);
-        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/cart', source: 'route' });
+        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/cart', source: 'route', url: u('/cart') });
     });
 
     it('tears down prior instrumentation when the same router is re-instrumented (HMR)', () => {
@@ -96,6 +100,8 @@ describe('traceVueRouter edge cases', () => {
         traceVueRouter(router); // must not throw on install-time enrichment either
         router.fireBefore(product, home); // client nav (home has matched → not initial): opens held root
         router.fireError();
+        // No current route => no destination href, so `url` is omitted and the root keeps the URL it
+        // opened with. Re-stamping url.full to something wrong is worse than leaving it alone.
         expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '', source: 'url' });
     });
 
@@ -107,6 +113,10 @@ describe('traceVueRouter edge cases', () => {
         router.fireBefore(product, START); // from is still START: aborted nav never committed
         router.fireAfter(product, START, undefined); // success → finalizes the pageload name
         expect(nav.startNavigation).not.toHaveBeenCalled();
-        expect(nav.setActiveRouteName).toHaveBeenLastCalledWith({ name: '/product/:id', source: 'route' });
+        expect(nav.setActiveRouteName).toHaveBeenLastCalledWith({
+            name: '/product/:id',
+            source: 'route',
+            url: u('/product/p01'),
+        });
     });
 });

--- a/packages/vue/tests/vue-router.test.ts
+++ b/packages/vue/tests/vue-router.test.ts
@@ -8,8 +8,8 @@ const nav = vi.hoisted(() => ({
     unregister: vi.fn(),
 }));
 const registerNavigationSource = vi.hoisted(() => vi.fn(() => nav));
-vi.mock('@flareapp/js/browser', async () => ({
-    ...(await import('@flareapp/test-helpers')).browserSeamMock(nav),
+vi.mock('@flareapp/js/browser', async (importOriginal) => ({
+    ...(await import('@flareapp/test-helpers')).browserSeamMock(nav, await importOriginal()),
     registerNavigationSource,
 }));
 

--- a/packages/vue/tests/vue-router.test.ts
+++ b/packages/vue/tests/vue-router.test.ts
@@ -8,24 +8,9 @@ const nav = vi.hoisted(() => ({
     unregister: vi.fn(),
 }));
 const registerNavigationSource = vi.hoisted(() => vi.fn(() => nav));
-vi.mock('@flareapp/js/browser', () => ({
+vi.mock('@flareapp/js/browser', async () => ({
+    ...(await import('@flareapp/test-helpers')).browserSeamMock(nav),
     registerNavigationSource,
-    insulate:
-        (fn: (...a: unknown[]) => void) =>
-        (...a: unknown[]) => {
-            try {
-                fn(...a);
-            } catch {
-                /* swallow */
-            }
-        },
-    safeInvoke: (fn?: (() => void) | null) => {
-        try {
-            fn?.();
-        } catch {
-            /* swallow */
-        }
-    },
 }));
 
 import { traceVueRouter } from '../src/traceVueRouter';

--- a/playgrounds/shared/src/routes.ts
+++ b/playgrounds/shared/src/routes.ts
@@ -5,6 +5,7 @@ export const routes = {
     checkout: '/checkout',
     confirmation: '/confirmation',
     broken: '/broken',
+    http: '/http',
     serverError: '/server-error',
 } as const;
 

--- a/playgrounds/shared/src/testIds.ts
+++ b/playgrounds/shared/src/testIds.ts
@@ -8,6 +8,8 @@ export const testIds = {
     confirmation: 'confirmation',
     brokenTrigger: (scenarioId: string) => `trigger-${scenarioId}`,
     logTrigger: (scenarioId: string) => `log-trigger-${scenarioId}`,
+    httpTrigger: (scenarioId: string) => `http-trigger-${scenarioId}`,
+    httpResult: 'http-result',
     boundaryFallback: 'boundary-fallback',
     boundaryReset: 'boundary-reset',
 } as const;

--- a/playgrounds/svelte/src/hooks.client.ts
+++ b/playgrounds/svelte/src/hooks.client.ts
@@ -1,5 +1,9 @@
 import { initFlareClient } from '$lib/flare.client';
-import { handleErrorWithFlare } from '@flareapp/sveltekit/client';
+import { startNavProbe } from '$lib/navProbe.svelte';
+import { handleErrorWithFlare, traceSvelteKitRouter } from '@flareapp/sveltekit/client';
 
 initFlareClient();
+traceSvelteKitRouter();
+startNavProbe();
+
 export const handleError = handleErrorWithFlare();

--- a/playgrounds/svelte/src/lib/flare.client.ts
+++ b/playgrounds/svelte/src/lib/flare.client.ts
@@ -8,6 +8,12 @@ export const initFlareClient = (): void => {
         flare.configure({
             ingestUrl: url,
             logsIngestUrl: url.replace('/v1/errors', '/v1/logs'),
+            tracesIngestUrl: url.replace('/v1/errors', '/v1/traces'),
+            // e2e-only timing: keep the pageload/navigation root active long enough for a prompt
+            // Playwright click to land and nest under it, then flush an ended root fast so arrival
+            // assertions don't need to wait out the production default.
+            idleTimeout: 2000,
+            spanFlushIntervalMs: 500,
         });
     }
 
@@ -17,6 +23,8 @@ export const initFlareClient = (): void => {
         // and fail like the error reports do). The fake-server logsIngestUrl
         // override above only applies under e2e (VITE_FLARE_URL set).
         enableLogs: true,
+        enableTracing: true,
+        tracesSampleRate: 1,
         beforeEvaluate: (error) => (error.message === 'hook-drop-report' ? null : error),
         beforeSubmit: (report) => {
             if (report.message === 'hook-mutate-report') {

--- a/playgrounds/svelte/src/lib/navProbe.svelte.ts
+++ b/playgrounds/svelte/src/lib/navProbe.svelte.ts
@@ -1,0 +1,22 @@
+import { navigating } from '$app/state';
+
+declare global {
+    interface Window {
+        __navStates?: string[];
+    }
+}
+
+/**
+ * Record every `navigating` transition an effect root created at client-init actually observes.
+ * Playground-only: it exists so the e2e suite can prove the non-null state is not batched away,
+ * which is the one assumption traceSvelteKitRouter rests on. Mirrors the SDK's effect shape (an
+ * `$effect.root` from a `.svelte.ts` module invoked by hooks.client.ts) as closely as possible.
+ */
+export function startNavProbe(): void {
+    window.__navStates = [];
+    $effect.root(() => {
+        $effect(() => {
+            window.__navStates?.push(navigating.to ? `to:${navigating.to.url.pathname}` : 'null');
+        });
+    });
+}

--- a/playgrounds/svelte/src/routes/+layout.svelte
+++ b/playgrounds/svelte/src/routes/+layout.svelte
@@ -17,6 +17,7 @@
                 <a href="/" class="text-sm font-medium hover:text-brand">Shop</a>
                 <a href="/cart" class="text-sm font-medium hover:text-brand">Cart</a>
                 <a href="/broken" class="text-sm font-medium hover:text-brand">Broken</a>
+                <a href="/http" class="text-sm font-medium hover:text-brand">HTTP</a>
                 <a
                     href="/cart"
                     class="rounded-full bg-brand px-3 py-1 text-xs font-semibold text-white"

--- a/playgrounds/svelte/src/routes/api/echo/+server.ts
+++ b/playgrounds/svelte/src/routes/api/echo/+server.ts
@@ -1,0 +1,15 @@
+import { json } from '@sveltejs/kit';
+
+import type { RequestHandler } from './$types';
+
+/**
+ * Echo endpoint for the HTTP tracing scenarios. `status` forces a response code so a failing
+ * request can be traced too; `delay` widens the request window so a span has measurable duration.
+ */
+export const GET: RequestHandler = async ({ url }) => {
+    const status = Number(url.searchParams.get('status') ?? '200');
+    const delay = Number(url.searchParams.get('delay') ?? '0');
+    if (delay > 0) await new Promise((resolve) => setTimeout(resolve, Math.min(delay, 2000)));
+    if (status !== 200) return new Response(`echo-${status}`, { status });
+    return json({ ok: true, at: url.searchParams.get('scenario') ?? 'unknown' });
+};

--- a/playgrounds/svelte/src/routes/http/+page.svelte
+++ b/playgrounds/svelte/src/routes/http/+page.svelte
@@ -1,0 +1,82 @@
+<script lang="ts">
+    import { testIds } from '@flareapp/playgrounds-shared';
+
+    let { data } = $props();
+    let result = $state<string>('idle');
+
+    const scenarios: Array<{ id: string; label: string; run: () => Promise<void> }> = [
+        {
+            id: 'fetch-ok',
+            label: 'fetch: GET 200',
+            run: async () => {
+                const res = await fetch('/api/echo?scenario=fetch-ok&delay=50');
+                result = `fetch-ok:${res.status}`;
+            },
+        },
+        {
+            id: 'fetch-404',
+            label: 'fetch: GET 404 (span still ends)',
+            run: async () => {
+                const res = await fetch('/api/echo?scenario=fetch-404&status=404');
+                result = `fetch-404:${res.status}`;
+            },
+        },
+        {
+            id: 'fetch-500',
+            label: 'fetch: GET 500',
+            run: async () => {
+                const res = await fetch('/api/echo?scenario=fetch-500&status=500');
+                result = `fetch-500:${res.status}`;
+            },
+        },
+        {
+            id: 'xhr-ok',
+            label: 'XHR: GET 200',
+            run: () =>
+                new Promise((resolve) => {
+                    const xhr = new XMLHttpRequest();
+                    xhr.open('GET', '/api/echo?scenario=xhr-ok&delay=50');
+                    xhr.onloadend = () => {
+                        result = `xhr-ok:${xhr.status}`;
+                        resolve();
+                    };
+                    xhr.send();
+                }),
+        },
+        {
+            id: 'xhr-404',
+            label: 'XHR: GET 404',
+            run: () =>
+                new Promise((resolve) => {
+                    const xhr = new XMLHttpRequest();
+                    xhr.open('GET', '/api/echo?scenario=xhr-404&status=404');
+                    xhr.onloadend = () => {
+                        result = `xhr-404:${xhr.status}`;
+                        resolve();
+                    };
+                    xhr.send();
+                }),
+        },
+    ];
+</script>
+
+<section>
+    <h1 class="text-xl font-semibold mb-2">HTTP playground</h1>
+    <p class="text-sm opacity-70 mb-6">
+        Each button fires one request. Loaded via Kit's load fetch: {data.loaded.at}
+    </p>
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-3">
+        {#each scenarios as scenario (scenario.id)}
+            <button
+                type="button"
+                data-testid={testIds.httpTrigger(scenario.id)}
+                onclick={() => void scenario.run()}
+                class="rounded-lg border border-surface-border bg-surface px-4 py-3 text-left text-sm hover:border-brand"
+            >
+                <div class="font-medium">{scenario.label}</div>
+                <div class="text-xs opacity-60 font-mono">{scenario.id}</div>
+            </button>
+        {/each}
+    </div>
+    <p class="mt-6 text-sm font-mono opacity-70" data-testid={testIds.httpResult}>{result}</p>
+</section>

--- a/playgrounds/svelte/src/routes/http/+page.ts
+++ b/playgrounds/svelte/src/routes/http/+page.ts
@@ -1,9 +1,9 @@
 import type { PageLoad } from './$types';
 
 /**
- * Universal load using the `fetch` SvelteKit provides. Kit routes it through `window.fetch` at call
- * time (fetcher.js:137 -> :151), so Flare's patch sees it and it MUST produce a browser_fetch span
- * on client navigation. On the server there is no patch and no span, which is expected.
+ * Universal load using the `fetch` SvelteKit provides. Kit sends it through `window.fetch` when it
+ * is called, so our patch sees it and it produces a browser_fetch span on a client navigation. On
+ * the server there is no patch and no span, which is expected.
  */
 export const load: PageLoad = async ({ fetch }) => {
     const res = await fetch('/api/echo?scenario=kit-load-fetch&delay=50');

--- a/playgrounds/svelte/src/routes/http/+page.ts
+++ b/playgrounds/svelte/src/routes/http/+page.ts
@@ -1,0 +1,11 @@
+import type { PageLoad } from './$types';
+
+/**
+ * Universal load using the `fetch` SvelteKit provides. Kit routes it through `window.fetch` at call
+ * time (fetcher.js:137 -> :151), so Flare's patch sees it and it MUST produce a browser_fetch span
+ * on client navigation. On the server there is no patch and no span, which is expected.
+ */
+export const load: PageLoad = async ({ fetch }) => {
+    const res = await fetch('/api/echo?scenario=kit-load-fetch&delay=50');
+    return { loaded: (await res.json()) as { ok: boolean; at: string } };
+};


### PR DESCRIPTION
## What

The fourth router-tracing slice, after TanStack (#69), React Router v7 (#72) and vue-router (#74).

- Adds `traceSvelteKitRouter` to `@flareapp/sveltekit/client`. Names the `browser_pageload` and `browser_navigation` roots with the parameterized route (`/product/[id]`) and sets `flare.route.source`.
- Adds an optional `url` to the `RouteName` seam, shared by all four slices, so a redirect updates the root's `url.full`.
- Fixes a base-path and hash bug in that url, across all four slices. It was built as `origin + path`, which drops the app's base path and `#` prefix (a `/app/` app reported `/product/p01` for the real `/app/product/p01`). Each slice now uses the router's own base-aware call: vue `resolve().href`, React Router `createHref()`, TanStack `publicHref`. SvelteKit already passed a real `URL`.
- Fixes a `@flareapp/js` fetch bug. Rebuilding `init` to inject the traceparent dropped Kit's hidden `__sveltekit_fetch__` flag, which made Kit warn about using `window.fetch` in a `load` function. It now copies property descriptors. Dev-only, no span was affected.
- Extracts the shared nav-seam test mock (`browserSeamMock`) to `@flareapp/test-helpers`; five suites use it.
- Adds an `/http` playground page and e2e checking `browser_fetch` and `browser_xhr` nest under the active root.

```ts
// hooks.client.ts
import { handleErrorWithFlare, traceSvelteKitRouter } from '@flareapp/sveltekit/client';

initFlareClient();
traceSvelteKitRouter(); // no-op while tracing is off; returns a cleanup

export const handleError = handleErrorWithFlare();
```

## Why

- `$app/state`, not Sentry's deprecated `$app/stores`. Sentry is stuck on the old API for Svelte 3/4 support; our peers already need Svelte 5 and Kit 2.12+.
- Effects batch, so the risk was Svelte running the `navigating` non-null and null updates together and dropping spans. A playground probe confirmed the transition is seen, so it does not happen.
- One held root, re-named across a redirect, instead of ending one span and starting another. Matches the vue and react slices.

## Manual tests

- By hand: `npm run playgrounds:svelte`, open `/http`, click the fetch and xhr scenarios. Spans nest under the active root.
- Automated: 1414 unit tests, 106/106 e2e across five playgrounds, TypeScript clean. sveltekit has 59 tests, 22 for this module.
- I checked the load-bearing tests by breaking the code they cover (the `inFlight` clear, the fallback `lastKey` stamp, the hydration guard, the base-path and hash href). Each one fails as expected.

## Notes for the reviewer

- **Blocks publish, not merge.** `/client` imports `registerNavigationSource`, `insulate` and `safeInvoke` from `@flareapp/js/browser`, which published `js@2.6.0` does not export, and the peer floor is still `^2.6.0`. On `js@2.6.0` the whole `/client` entry throws on import, including `handleErrorWithFlare`. Needs the coordinated peer bump across react, vue, svelte and sveltekit that #72 and #74 flagged. React and vue import the new `absoluteHref` too.
- **Open findings, not yet fixed:**
  - The fallback branch is reachable (shallow routing, then a form-action error). There it emits the old route name with the new url, tagged `source: 'route'`. Fix: name that case from the url, or drop the span.
  - The `$app/state` shim types `willUnload` as `boolean`; Kit's is `boolean | null`. Harmless today, since it is only read where `to` is non-null.
  - `tracing = true` is set before the wiring can throw, so a throw in `registerNavigationSource()` leaves tracing stuck off until cleanup runs.
- `svelte-package` does not compile runes out of `.svelte.ts`, so a literal `$effect.root(` in `dist` is correct (same as the shipping `trackRouteContext.svelte.js`). `vitest.config.mts` needs `resolve.conditions: ['browser']`, or `$effect` does nothing in tests.
- **Backend:** the contract is built in flareapp.io#2501 (draft) and ships with this client. Two prerequisites sit outside that PR and are not verified from here: `/v1/traces` accepting the public key with CORS, and `spatie/laravel-flare` reading the inbound `traceparent` header.
