### PR TITLE
fix(js): keep non-enumerable init properties when injecting traceparent

### DIFF
--- a/packages/js/src/tracing/propagation.ts
+++ b/packages/js/src/tracing/propagation.ts
@@ -87,7 +87,17 @@ export function mergeTraceparentHeader(
         headers = { traceparent };
     }
 
-    const result: RequestInit = { ...init, headers };
+    // Copy every own descriptor rather than spreading: a spread takes only ENUMERABLE own
+    // properties, and callers brand `init` with non-enumerable markers. SvelteKit tags the init it
+    // hands a `load` function with a non-enumerable `__sveltekit_fetch__`, and its dev-mode
+    // `window.fetch` wrapper tells the developer to "use the `fetch` passed to your load function"
+    // when the tag is missing, so dropping it makes Flare scold them for code that is already right.
+    const result: RequestInit = { headers };
+    if (init) {
+        const descriptors = Object.getOwnPropertyDescriptors(init);
+        delete descriptors.headers; // the merged headers above win
+        Object.defineProperties(result, descriptors);
+    }
     // A Request with a ReadableStream body requires `duplex` when re-issued with an init;
     // without it fetch throws and breaks a host request that worked pre-tracing.
     if (

--- a/packages/js/tests/propagation.test.ts
+++ b/packages/js/tests/propagation.test.ts
@@ -229,4 +229,49 @@ describe('mergeTraceparentHeader', () => {
         const init = mergeTraceparentHeader(req, undefined, TP);
         expect((init as RequestInit & { duplex?: string })!.duplex).toBeUndefined();
     });
+
+    // A spread copies only ENUMERABLE own properties. Callers brand `init` with non-enumerable
+    // markers: SvelteKit's `dev_fetch` tags the init it hands a `load` function with a
+    // non-enumerable `__sveltekit_fetch__`, and its dev-mode `window.fetch` wrapper warns the
+    // developer to "use the `fetch` passed to your load function" when the tag is missing. Rebuilding
+    // the init to inject `traceparent` must not strip it, or Flare makes SvelteKit scold developers
+    // for something they are already doing correctly.
+    it('preserves a NON-ENUMERABLE own property on the caller init (regression)', () => {
+        const callerInit: RequestInit = { method: 'GET' };
+        Object.defineProperty(callerInit, '__sveltekit_fetch__', {
+            value: true,
+            writable: true,
+            configurable: true,
+        });
+
+        const init = mergeTraceparentHeader('https://app.example/x', callerInit, TP);
+
+        expect((init as Record<string, unknown>).__sveltekit_fetch__).toBe(true);
+        expect((init!.headers as Record<string, string>).traceparent).toBe(TP);
+        expect(init!.method).toBe('GET');
+    });
+
+    it('keeps a preserved non-enumerable property non-enumerable (regression)', () => {
+        const callerInit: RequestInit = {};
+        Object.defineProperty(callerInit, '__sveltekit_fetch__', {
+            value: true,
+            writable: true,
+            configurable: true,
+        });
+
+        const init = mergeTraceparentHeader('https://app.example/x', callerInit, TP);
+
+        // Re-enumerating it would leak the marker into anything that spreads or serializes the init.
+        expect(Object.keys(init!)).not.toContain('__sveltekit_fetch__');
+        expect(Object.getOwnPropertyDescriptor(init!, '__sveltekit_fetch__')?.enumerable).toBe(false);
+    });
+
+    it('does not mutate the caller init when preserving its own properties', () => {
+        const callerInit: RequestInit = { method: 'POST', headers: { a: '1' } };
+
+        const init = mergeTraceparentHeader('https://app.example/x', callerInit, TP);
+
+        expect(init).not.toBe(callerInit);
+        expect(callerInit.headers).toEqual({ a: '1' }); // no traceparent leaked back
+    });
 });


### PR DESCRIPTION
Flare's fetch instrumentation makes SvelteKit tell developers to stop doing the thing they are already doing correctly:

```
Loading http://localhost:5183/api/echo?... using `window.fetch`.
For best results, use the `fetch` that is passed to your `load` function
```

That fires on every `load({ fetch })` call in dev once tracing is enabled, and the advice is wrong — the developer *is* using the load fetch.

Found while building the SvelteKit tracing slice (#77). Independent of it; this branch is off `main`.

## Root cause

`mergeTraceparentHeader` rebuilt the init with a spread:

```ts
const result: RequestInit = { ...init, headers };
```

A spread copies only **enumerable own** properties. SvelteKit's `dev_fetch` brands the init it hands a `load` function with a **non-enumerable** marker (`runtime/client/fetcher.js`):

```js
Object.defineProperty(patched_opts, '__sveltekit_fetch__', {
    value: true, writable: true, configurable: true,   // enumerable defaults to false
});
return window.fetch(resource, patched_opts);
```

`window.fetch` is Flare's patch, so the chain is `flarePatch -> kitWrapper -> native`. Flare rebuilds the init to inject `traceparent`, the brand is dropped, and Kit's dev wrapper (`if (in_load_heuristic && !used_kit_fetch)`) then warns.

Nothing SvelteKit-specific is wrong here — the bug is that we silently discard any non-enumerable own property a caller put on `init`. The fix is generic; SvelteKit is just the library that noticed.

## Fix

Copy every own descriptor instead of spreading, then let the merged headers win:

```ts
const result: RequestInit = { headers };
if (init) {
    const descriptors = Object.getOwnPropertyDescriptors(init);
    delete descriptors.headers;
    Object.defineProperties(result, descriptors);
}
```

This also preserves symbol keys and property attributes, and still returns a fresh object — the caller's `init` and `Request` are untouched, as before. The caller-wins branches already returned `init` unchanged and were never affected.

## Scope

Only the inject path was affected: `finalInit` is rebuilt solely when `traceparentFor()` returns a value (`instrumentFetch.ts`). No behaviour change when tracing is off, for ingest URLs, or when the caller already set `traceparent`. XHR takes no init and is unaffected.

## Verification

Unit (TDD, watched fail first): 3 tests in `packages/js/tests/propagation.test.ts` — the marker survives, it stays non-enumerable (re-enumerating it would leak into anything that spreads or serializes the init), and the caller's init is not mutated. Before the fix the first two fail with `expected undefined to be true`.

End-to-end against real SvelteKit, with a control, since "no warning" proves nothing on its own:

| | Kit load-fetch warnings |
| --- | --- |
| without fix | **1** — `Loading .../api/echo?scenario=kit-load-fetch... using \`window.fetch\`` |
| with fix | **0** |

Full monorepo: 1373 unit tests, TypeScript clean, lint clean.

## Impact

Dev-only (Kit gates its `window.fetch` wrapper on `DEV && BROWSER`) and tracing-only. No span was ever wrong and no production behaviour changes — the cost was purely misleading console noise that would have generated support questions the moment tracing shipped to SvelteKit users.