### PR TITLE
fix(sveltekit): address review findings on #77

### DIFF
--- a/e2e/specs/js.spec.ts
+++ b/e2e/specs/js.spec.ts
@@ -1,25 +1,8 @@
 import { testIds } from '../../playgrounds/shared/src';
 import { expect, test } from '../fixtures/fake-flare';
 import { logScenariosFor, runLogScenario } from './logShared';
+import { attr, hasSpanType, spansOf } from './otlp';
 import { runScenario, scenariosFor } from './shared';
-
-type OtlpSpan = {
-    name: string;
-    spanId: string;
-    parentSpanId: string | null;
-    traceId: string;
-    attributes: Array<{ key: string; value: Record<string, unknown> }>;
-};
-
-const spansOf = (bodyJson: unknown): OtlpSpan[] =>
-    ((bodyJson as { resourceSpans?: Array<{ scopeSpans?: Array<{ spans?: OtlpSpan[] }> }> }).resourceSpans ?? [])
-        .flatMap((r) => r.scopeSpans ?? [])
-        .flatMap((s) => s.spans ?? []);
-
-const attr = (span: OtlpSpan, key: string): unknown => span.attributes.find((a) => a.key === key)?.value;
-
-const hasSpanType = (span: OtlpSpan, type: string): boolean =>
-    JSON.stringify(attr(span, 'flare.span_type') ?? '').includes(type);
 
 test.describe('js playground', () => {
     test('renders product grid', async ({ page }) => {

--- a/e2e/specs/otlp.ts
+++ b/e2e/specs/otlp.ts
@@ -1,4 +1,6 @@
-// Shared OTLP trace-span parsing helpers for the tracing e2e specs (react, react-router, svelte).
+// Shared OTLP trace-span parsing helpers for the tracing e2e specs (js, react, react-router, svelte).
+
+import type { FakeFlare } from '../fixtures/fake-flare';
 
 export type OtlpSpan = {
     name: string;
@@ -18,3 +20,21 @@ export const attr = (span: OtlpSpan, key: string): unknown => span.attributes.fi
 
 export const hasSpanType = (span: OtlpSpan, type: string): boolean =>
     JSON.stringify(attr(span, 'flare.span_type') ?? '').includes(type);
+
+/** A span's `url.full`, JSON-stringified so a missing attribute matches nothing instead of throwing. */
+export const urlOf = (span: OtlpSpan): string => JSON.stringify(attr(span, 'url.full') ?? '');
+
+/**
+ * Wait for the envelope carrying a child's parent root. A root holds open for its idle window while
+ * request spans flush eagerly, so the parent routinely arrives in a LATER envelope than the child:
+ * poll across every captured trace rather than searching the one the child was found in.
+ */
+export const waitForParentEnvelope = (fakeFlare: FakeFlare, child: OtlpSpan) =>
+    fakeFlare.waitForTrace({
+        timeout: 9000,
+        predicate: (r) => spansOf(r.bodyJson).some((s) => s.spanId === child.parentSpanId),
+    });
+
+/** The root a child nests under, or undefined if that envelope has not arrived yet. */
+export const parentOf = async (fakeFlare: FakeFlare, child: OtlpSpan): Promise<OtlpSpan | undefined> =>
+    spansOf((await waitForParentEnvelope(fakeFlare, child)).bodyJson).find((s) => s.spanId === child.parentSpanId);

--- a/e2e/specs/svelte.spec.ts
+++ b/e2e/specs/svelte.spec.ts
@@ -1,7 +1,7 @@
 import { testIds } from '../../playgrounds/shared/src';
-import { expect, type FakeFlare, test } from '../fixtures/fake-flare';
+import { expect, test } from '../fixtures/fake-flare';
 import { logScenariosFor, runLogScenario } from './logShared';
-import { attr, hasSpanType, type OtlpSpan, spansOf } from './otlp';
+import { attr, hasSpanType, parentOf, spansOf, urlOf } from './otlp';
 import { runScenario, scenariosFor } from './shared';
 
 test.describe('svelte playground', () => {
@@ -143,19 +143,6 @@ test.describe('svelte tracing', () => {
 });
 
 test.describe('svelte http tracing', () => {
-    const urlOf = (span: OtlpSpan) => JSON.stringify(attr(span, 'url.full') ?? '');
-
-    /**
-     * A request span's parent root can flush in an earlier envelope than the request itself (roots
-     * hold open for their idle window; requests flush eagerly), so poll across every captured trace
-     * rather than the single envelope the request span was found in.
-     */
-    const waitForParentEnvelope = (fakeFlare: FakeFlare, child: OtlpSpan) =>
-        fakeFlare.waitForTrace({
-            timeout: 9000,
-            predicate: (r) => spansOf(r.bodyJson).some((s) => s.spanId === child.parentSpanId),
-        });
-
     test('a fetch fires a browser_fetch span nested under the active root', async ({ page, fakeFlare }) => {
         await page.goto('/http');
         await page.waitForLoadState('networkidle');
@@ -174,8 +161,7 @@ test.describe('svelte http tracing', () => {
 
         // The real assertion: it nests under a root, not orphaned at the top level.
         expect(fetchSpan!.parentSpanId).toBeTruthy();
-        const rootTrace = await waitForParentEnvelope(fakeFlare, fetchSpan!);
-        const root = spansOf(rootTrace.bodyJson).find((s) => s.spanId === fetchSpan!.parentSpanId);
+        const root = await parentOf(fakeFlare, fetchSpan!);
         expect(root).toBeTruthy();
         expect(hasSpanType(root!, 'browser_pageload') || hasSpanType(root!, 'browser_navigation')).toBe(true);
     });
@@ -246,10 +232,52 @@ test.describe('svelte http tracing', () => {
         expect(attr(xhrSpan!, 'http.request.method')).toEqual({ stringValue: 'GET' });
 
         expect(xhrSpan!.parentSpanId).toBeTruthy();
-        const rootTrace = await waitForParentEnvelope(fakeFlare, xhrSpan!);
-        const root = spansOf(rootTrace.bodyJson).find((s) => s.spanId === xhrSpan!.parentSpanId);
+        const root = await parentOf(fakeFlare, xhrSpan!);
         expect(root).toBeTruthy();
         expect(hasSpanType(root!, 'browser_pageload') || hasSpanType(root!, 'browser_navigation')).toBe(true);
+    });
+
+    // The fetch 404/500 pair above pins both sides of endHttpRequestSpan's status branch. XHR runs
+    // through the same span helper but a different patch, so pin that its 404 is recorded rather
+    // than assumed to behave like fetch's.
+    test('a failing XHR records its status without marking the span an error', async ({ page, fakeFlare }) => {
+        await page.goto('/http');
+        await page.waitForLoadState('networkidle');
+
+        await page.getByTestId(testIds.httpTrigger('xhr-404')).click();
+        await expect(page.getByTestId(testIds.httpResult)).toHaveText('xhr-404:404');
+
+        const trace = await fakeFlare.waitForTrace({
+            timeout: 9000,
+            predicate: (r) =>
+                spansOf(r.bodyJson).some((s) => hasSpanType(s, 'browser_xhr') && urlOf(s).includes('xhr-404')),
+        });
+        const span = spansOf(trace.bodyJson).find((s) => hasSpanType(s, 'browser_xhr') && urlOf(s).includes('xhr-404'));
+        expect(span).toBeTruthy();
+        expect(attr(span!, 'http.response.status_code')).toEqual({ intValue: 404 });
+        expect(span!.status?.code ?? 0).toBe(0);
+    });
+
+    // REGRESSION TEST FOR THE TRACEPARENT INIT REBUILD. Kit's dev_fetch brands the init it hands a
+    // `load` fetch with a NON-ENUMERABLE `__sveltekit_fetch__`, and its dev-mode window.fetch wrapper
+    // warns when the brand is missing. Flare patches window.fetch after Kit's, so rebuilding the init
+    // to inject traceparent used to spread the brand away and make Kit scold the developer for using
+    // `window.fetch` in a load function while they were already using the right one. Unit tests pin
+    // mergeTraceparentHeader in isolation; only this catches the symptom as reported. Needs dev mode
+    // (Kit gates the wrapper on DEV && BROWSER), which is what the default e2e webServer runs.
+    test('Kit does not warn about window.fetch for a traced load fetch', async ({ page }) => {
+        const warnings: string[] = [];
+        page.on('console', (msg) => {
+            if (msg.type() === 'warning') warnings.push(msg.text());
+        });
+
+        await page.goto('/');
+        await page.waitForLoadState('networkidle');
+        await page.getByRole('link', { name: 'HTTP' }).click(); // client nav => load fetch runs in the browser
+        await expect(page).toHaveURL(/\/http$/);
+        await expect(page.getByTestId(testIds.httpResult)).toBeVisible();
+
+        expect(warnings.filter((w) => /using `window.fetch`/.test(w))).toEqual([]);
     });
 
     // PINS VERIFIED FACT 11. Kit's fetcher.js:9 captures `native_fetch = window.fetch` at module
@@ -276,8 +304,7 @@ test.describe('svelte http tracing', () => {
 
         // It fired during the navigation, so it must nest under the navigation root, not the pageload.
         expect(loadFetch!.parentSpanId).toBeTruthy();
-        const rootTrace = await waitForParentEnvelope(fakeFlare, loadFetch!);
-        const root = spansOf(rootTrace.bodyJson).find((s) => s.spanId === loadFetch!.parentSpanId);
+        const root = await parentOf(fakeFlare, loadFetch!);
         expect(root && hasSpanType(root, 'browser_navigation')).toBe(true);
     });
 });

--- a/packages/js/src/browser/context/collectBrowserSpanContext.ts
+++ b/packages/js/src/browser/context/collectBrowserSpanContext.ts
@@ -1,4 +1,5 @@
 import type { Attributes, Config } from '@flareapp/core';
+import { redactUrlQuery } from '@flareapp/core';
 
 import { browserEntryPoint } from './collectBrowser';
 import request from './request';
@@ -21,6 +22,24 @@ export const collectBrowserSpanContext = (config: Readonly<Config>, hrefOverride
     }
     const href = resolveHref(hrefOverride);
     return { ...browserEntryPoint(config, href), ...request(config.urlDenylist, href) };
+};
+
+/**
+ * The URL-derived subset of a root's context, for re-stamping a root whose destination changed
+ * after it opened: a redirect hop, or a navigation superseded by a newer one. Both re-name a root
+ * that `startNavigation` already stamped from the FIRST destination, which would otherwise keep
+ * reporting a URL the user never landed on.
+ *
+ * Deliberately excludes `flare.entry_point.handler.identifier`: on a named root the route template
+ * owns it, and re-deriving it from the href would clobber `/product/[id]` back to `/product/p01`.
+ * Returns `{}` for an unparseable href, so a bad destination leaves the existing values intact.
+ */
+export const browserSpanUrlAttributes = (config: Readonly<Config>, href: string): Attributes => {
+    if (typeof window === 'undefined') return {};
+    const resolved = resolveHref(href);
+    if (resolved === undefined) return {};
+    const redacted = redactUrlQuery(resolved, config.urlDenylist);
+    return { 'url.full': redacted, 'flare.entry_point.value': redacted };
 };
 
 /** Normalize an override href once; undefined (fall back to live location) when unparseable. */

--- a/packages/js/src/tracing/browserTracing.ts
+++ b/packages/js/src/tracing/browserTracing.ts
@@ -1,6 +1,6 @@
 import { defaultNowNano, type Config, type Span, type SpanOptions, type Tracer } from '@flareapp/core';
 
-import { collectBrowserSpanContext } from '../browser/context/collectBrowserSpanContext';
+import { browserSpanUrlAttributes, collectBrowserSpanContext } from '../browser/context/collectBrowserSpanContext';
 import { fill, unfill } from './fill';
 import { IdleRootController, type IdleTimeouts } from './IdleRootController';
 import { pageloadEndNano, pageloadStartNano, resolvePageloadStartNano } from './navigationTiming';
@@ -13,7 +13,16 @@ export type BrowserTracingFlare = {
     tracer: Pick<Tracer, 'addSpanListener' | 'setActiveRoot' | 'flush' | 'getActiveSpan'>;
 };
 
-export type RouteName = { name: string; source: 'route' | 'url' };
+export type RouteName = {
+    name: string;
+    source: 'route' | 'url';
+    /**
+     * Destination href. When set, re-stamps the root's `url.full` + `flare.entry_point.value` in
+     * lockstep with the name, so a redirected or superseded navigation reports where it actually
+     * landed rather than the destination it opened with. Omit to leave the opening URL alone.
+     */
+    url?: string;
+};
 export type NavigationSource = {
     startNavigation(opts?: { path?: string; url?: string; hold?: boolean }): void;
     setActiveRouteName(route: RouteName): void;
@@ -206,6 +215,10 @@ function applyRouteName(route: RouteName): void {
             currentRoot.name = route.name;
             currentRoot.setAttribute('flare.entry_point.handler.identifier', route.name);
             currentRoot.setAttribute('flare.route.source', route.source);
+            if (route.url !== undefined && activeFlare) {
+                const urlAttrs = browserSpanUrlAttributes(activeFlare.config, route.url);
+                for (const key of Object.keys(urlAttrs)) currentRoot.setAttribute(key, urlAttrs[key]);
+            }
         } catch {
             // instrumentation must never throw into the host app
         }

--- a/packages/js/src/tracing/propagation.ts
+++ b/packages/js/src/tracing/propagation.ts
@@ -87,7 +87,17 @@ export function mergeTraceparentHeader(
         headers = { traceparent };
     }
 
-    const result: RequestInit = { ...init, headers };
+    // Copy every own descriptor rather than spreading: a spread takes only ENUMERABLE own
+    // properties, and callers brand `init` with non-enumerable markers. SvelteKit tags the init it
+    // hands a `load` function with a non-enumerable `__sveltekit_fetch__`, and its dev-mode
+    // `window.fetch` wrapper tells the developer to "use the `fetch` passed to your load function"
+    // when the tag is missing, so dropping it makes Flare scold them for code that is already right.
+    const result: RequestInit = { headers };
+    if (init) {
+        const descriptors = Object.getOwnPropertyDescriptors(init);
+        delete descriptors.headers; // the merged headers above win
+        Object.defineProperties(result, descriptors);
+    }
     // A Request with a ReadableStream body requires `duplex` when re-issued with an init;
     // without it fetch throws and breaks a host request that worked pre-tracing.
     if (

--- a/packages/js/tests/navigationSource.test.ts
+++ b/packages/js/tests/navigationSource.test.ts
@@ -114,6 +114,73 @@ describe('registerNavigationSource', () => {
         src.unregister();
     });
 
+    // THE REDIRECT CASE. `startNavigation` stamps url.full from the FIRST destination, but a redirect
+    // hop (or a newer nav superseding this one) re-names the SAME held root. Without the re-stamp the
+    // root reports the parameterized name of where it landed next to the URL it never landed on.
+    it('setActiveRouteName re-stamps url.full + entry_point.value when a url rides along', () => {
+        vi.useFakeTimers();
+        window.history.replaceState({}, '', '/');
+        const { flare, spans } = fakeFlare();
+        startBrowserTracing(flare);
+        const src = registerNavigationSource();
+
+        src.startNavigation({ path: '/old', url: 'https://app.example/old', hold: true });
+        src.setActiveRouteName({ name: '/cart', source: 'route', url: 'https://app.example/cart' });
+
+        const nav = spans[1];
+        expect(nav.attrs['url.full']).toBe('https://app.example/cart');
+        expect(nav.attrs['flare.entry_point.value']).toBe('https://app.example/cart');
+        // The route template still owns the identifier: re-deriving it from the href would clobber
+        // '/cart' back to a URL-shaped name.
+        expect(nav.attrs['flare.entry_point.handler.identifier']).toBe('/cart');
+        src.unregister();
+    });
+
+    // `attrs` records only setAttribute calls, so an absent key here means no re-stamp was attempted
+    // and the root keeps whatever startNavigation stamped at creation.
+    it('omitting url leaves the url the root opened with untouched', () => {
+        vi.useFakeTimers();
+        const { flare, startSpan, spans } = fakeFlare();
+        startBrowserTracing(flare);
+        const src = registerNavigationSource();
+
+        src.startNavigation({ path: '/old', url: 'https://app.example/old', hold: true });
+        src.settleNavigation({ name: '/old', source: 'route' }); // no url
+
+        expect(spans[1].attrs['url.full']).toBeUndefined(); // no re-stamp
+        expect(startSpan.mock.calls[1]![1]!.attributes?.['url.full']).toBe('https://app.example/old');
+        src.unregister();
+    });
+
+    it('an unparseable url leaves the existing url.full intact rather than poisoning it', () => {
+        vi.useFakeTimers();
+        const { flare, startSpan, spans } = fakeFlare();
+        startBrowserTracing(flare);
+        const src = registerNavigationSource();
+
+        src.startNavigation({ path: '/old', url: 'https://app.example/old', hold: true });
+        src.setActiveRouteName({ name: '/cart', source: 'route', url: 'http://[' });
+
+        expect(spans[1].attrs['url.full']).toBeUndefined(); // rejected, not written
+        expect(startSpan.mock.calls[1]![1]!.attributes?.['url.full']).toBe('https://app.example/old');
+        expect(spans[1].span.name).toBe('/cart'); // the rename still lands
+        src.unregister();
+    });
+
+    it('the re-stamped url is redacted by urlDenylist like the opening one', () => {
+        vi.useFakeTimers();
+        const { flare, spans } = fakeFlare();
+        (flare.config as { urlDenylist: RegExp }).urlDenylist = /token/;
+        startBrowserTracing(flare);
+        const src = registerNavigationSource();
+
+        src.startNavigation({ path: '/old', url: 'https://app.example/old', hold: true });
+        src.settleNavigation({ name: '/cart', source: 'route', url: 'https://app.example/cart?token=secret' });
+
+        expect(spans[1].attrs['url.full']).not.toContain('secret');
+        src.unregister();
+    });
+
     it('setActiveRouteName no-ops once the active root has ended', () => {
         vi.useFakeTimers();
         const { flare, spans } = fakeFlare();

--- a/packages/js/tests/propagation.test.ts
+++ b/packages/js/tests/propagation.test.ts
@@ -229,4 +229,49 @@ describe('mergeTraceparentHeader', () => {
         const init = mergeTraceparentHeader(req, undefined, TP);
         expect((init as RequestInit & { duplex?: string })!.duplex).toBeUndefined();
     });
+
+    // A spread copies only ENUMERABLE own properties. Callers brand `init` with non-enumerable
+    // markers: SvelteKit's `dev_fetch` tags the init it hands a `load` function with a
+    // non-enumerable `__sveltekit_fetch__`, and its dev-mode `window.fetch` wrapper warns the
+    // developer to "use the `fetch` passed to your load function" when the tag is missing. Rebuilding
+    // the init to inject `traceparent` must not strip it, or Flare makes SvelteKit scold developers
+    // for something they are already doing correctly.
+    it('preserves a NON-ENUMERABLE own property on the caller init (regression)', () => {
+        const callerInit: RequestInit = { method: 'GET' };
+        Object.defineProperty(callerInit, '__sveltekit_fetch__', {
+            value: true,
+            writable: true,
+            configurable: true,
+        });
+
+        const init = mergeTraceparentHeader('https://app.example/x', callerInit, TP);
+
+        expect((init as Record<string, unknown>).__sveltekit_fetch__).toBe(true);
+        expect((init!.headers as Record<string, string>).traceparent).toBe(TP);
+        expect(init!.method).toBe('GET');
+    });
+
+    it('keeps a preserved non-enumerable property non-enumerable (regression)', () => {
+        const callerInit: RequestInit = {};
+        Object.defineProperty(callerInit, '__sveltekit_fetch__', {
+            value: true,
+            writable: true,
+            configurable: true,
+        });
+
+        const init = mergeTraceparentHeader('https://app.example/x', callerInit, TP);
+
+        // Re-enumerating it would leak the marker into anything that spreads or serializes the init.
+        expect(Object.keys(init!)).not.toContain('__sveltekit_fetch__');
+        expect(Object.getOwnPropertyDescriptor(init!, '__sveltekit_fetch__')?.enumerable).toBe(false);
+    });
+
+    it('does not mutate the caller init when preserving its own properties', () => {
+        const callerInit: RequestInit = { method: 'POST', headers: { a: '1' } };
+
+        const init = mergeTraceparentHeader('https://app.example/x', callerInit, TP);
+
+        expect(init).not.toBe(callerInit);
+        expect(callerInit.headers).toEqual({ a: '1' }); // no traceparent leaked back
+    });
 });

--- a/packages/react/src/react-router.ts
+++ b/packages/react/src/react-router.ts
@@ -34,14 +34,17 @@ export function routeNameFromMatches(matches: RRMatch[] | undefined): string | u
 export function traceReactRouter(router: RRDataRouter): () => void {
     const nav = registerNavigationSource();
 
+    // `url` rides along on every name so a redirect hop re-stamps the root's url.full in lockstep:
+    // the root was opened from the FIRST destination and would otherwise report a URL never landed on.
     const routeNameFor = (state: RRRouterState): RouteName => {
+        const url = hrefOf(state.location);
         try {
             const name = routeNameFromMatches(state.matches);
-            if (name) return { name, source: 'route' };
+            if (name) return { name, source: 'route', url };
         } catch {
             // fall through to the URL name
         }
-        return { name: state.location.pathname, source: 'url' };
+        return { name: state.location.pathname, source: 'url', url };
     };
 
     // Same-origin SPA: reconstruct the destination href for the nav root's url.full. NOTE: for

--- a/packages/react/src/tanstack-router.ts
+++ b/packages/react/src/tanstack-router.ts
@@ -14,17 +14,27 @@ import type { TsrLocation, TsrNavEvent, TsrRouter } from './vendor/tanstackRoute
 export function traceTanStackRouter(router: TsrRouter): () => void {
     const nav = registerNavigationSource();
 
+    // Same-origin SPA: TanStack's `href` is origin-relative, so prepend the origin to get a full one.
+    const hrefOf = (loc: TsrLocation): string | undefined => {
+        if (typeof window === 'undefined') return undefined;
+        return window.location.origin + (loc.href ?? loc.pathname ?? '');
+    };
+
+    // `url` rides along on every name so it re-stamps the root's url.full in lockstep. This slice
+    // opens roots without a url override (TanStack reports the destination only as a parsed
+    // location), so without the re-stamp a nav root keeps the url of the page it left.
     const routeNameFor = (loc: TsrLocation): RouteName => {
+        const url = hrefOf(loc);
         try {
             const matches = router.matchRoutes(loc.pathname, loc.search, { preload: false, throwOnError: false });
             const last = matches[matches.length - 1];
             const matched = matches.some((m) => m.routeId !== '__root__');
             const name = matched ? last?.fullPath || last?.routeId : undefined;
-            if (name) return { name, source: 'route' };
+            if (name) return { name, source: 'route', url };
         } catch {
             // fall through to the URL name
         }
-        return { name: loc.pathname, source: 'url' };
+        return { name: loc.pathname, source: 'url', url };
     };
 
     // Enrich the pageload root immediately from the current (already-resolved) location.

--- a/packages/react/src/vendor/tanstackRouterTypes.ts
+++ b/packages/react/src/vendor/tanstackRouterTypes.ts
@@ -3,7 +3,9 @@
 // the router and non-TanStack consumers of @flareapp/react type-check cleanly.
 // Verify against the pinned router version if these shapes drift.
 
-export type TsrLocation = { pathname: string; search: unknown; state?: unknown };
+// `href` is ParsedLocation.href: pathname + search + hash, WITHOUT the origin (verified against
+// @tanstack/react-router 1.170.10). Optional so a caller passing a hand-built location still types.
+export type TsrLocation = { pathname: string; search: unknown; href?: string; state?: unknown };
 export type TsrNavEvent = { fromLocation?: TsrLocation; toLocation: TsrLocation };
 export type TsrMatch = { routeId?: string; fullPath?: string };
 

--- a/packages/react/tests/react-router.integration.test.ts
+++ b/packages/react/tests/react-router.integration.test.ts
@@ -45,10 +45,14 @@ beforeEach(() => {
     nav.unregister.mockClear();
 });
 
+// Every RouteName now carries the destination url, so the root's url.full tracks a redirect hop
+// instead of keeping the URL the navigation opened with. Same-origin SPA: origin + path.
+const u = (path: string): string => `${window.location.origin}${path}`;
+
 describe('traceReactRouter against a real react-router data router', () => {
     it('names the pageload index route at registration', async () => {
         await boot(['/']);
-        expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/', source: 'route' });
+        expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/', source: 'route', url: u('/') });
     });
 
     it('opens a nav root on a loader-less push and settles it with the parameterized name', async () => {
@@ -58,7 +62,11 @@ describe('traceReactRouter against a real react-router data router', () => {
         expect(nav.startNavigation.mock.calls[0]![0].path).toBe('/product/p01');
         expect(nav.startNavigation.mock.calls[0]![0].hold).toBeFalsy(); // no loader window -> no hold
         expect(nav.startNavigation.mock.calls[0]![0].url).toContain('/product/p01');
-        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/product/:id', source: 'route' });
+        expect(nav.settleNavigation).toHaveBeenLastCalledWith({
+            name: '/product/:id',
+            source: 'route',
+            url: u('/product/p01'),
+        });
     });
 
     it('stamps the exact destination url (origin + path + search) on a query-string navigation', async () => {
@@ -66,7 +74,11 @@ describe('traceReactRouter against a real react-router data router', () => {
         await router.navigate('/product/p01?tab=specs');
         expect(nav.startNavigation).toHaveBeenCalledTimes(1);
         expect(nav.startNavigation.mock.calls[0]![0].url).toBe(`${window.location.origin}/product/p01?tab=specs`);
-        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/product/:id', source: 'route' });
+        expect(nav.settleNavigation).toHaveBeenLastCalledWith({
+            name: '/product/:id',
+            source: 'route',
+            url: u('/product/p01?tab=specs'),
+        });
     });
 
     it('detects a same-pathname search-only change as a navigation', async () => {
@@ -97,19 +109,28 @@ describe('traceReactRouter against a real react-router data router', () => {
         expect(nav.settleNavigation).toHaveBeenLastCalledWith({
             name: '/stores/:storeId/products/:productId',
             source: 'route',
+            url: u('/stores/s1/products/p9'),
         });
     });
 
     it('keeps splats', async () => {
         const { router } = await boot();
         await router.navigate('/files/a/b');
-        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/files/*', source: 'route' });
+        expect(nav.settleNavigation).toHaveBeenLastCalledWith({
+            name: '/files/*',
+            source: 'route',
+            url: u('/files/a/b'),
+        });
     });
 
     it('resolves an absolute-path child route', async () => {
         const { router } = await boot();
         await router.navigate('/dashboard/settings');
-        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/dashboard/settings', source: 'route' });
+        expect(nav.settleNavigation).toHaveBeenLastCalledWith({
+            name: '/dashboard/settings',
+            source: 'route',
+            url: u('/dashboard/settings'),
+        });
     });
 
     it('handles a REPLACE navigation (not dropped)', async () => {
@@ -117,7 +138,11 @@ describe('traceReactRouter against a real react-router data router', () => {
         nav.startNavigation.mockClear();
         await router.navigate('/product/p02', { replace: true });
         expect(nav.startNavigation).toHaveBeenCalledTimes(1);
-        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/product/:id', source: 'route' });
+        expect(nav.settleNavigation).toHaveBeenLastCalledWith({
+            name: '/product/:id',
+            source: 'route',
+            url: u('/product/p02'),
+        });
     });
 
     it('handles a POP back-navigation', async () => {
@@ -126,7 +151,7 @@ describe('traceReactRouter against a real react-router data router', () => {
         nav.startNavigation.mockClear();
         await router.navigate(-1); // back to the index route
         expect(nav.startNavigation).toHaveBeenCalledTimes(1);
-        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/', source: 'route' });
+        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/', source: 'route', url: u('/') });
     });
 
     it('handles a form-action submission (submitting state) as one held root named for its destination', async () => {
@@ -134,7 +159,7 @@ describe('traceReactRouter against a real react-router data router', () => {
         await router.navigate('/submit', { formMethod: 'post', formData: new FormData() });
         expect(nav.startNavigation).toHaveBeenCalledTimes(1);
         expect(nav.startNavigation.mock.calls[0]![0].hold).toBe(true); // submitting is a non-idle, loader-shape nav
-        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/submit', source: 'route' });
+        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/submit', source: 'route', url: u('/submit') });
     });
 
     it('names a navigation with an async loader (hold is requested)', async () => {
@@ -152,6 +177,6 @@ describe('traceReactRouter against a real react-router data router', () => {
         router.initialize(); // loader-less index settles synchronously
         await router.navigate('/slow');
         expect(nav.startNavigation.mock.calls.at(-1)![0]).toMatchObject({ hold: true });
-        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/slow', source: 'route' });
+        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/slow', source: 'route', url: u('/slow') });
     });
 });

--- a/packages/react/tests/react-router.test.ts
+++ b/packages/react/tests/react-router.test.ts
@@ -87,11 +87,19 @@ describe('routeNameFromMatches', () => {
     });
 });
 
+// Every RouteName now carries the destination url so a redirect hop re-stamps the root's url.full.
+// These fake locations carry only a pathname, so hrefOf reconstructs origin + pathname.
+const u = (path: string): string => `${window.location.origin}${path}`;
+
 describe('traceReactRouter', () => {
     it('names the pageload root from the current matches at registration', () => {
         const { router } = fakeRouter({ matches: PRODUCT_MATCHES, location: { pathname: '/product/p01' } });
         traceReactRouter(router);
-        expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/product/:id', source: 'route' });
+        expect(nav.setActiveRouteName).toHaveBeenCalledWith({
+            name: '/product/:id',
+            source: 'route',
+            url: u('/product/p01'),
+        });
     });
 
     it('defers pageload naming to the settle when matches are empty at registration, opening no nav root', () => {
@@ -99,7 +107,11 @@ describe('traceReactRouter', () => {
         traceReactRouter(router);
         expect(nav.setActiveRouteName).not.toHaveBeenCalled();
         emit({ initialized: true, matches: PRODUCT_MATCHES, location: { pathname: '/product/p01' } });
-        expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/product/:id', source: 'route' });
+        expect(nav.setActiveRouteName).toHaveBeenCalledWith({
+            name: '/product/:id',
+            source: 'route',
+            url: u('/product/p01'),
+        });
         expect(nav.startNavigation).not.toHaveBeenCalled();
     });
 
@@ -111,7 +123,11 @@ describe('traceReactRouter', () => {
         });
         traceReactRouter(router);
         // Named now from the synchronously-resolved matches, not deferred to a later fire.
-        expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/product/:id', source: 'route' });
+        expect(nav.setActiveRouteName).toHaveBeenCalledWith({
+            name: '/product/:id',
+            source: 'route',
+            url: u('/product/p01'),
+        });
         nav.setActiveRouteName.mockClear();
         // The initialize settle (same location) may re-name but must open no navigation root.
         emit({ initialized: true, matches: PRODUCT_MATCHES, location: { pathname: '/product/p01' } });
@@ -128,7 +144,11 @@ describe('traceReactRouter', () => {
             matches: PRODUCT_MATCHES,
             location: { pathname: '/product/p01' },
         });
-        expect(nav.setActiveRouteName).toHaveBeenLastCalledWith({ name: '/product/:id', source: 'route' });
+        expect(nav.setActiveRouteName).toHaveBeenLastCalledWith({
+            name: '/product/:id',
+            source: 'route',
+            url: u('/product/p01'),
+        });
         expect(nav.startNavigation).not.toHaveBeenCalled();
     });
 
@@ -149,7 +169,11 @@ describe('traceReactRouter', () => {
             matches: PRODUCT_MATCHES,
             location: { pathname: '/product/p01' },
         });
-        expect(nav.settleNavigation).toHaveBeenCalledWith({ name: '/product/:id', source: 'route' });
+        expect(nav.settleNavigation).toHaveBeenCalledWith({
+            name: '/product/:id',
+            source: 'route',
+            url: u('/product/p01'),
+        });
     });
 
     it('detects a loader-less navigation (single idle fire, no loading state) via the committed location', () => {
@@ -164,7 +188,11 @@ describe('traceReactRouter', () => {
         expect(nav.startNavigation).toHaveBeenCalledTimes(1);
         expect(nav.startNavigation.mock.calls[0]![0].path).toBe('/product/p01');
         expect(nav.startNavigation.mock.calls[0]![0].hold).toBeFalsy(); // no loader window -> no hold
-        expect(nav.settleNavigation).toHaveBeenCalledWith({ name: '/product/:id', source: 'route' });
+        expect(nav.settleNavigation).toHaveBeenCalledWith({
+            name: '/product/:id',
+            source: 'route',
+            url: u('/product/p01'),
+        });
     });
 
     it('does not double-open on a follow-up same-location fire (scroll restoration etc.)', () => {
@@ -193,7 +221,7 @@ describe('traceReactRouter', () => {
             location: { pathname: '/b' },
         });
         expect(nav.settleNavigation).toHaveBeenCalledTimes(1);
-        expect(nav.settleNavigation).toHaveBeenCalledWith({ name: '/b', source: 'route' });
+        expect(nav.settleNavigation).toHaveBeenCalledWith({ name: '/b', source: 'route', url: u('/b') });
     });
 
     it('falls back to the URL name when matches yield nothing', () => {
@@ -205,7 +233,7 @@ describe('traceReactRouter', () => {
             matches: [{ route: {}, pathname: '/nope' }],
             location: { pathname: '/nope' },
         });
-        expect(nav.settleNavigation).toHaveBeenCalledWith({ name: '/nope', source: 'url' });
+        expect(nav.settleNavigation).toHaveBeenCalledWith({ name: '/nope', source: 'url', url: u('/nope') });
     });
 
     it('opens no nav root for revalidation (navigation.state stays idle)', () => {

--- a/packages/react/tests/tanstack-router.test.ts
+++ b/packages/react/tests/tanstack-router.test.ts
@@ -34,11 +34,20 @@ beforeEach(() => {
     nav.unregister.mockClear();
 });
 
+// Every RouteName now carries the destination url so the root's url.full tracks redirect hops. These
+// fakes omit TanStack's `href`, so hrefOf falls back to origin + pathname (the `href` shape is
+// pinned separately below).
+const u = (path: string): string => `${window.location.origin}${path}`;
+
 describe('traceTanStackRouter', () => {
     it('enriches the pageload root from the current location at registration', () => {
         const { router } = fakeRouter({ location: { pathname: '/product/p01', search: {} } });
         traceTanStackRouter(router);
-        expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/product/$id', source: 'route' });
+        expect(nav.setActiveRouteName).toHaveBeenCalledWith({
+            name: '/product/$id',
+            source: 'route',
+            url: u('/product/p01'),
+        });
     });
 
     it('corrects the pageload name on the initial onResolved (loader redirect), no nav root', () => {
@@ -50,7 +59,7 @@ describe('traceTanStackRouter', () => {
             { routeId: '/login', fullPath: '/login' },
         ]);
         emit('onResolved', { fromLocation: undefined, toLocation: { pathname: '/login', search: {} } });
-        expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/login', source: 'route' });
+        expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/login', source: 'route', url: u('/login') });
         expect(nav.startNavigation).not.toHaveBeenCalled();
     });
 
@@ -62,9 +71,17 @@ describe('traceTanStackRouter', () => {
         const to = { pathname: '/product/p01', search: {}, state: {} };
         emit('onBeforeLoad', { fromLocation: from, toLocation: to });
         expect(nav.startNavigation).toHaveBeenCalledWith({ path: '/product/p01' });
-        expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/product/$id', source: 'route' });
+        expect(nav.setActiveRouteName).toHaveBeenCalledWith({
+            name: '/product/$id',
+            source: 'route',
+            url: u('/product/p01'),
+        });
         emit('onResolved', { fromLocation: from, toLocation: to });
-        expect(nav.setActiveRouteName).toHaveBeenLastCalledWith({ name: '/product/$id', source: 'route' });
+        expect(nav.setActiveRouteName).toHaveBeenLastCalledWith({
+            name: '/product/$id',
+            source: 'route',
+            url: u('/product/p01'),
+        });
     });
 
     it('skips the initial pageload onBeforeLoad', () => {
@@ -102,7 +119,7 @@ describe('traceTanStackRouter', () => {
         emit('onBeforeLoad', { fromLocation: from, toLocation: { pathname: '/b', search: {}, state: {} } });
         expect(nav.startNavigation).toHaveBeenCalledTimes(1);
         emit('onResolved', { fromLocation: from, toLocation: { pathname: '/b', search: {}, state: {} } });
-        expect(nav.setActiveRouteName).toHaveBeenLastCalledWith({ name: '/b', source: 'route' });
+        expect(nav.setActiveRouteName).toHaveBeenLastCalledWith({ name: '/b', source: 'route', url: u('/b') });
     });
 
     it('falls back to the URL name when only __root__ matches', () => {
@@ -114,7 +131,7 @@ describe('traceTanStackRouter', () => {
             fromLocation: { pathname: '/', search: {}, state: {} },
             toLocation: { pathname: '/nope', search: {}, state: {} },
         });
-        expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/nope', source: 'url' });
+        expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/nope', source: 'url', url: u('/nope') });
     });
 
     it('falls back to routeId when fullPath is empty', () => {
@@ -129,7 +146,29 @@ describe('traceTanStackRouter', () => {
             fromLocation: { pathname: '/', search: {}, state: {} },
             toLocation: { pathname: '/layout', search: {}, state: {} },
         });
-        expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/layout', source: 'route' });
+        expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/layout', source: 'route', url: u('/layout') });
+    });
+
+    // TanStack's real ParsedLocation.href is pathname + search + hash WITHOUT the origin, so the
+    // integration must prepend it. Taking `pathname` instead would silently drop the query string.
+    it("builds the url from TanStack's origin-relative href, not the bare pathname", () => {
+        const { router, emit } = fakeRouter();
+        traceTanStackRouter(router);
+        nav.setActiveRouteName.mockClear();
+        emit('onBeforeLoad', {
+            fromLocation: { pathname: '/', search: {}, href: '/', state: {} },
+            toLocation: {
+                pathname: '/product/p01',
+                search: { tab: 'specs' },
+                href: '/product/p01?tab=specs',
+                state: {},
+            },
+        });
+        expect(nav.setActiveRouteName).toHaveBeenCalledWith({
+            name: '/product/$id',
+            source: 'route',
+            url: u('/product/p01?tab=specs'),
+        });
     });
 
     it('cleanup unsubscribes and unregisters', () => {
@@ -154,6 +193,6 @@ describe('traceTanStackRouter', () => {
                 toLocation: { pathname: '/kaboom', search: {}, state: {} },
             }),
         ).not.toThrow();
-        expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/kaboom', source: 'url' });
+        expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/kaboom', source: 'url', url: u('/kaboom') });
     });
 });

--- a/packages/sveltekit/src/client/traceSvelteKitRouter.svelte.ts
+++ b/packages/sveltekit/src/client/traceSvelteKitRouter.svelte.ts
@@ -25,19 +25,28 @@ let lastKey = '';
 // navigation, and a hash-keyed comparison would fabricate a root for it.
 const keyOf = (url: URL): string => url.pathname + url.search;
 
+// `url` rides along on every name so a redirect hop re-stamps the root's url.full in lockstep: the
+// root was opened from the FIRST destination and would otherwise report a URL never landed on.
 const routeNameFor = (routeId: string | null | undefined, url: URL): RouteName =>
-    routeId ? { name: routeId, source: 'route' } : { name: url.pathname, source: 'url' };
+    routeId ? { name: routeId, source: 'route', url: url.href } : { name: url.pathname, source: 'url', url: url.href };
 
 /** Advance the state machine for one observed snapshot. Exported for unit tests; not public API. */
 export function syncNavigation(snapshot: NavSnapshot): void {
     if (!nav) return;
+    // branch 1: Kit's `a:` placeholder. Checked BEFORE the tracing gate because it is not a real
+    // location: its pathname is empty, so letting it reach the lastKey stamp below would poison the
+    // key and make the next real snapshot look like a move.
+    if (snapshot.url.origin !== location.origin) return;
     if (!flare.config?.enableTracing) {
         // A settle can never arrive while tracing is off, so the latch must not persist across the
         // toggle: otherwise a held root is stranded and the next navigation opens no root at all.
         inFlight = false;
+        // Keep tracking the committed location too. Without this the key goes stale for every
+        // navigation made while tracing was off, and the first idle snapshot after it flips back on
+        // reads as a move and fabricates a branch-7 root for a page that never navigated.
+        lastKey = keyOf(snapshot.url);
         return; // branch 0
     }
-    if (snapshot.url.origin !== location.origin) return; // branch 1: Kit's `a:` placeholder
 
     const to = snapshot.to;
     if (to) {
@@ -95,11 +104,27 @@ export function traceSvelteKitRouter(): () => void {
     if (tracing || typeof window === 'undefined') return () => {};
     tracing = true;
 
-    nav = registerNavigationSource();
-    inFlight = false;
-    lastKey = location.pathname + location.search;
+    let dispose: (() => void) | undefined;
+    // Wiring runs inside the guard because hooks.client.ts calls this at module scope: a throw here
+    // would take down client boot, not just tracing. The effect body has its own `insulate`.
+    safeInvoke(() => {
+        nav = registerNavigationSource();
+        inFlight = false;
+        lastKey = location.pathname + location.search;
+        dispose = startEffect();
+    });
 
-    const dispose = $effect.root(() => {
+    return () => {
+        safeInvoke(dispose);
+        safeInvoke(() => nav?.unregister());
+        nav = null;
+        tracing = false;
+    };
+}
+
+/** The reactive half: one `$effect.root` feeding observed snapshots to the pure state machine. */
+function startEffect(): () => void {
+    return $effect.root(() => {
         $effect(
             insulate(() =>
                 // The reads ARE the body. No control flow here: Svelte tracks dependencies as they
@@ -113,11 +138,4 @@ export function traceSvelteKitRouter(): () => void {
             ),
         );
     });
-
-    return () => {
-        safeInvoke(dispose);
-        safeInvoke(() => nav?.unregister());
-        nav = null;
-        tracing = false;
-    };
 }

--- a/packages/sveltekit/tests/__mocks__/app-state.svelte.ts
+++ b/packages/sveltekit/tests/__mocks__/app-state.svelte.ts
@@ -1,12 +1,15 @@
+// Stand-in for `$app/state`, aliased in vitest.config.mts. A `.svelte.ts` module so the fields are
+// real runes: a plain object would let the module under test read them, but nothing would ever
+// re-run its `$effect`, and the reads-are-the-body contract could not be tested at all.
 export const page: {
     url: URL;
     params: Record<string, string>;
     route: { id: string | null };
-} = {
+} = $state({
     url: new URL('http://localhost/'),
     params: {},
     route: { id: null },
-};
+});
 
 export const navigating: {
     from: { url: URL; route: { id: string | null } } | null;
@@ -15,11 +18,11 @@ export const navigating: {
     willUnload: boolean;
     delta: number | null;
     complete: Promise<void> | null;
-} = {
+} = $state({
     from: null,
     to: null,
     type: null,
     willUnload: false,
     delta: null,
     complete: null,
-};
+});

--- a/packages/sveltekit/tests/client/getRouteContext.test.ts
+++ b/packages/sveltekit/tests/client/getRouteContext.test.ts
@@ -8,7 +8,7 @@ vi.mock('@flareapp/js', () => ({
 }));
 
 const mockPage = await vi.hoisted(async () => {
-    const mod = await import('../../tests/__mocks__/app-state');
+    const mod = await import('../../tests/__mocks__/app-state.svelte');
     return mod.page;
 });
 

--- a/packages/sveltekit/tests/client/traceSvelteKitRouter.test.ts
+++ b/packages/sveltekit/tests/client/traceSvelteKitRouter.test.ts
@@ -1,5 +1,4 @@
 // @vitest-environment jsdom
-import { flushSync } from 'svelte';
 import { beforeEach, expect, test, vi } from 'vitest';
 
 import type { NavSnapshot } from '../../src/client/traceSvelteKitRouter.svelte';
@@ -37,7 +36,11 @@ async function load() {
     page.route = { id: '/' };
     navigating.to = null;
     navigating.willUnload = false;
-    return import('../../src/client/traceSvelteKitRouter.svelte');
+    // `flushSync` MUST come from the post-reset `svelte` instance: resetModules gives the module
+    // under test a brand-new svelte runtime with its own effect queue, and the copy imported at the
+    // top of this file flushes the OLD queue, which is a silent no-op.
+    const { flushSync } = await import('svelte');
+    return { ...(await import('../../src/client/traceSvelteKitRouter.svelte')), page, navigating, flushSync };
 }
 
 beforeEach(() => {
@@ -79,7 +82,7 @@ test('ignores the pre-hydration placeholder page', async () => {
 });
 
 test('cleanup disposes the effect and unregisters', async () => {
-    const { traceSvelteKitRouter } = await load();
+    const { traceSvelteKitRouter, flushSync } = await load();
     const stop = traceSvelteKitRouter();
     flushSync();
     stop();
@@ -112,6 +115,50 @@ async function started() {
 // fallback), NOT branch 6. So pageload-naming cases MUST use `url: HERE`. `routeId` is what names the
 // root; the url only decides the key and the fallback name. Getting this wrong makes a branch-6 test
 // silently assert branch-7 behaviour.
+
+// EVERY OTHER CASE BELOW CALLS `syncNavigation` DIRECTLY, so none of them touch the effect body.
+// That body is the fragile half: it must read `navigating.to` (not `.from`), `page.route.id` and
+// `page.url`, and it must re-run when any of them change. Swap a field for the wrong one and every
+// other unit test here still passes. So drive one full navigation through the reactive state.
+test('the effect reads $app/state and re-runs, feeding the state machine', async () => {
+    const { traceSvelteKitRouter, page, navigating, flushSync } = await load();
+    const stop = traceSvelteKitRouter();
+    flushSync();
+    vi.clearAllMocks();
+
+    navigating.to = { url: PRODUCT, route: { id: '/product/[id]' } };
+    flushSync();
+    expect(nav.startNavigation).toHaveBeenCalledWith({ path: '/product/p01', url: PRODUCT.href, hold: true });
+    expect(nav.setActiveRouteName).toHaveBeenCalledWith({
+        name: '/product/[id]',
+        source: 'route',
+        url: PRODUCT.href,
+    });
+
+    // Kit commits `page` before it nulls `navigating`, so the settle names from the committed route.
+    navigating.to = null;
+    page.url = PRODUCT;
+    page.route = { id: '/product/[id]' };
+    flushSync();
+    expect(nav.settleNavigation).toHaveBeenCalledWith({
+        name: '/product/[id]',
+        source: 'route',
+        url: PRODUCT.href,
+    });
+    stop();
+});
+
+test('the disposed effect stops observing $app/state', async () => {
+    const { traceSvelteKitRouter, navigating, flushSync } = await load();
+    const stop = traceSvelteKitRouter();
+    flushSync();
+    stop();
+    vi.clearAllMocks();
+
+    navigating.to = { url: PRODUCT, route: { id: '/product/[id]' } };
+    flushSync();
+    expect(nav.startNavigation).not.toHaveBeenCalled();
+});
 
 test('names the pageload root from the committed route id', async () => {
     const { syncNavigation, stop } = await started();
@@ -242,6 +289,45 @@ test('branch 0 does not consume the transition when tracing is off', async () =>
     syncNavigation(snap({ to: { url: PRODUCT, route: { id: '/product/[id]' } } }));
     expect(nav.startNavigation).toHaveBeenCalledTimes(1);
     expect(nav.startNavigation).toHaveBeenCalledWith({ path: '/product/p01', url: PRODUCT.href, hold: true });
+    stop();
+});
+
+// Branch 0 must keep tracking the committed location, not just eat the snapshot. Without the
+// lastKey stamp the key goes stale for every navigation made while tracing was off, and the first
+// idle snapshot after it flips back on reads as a move and fabricates a branch-7 root for a page
+// that never navigated.
+test('a navigation made while tracing was off does not fabricate a root when it comes back on', async () => {
+    const { syncNavigation, stop } = await started();
+    flareConfig.enableTracing = false;
+    syncNavigation(snap({ to: { url: PRODUCT, route: { id: '/product/[id]' } } }));
+    syncNavigation(snap({ routeId: '/product/[id]', url: PRODUCT })); // committed at /product/p01
+    flareConfig.enableTracing = true;
+
+    vi.clearAllMocks();
+    // An idle snapshot at the SAME committed location (e.g. Kit reassigning page.url on a hash
+    // change). It is not a move, so it must take branch 6 and name, never branch 7 and open a root.
+    syncNavigation(snap({ routeId: '/product/[id]', url: PRODUCT }));
+
+    expect(nav.startNavigation).not.toHaveBeenCalled();
+    expect(nav.settleNavigation).not.toHaveBeenCalled();
+    expect(nav.setActiveRouteName).toHaveBeenCalledWith({
+        name: '/product/[id]',
+        source: 'route',
+        url: PRODUCT.href,
+    });
+    stop();
+});
+
+// The `a:` placeholder is checked before the tracing gate precisely so it cannot reach that stamp:
+// its pathname is empty, and stamping '' would make the next real snapshot look like a move.
+test('the pre-hydration placeholder does not poison lastKey while tracing is off', async () => {
+    const { syncNavigation, stop } = await started();
+    flareConfig.enableTracing = false;
+    syncNavigation({ to: null, willUnload: false, routeId: null, url: new URL('a:') });
+    flareConfig.enableTracing = true;
+
+    syncNavigation(snap({ routeId: '/', url: HERE })); // still the initial location => branch 6
+    expect(nav.startNavigation).not.toHaveBeenCalled();
     stop();
 });
 

--- a/packages/sveltekit/tests/client/traceSvelteKitRouter.test.ts
+++ b/packages/sveltekit/tests/client/traceSvelteKitRouter.test.ts
@@ -116,7 +116,7 @@ async function started() {
 test('names the pageload root from the committed route id', async () => {
     const { syncNavigation, stop } = await started();
     syncNavigation(snap({ routeId: '/product/[id]', url: HERE })); // url: HERE => branch 6
-    expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/product/[id]', source: 'route' });
+    expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/product/[id]', source: 'route', url: HERE.href });
     expect(nav.startNavigation).not.toHaveBeenCalled();
     stop();
 });
@@ -124,7 +124,7 @@ test('names the pageload root from the committed route id', async () => {
 test('falls back to the pathname when there is no route id', async () => {
     const { syncNavigation, stop } = await started();
     syncNavigation(snap({ routeId: null }));
-    expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/', source: 'url' });
+    expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/', source: 'url', url: HERE.href });
     stop();
 });
 
@@ -136,10 +136,10 @@ test('a late-resolving route id renames the pageload root and opens no nav root'
     // branch 6 and neither may open a navigation root. The re-name is a `source` flip, not a
     // name change: that IS the observable here.
     syncNavigation(snap({ routeId: null }));
-    expect(nav.setActiveRouteName).toHaveBeenLastCalledWith({ name: '/', source: 'url' });
+    expect(nav.setActiveRouteName).toHaveBeenLastCalledWith({ name: '/', source: 'url', url: HERE.href });
 
     syncNavigation(snap({ routeId: '/' }));
-    expect(nav.setActiveRouteName).toHaveBeenLastCalledWith({ name: '/', source: 'route' });
+    expect(nav.setActiveRouteName).toHaveBeenLastCalledWith({ name: '/', source: 'route', url: HERE.href });
     expect(nav.startNavigation).not.toHaveBeenCalled();
     stop();
 });
@@ -152,7 +152,7 @@ test('opens a held navigation root named from the destination', async () => {
         url: PRODUCT.href,
         hold: true,
     });
-    expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/product/[id]', source: 'route' });
+    expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/product/[id]', source: 'route', url: PRODUCT.href });
     stop();
 });
 
@@ -160,7 +160,7 @@ test('settles the navigation from the committed page', async () => {
     const { syncNavigation, stop } = await started();
     syncNavigation(snap({ to: { url: PRODUCT, route: { id: '/product/[id]' } } }));
     syncNavigation(snap({ routeId: '/product/[id]', url: PRODUCT }));
-    expect(nav.settleNavigation).toHaveBeenCalledWith({ name: '/product/[id]', source: 'route' });
+    expect(nav.settleNavigation).toHaveBeenCalledWith({ name: '/product/[id]', source: 'route', url: PRODUCT.href });
     stop();
 });
 
@@ -170,7 +170,11 @@ test('a redirect keeps ONE held root and renames it to the final destination', a
     syncNavigation(snap({ to: { url: OLD, route: { id: '/old' } } }));
     syncNavigation(snap({ to: { url: PRODUCT, route: { id: '/product/[id]' } } })); // redirect hop
     expect(nav.startNavigation).toHaveBeenCalledTimes(1);
-    expect(nav.setActiveRouteName).toHaveBeenLastCalledWith({ name: '/product/[id]', source: 'route' });
+    expect(nav.setActiveRouteName).toHaveBeenLastCalledWith({
+        name: '/product/[id]',
+        source: 'route',
+        url: PRODUCT.href,
+    });
     stop();
 });
 
@@ -204,7 +208,7 @@ test('fallback: a committed key change while idle opens an un-held root and sett
     syncNavigation(snap({ routeId: '/product/[id]', url: PRODUCT }));
     expect(nav.startNavigation).toHaveBeenCalledWith({ path: '/product/p01', url: PRODUCT.href });
     expect(nav.startNavigation.mock.calls[0][0]).not.toHaveProperty('hold');
-    expect(nav.settleNavigation).toHaveBeenCalledWith({ name: '/product/[id]', source: 'route' });
+    expect(nav.settleNavigation).toHaveBeenCalledWith({ name: '/product/[id]', source: 'route', url: PRODUCT.href });
     stop();
 });
 

--- a/packages/sveltekit/vitest.config.mts
+++ b/packages/sveltekit/vitest.config.mts
@@ -10,7 +10,7 @@ export default defineConfig({
         // no-op: runes modules still compile, effects just silently never run.
         conditions: ['browser'],
         alias: {
-            '$app/state': path.resolve('./tests/__mocks__/app-state.ts'),
+            '$app/state': path.resolve('./tests/__mocks__/app-state.svelte.ts'),
         },
     },
     test: {

--- a/packages/vue/src/traceVueRouter.ts
+++ b/packages/vue/src/traceVueRouter.ts
@@ -25,15 +25,18 @@ export function traceVueRouter(router: unknown): () => void {
 
     const nav = registerNavigationSource();
 
+    // `url` rides along on every name so a redirect hop re-stamps the root's url.full in lockstep:
+    // the root was opened from the FIRST destination and would otherwise report a URL never landed on.
     const routeNameFor = (loc: VueRouteLocationLike): RouteName => {
+        const url = hrefOf(loc);
         try {
             const matched = loc.matched;
             const template = matched && matched.length > 0 ? matched[matched.length - 1]?.path : undefined;
-            if (template) return { name: template, source: 'route' };
+            if (template) return { name: template, source: 'route', url };
         } catch {
             // fall through to the URL name
         }
-        return { name: loc.path, source: 'url' };
+        return { name: loc.path, source: 'url', url };
     };
 
     const hrefOf = (loc: VueRouteLocationLike): string => {

--- a/packages/vue/tests/vue-router.integration.test.ts
+++ b/packages/vue/tests/vue-router.integration.test.ts
@@ -39,13 +39,17 @@ beforeEach(() => {
     nav.unregister.mockClear();
 });
 
+// Every RouteName now carries the destination url so the root's url.full follows a redirect hop to
+// its final target instead of keeping the URL the navigation opened with. Same-origin SPA: origin + fullPath.
+const u = (path: string): string => `${window.location.origin}${path}`;
+
 describe('traceVueRouter against a real vue-router', () => {
     it('names the pageload root from the initial route and opens no nav root', async () => {
         const router = makeRouter();
         traceVueRouter(router);
         mountWith(router);
         await router.isReady();
-        expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/', source: 'route' });
+        expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/', source: 'route', url: u('/') });
         expect(nav.startNavigation).not.toHaveBeenCalled();
     });
 
@@ -59,7 +63,11 @@ describe('traceVueRouter against a real vue-router', () => {
         expect(nav.startNavigation).toHaveBeenCalledTimes(1);
         expect(nav.startNavigation.mock.calls[0]![0]).toMatchObject({ path: '/product/p01', hold: true });
         expect(nav.startNavigation.mock.calls[0]![0].url).toBe(`${window.location.origin}/product/p01`);
-        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/product/:id', source: 'route' });
+        expect(nav.settleNavigation).toHaveBeenLastCalledWith({
+            name: '/product/:id',
+            source: 'route',
+            url: u('/product/p01'),
+        });
     });
 
     it('names a nested child route with the absolute parameterized template', async () => {
@@ -71,7 +79,11 @@ describe('traceVueRouter against a real vue-router', () => {
         await router.push('/user/u01/profile');
         // Confirms vue-router normalizes the child's relative `path` to the full absolute template —
         // the one runtime behavior the spec flagged as unpinned (matched[last].path, not chain-joined).
-        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/user/:id/profile', source: 'route' });
+        expect(nav.settleNavigation).toHaveBeenLastCalledWith({
+            name: '/user/:id/profile',
+            source: 'route',
+            url: u('/user/u01/profile'),
+        });
     });
 
     it('names a truly unmatched route from its path with url source', async () => {
@@ -81,7 +93,11 @@ describe('traceVueRouter against a real vue-router', () => {
         await router.isReady();
         nav.settleNavigation.mockClear();
         await router.push('/does/not/exist').catch(() => {});
-        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/does/not/exist', source: 'url' });
+        expect(nav.settleNavigation).toHaveBeenLastCalledWith({
+            name: '/does/not/exist',
+            source: 'url',
+            url: u('/does/not/exist'),
+        });
     });
 
     it('follows a route-config redirect and settles the final target (one nav root)', async () => {
@@ -92,7 +108,7 @@ describe('traceVueRouter against a real vue-router', () => {
         nav.startNavigation.mockClear();
         await router.push('/old');
         expect(nav.startNavigation).toHaveBeenCalledTimes(1);
-        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/cart', source: 'route' });
+        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/cart', source: 'route', url: u('/cart') });
     });
 
     it('follows a guard-returned redirect (one nav root, final name)', async () => {
@@ -104,7 +120,7 @@ describe('traceVueRouter against a real vue-router', () => {
         nav.startNavigation.mockClear();
         await router.push('/product/p01');
         expect(nav.startNavigation).toHaveBeenCalledTimes(1);
-        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/cart', source: 'route' });
+        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/cart', source: 'route', url: u('/cart') });
     });
 
     it('settles an aborted navigation to the current location', async () => {
@@ -117,7 +133,7 @@ describe('traceVueRouter against a real vue-router', () => {
         nav.settleNavigation.mockClear();
         await router.push('/blocked');
         expect(nav.startNavigation).toHaveBeenCalledTimes(1);
-        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/', source: 'route' });
+        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/', source: 'route', url: u('/') });
     });
 
     it('emits no nav span for a plain duplicated navigation', async () => {
@@ -160,7 +176,7 @@ describe('traceVueRouter against a real vue-router', () => {
         await router.push('/product/p01').catch(() => {});
         expect(nav.startNavigation).toHaveBeenCalledTimes(1);
         expect(nav.settleNavigation).toHaveBeenCalledTimes(1);
-        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/', source: 'route' });
+        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/', source: 'route', url: u('/') });
     });
 
     it('names the pageload immediately when installed after the router is ready', async () => {
@@ -168,7 +184,7 @@ describe('traceVueRouter against a real vue-router', () => {
         mountWith(router);
         await router.isReady();
         traceVueRouter(router);
-        expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/', source: 'route' });
+        expect(nav.setActiveRouteName).toHaveBeenCalledWith({ name: '/', source: 'route', url: u('/') });
         nav.startNavigation.mockClear();
         await router.push('/cart');
         expect(nav.startNavigation).toHaveBeenCalledTimes(1);

--- a/packages/vue/tests/vue-router.test.ts
+++ b/packages/vue/tests/vue-router.test.ts
@@ -63,6 +63,10 @@ beforeEach(() => {
     registerNavigationSource.mockClear();
 });
 
+// Every RouteName now carries the destination url so the root's url.full follows a redirect hop to
+// its final target instead of keeping the URL the navigation opened with. Same-origin SPA: origin + fullPath.
+const u = (path: string): string => `${window.location.origin}${path}`;
+
 describe('traceVueRouter edge cases', () => {
     it('is inert for a non-router value (no registration, no-op cleanup)', () => {
         const stop = traceVueRouter({});
@@ -79,7 +83,7 @@ describe('traceVueRouter edge cases', () => {
         router.fireAfter(cart, home, undefined); // success → settle cart
         expect(nav.startNavigation).toHaveBeenCalledTimes(1);
         expect(nav.settleNavigation).toHaveBeenCalledTimes(1);
-        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/cart', source: 'route' });
+        expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '/cart', source: 'route', url: u('/cart') });
     });
 
     it('tears down prior instrumentation when the same router is re-instrumented (HMR)', () => {
@@ -96,6 +100,8 @@ describe('traceVueRouter edge cases', () => {
         traceVueRouter(router); // must not throw on install-time enrichment either
         router.fireBefore(product, home); // client nav (home has matched → not initial): opens held root
         router.fireError();
+        // No current route => no destination href, so `url` is omitted and the root keeps the URL it
+        // opened with. Re-stamping url.full to something wrong is worse than leaving it alone.
         expect(nav.settleNavigation).toHaveBeenLastCalledWith({ name: '', source: 'url' });
     });
 
@@ -107,6 +113,10 @@ describe('traceVueRouter edge cases', () => {
         router.fireBefore(product, START); // from is still START: aborted nav never committed
         router.fireAfter(product, START, undefined); // success → finalizes the pageload name
         expect(nav.startNavigation).not.toHaveBeenCalled();
-        expect(nav.setActiveRouteName).toHaveBeenLastCalledWith({ name: '/product/:id', source: 'route' });
+        expect(nav.setActiveRouteName).toHaveBeenLastCalledWith({
+            name: '/product/:id',
+            source: 'route',
+            url: u('/product/p01'),
+        });
     });
 });


### PR DESCRIPTION
Fixes the findings from the review of #77. Based on `sveltekit-tracing` (#77), with #78 merged in, because the Kit-warning e2e below needs both #77's `/http` route and #78's fix to be meaningful.

**Stacking: merge #78 first, then #77, then this.**

## 1. `url.full` went stale on redirects (`@flareapp/js` seam, all four slices)

`startNavigation` stamps `url.full` from the FIRST destination, but a redirect hop (or a newer navigation superseding an in-flight one) re-names the *same* held root via `setActiveRouteName`, which only touched the name, identifier and route source. The root then reported the parameterized name of where it landed next to a URL the user never landed on. Pre-existing and shared across vue/react, so fixed once in the seam rather than per-router.

`RouteName` gains an optional `url`. When set, `applyRouteName` re-stamps `url.full` + `flare.entry_point.value`. Deliberately NOT `flare.entry_point.handler.identifier`: the route template owns that, and re-deriving it from the href would clobber `/product/[id]` back to `/product/p01`. An unparseable url leaves the existing values intact rather than poisoning them.

All four slices now pass it. Vue's `onError` fallback deliberately does not: no current route means no href, and a wrong url is worse than a stale one. TanStack needed `href` added to its vendored `TsrLocation` (verified against `@tanstack/react-router` 1.170.10: `ParsedLocation.href` is pathname + search + hash *without* the origin). That also closes a second gap in that slice, which passed no `url` to `startNavigation` at all, so its nav roots kept the url of the page they left.

## 2. Branch 0 did not track the committed location (`@flareapp/sveltekit`)

Branch 0 ate the snapshot without stamping `lastKey`, so the key went stale for every navigation made while tracing was off. The first idle snapshot after it flipped back on read as a move and fabricated a branch-7 root for a page that never navigated. The `a:` placeholder check moves above the tracing gate so its empty pathname cannot reach the stamp.

## 3. The effect body was untested

Every case drove `syncNavigation` directly; the `started()` helper deliberately cleared the first effect run's mock history. Swapping `navigating.to` for `.from` passed all 16 tests. The `$app/state` mock is now a runes module (`app-state.svelte.ts`), so the effect can actually re-run, and one full navigation is driven through the reactive state.

Note for reviewers: `flushSync` must be imported from the **post-`resetModules`** svelte instance. The top-level import flushes a different effect queue and was a silent no-op at every existing call site (oxlint confirmed it: after the fix the top-level import is unused).

## 4. Instrumentation could throw into client boot

`traceSvelteKitRouter`'s wiring now runs inside `safeInvoke`. `hooks.client.ts` calls it at module scope, where a throw takes down the whole client app, not just tracing. Matches `traceVueRouter`, which already guards its wiring.

## 5. E2E dedup + coverage gaps

- `urlOf` / `waitForParentEnvelope` were local to `svelte.spec` despite being generic; moved to `otlp.ts`, which also gains `parentOf` for the child -> parent-envelope lookup all three specs repeated.
- `js.spec.ts` carried its own copy of the `OtlpSpan` type and all three parsers, predating `otlp.ts`. Converted. This closes the follow-up left open since #73.
- `xhr-404` had a playground button but no assertion, while `fetch-404`/`fetch-500` had both.
- **A real regression test for #78**: Kit's dev `window.fetch` wrapper warns when `__sveltekit_fetch__` is missing. The propagation unit tests pin `mergeTraceparentHeader` in isolation and never run Kit's wrapper, so they cannot catch the symptom as reported. This one does, and the e2e already runs `vite dev`, so `DEV && BROWSER` holds.

## Verification

- 1400 unit tests, TypeScript clean, 106/106 e2e (was 104).
- Mutation-probed rather than assumed. Each of these fails exactly the test claiming to cover it, and passes when restored:
  - reading `navigating.from` instead of `.to` -> effect wiring test
  - reverting the branch-0 `lastKey` stamp -> tracing-toggle test
  - moving the origin check back below the tracing gate -> placeholder test
  - reverting #78's descriptor copy to `{ ...init, headers }` -> Kit warning e2e