### PR TITLE
feat(react): move minified error to flare.exception.react_minified_error

### DIFF
--- a/docs/superpowers/specs/2026-07-17-react-minified-error-flare-field-design.md
+++ b/docs/superpowers/specs/2026-07-17-react-minified-error-flare-field-design.md
@@ -1,0 +1,230 @@
+# Move the React minified error to `flare.exception.react_minified_error`
+
+Date: 2026-07-17
+Package: `@flareapp/react`
+Supersedes the reporting destination chosen in `2026-06-08-decode-minified-react-errors-design.md`.
+
+## Problem
+
+`2026-06-08-decode-minified-react-errors-design.md` shipped in `@flareapp/react@2.6.0`
+(feature commit `61ccaa3`, released 2026-06-30). It parses a production React error
+message into structured fields and reports them at:
+
+```
+context.custom.react.minifiedError = { number, args, url }
+context.custom.react.version       = "19.0.0"
+```
+
+`context.custom` is the user-visible display namespace. Everything a consumer puts
+there via `addContext` / `addContextGroup` is rendered as context in the Flare UI.
+`minifiedError` is not context: it is plumbing for a backend decode step, and it has
+no meaning to the person reading the report. It should be a field only Flare reads.
+
+The backend has not been built against the current field yet, so there is no consumer
+to keep working. We move rather than dual-write.
+
+## Decision
+
+Emit one atomic, self-contained attribute, only when the error parses as a minified
+React error:
+
+```js
+'flare.exception.react_minified_error': {
+    number: 418,
+    args: ['Foo', 'Bar'],
+    url: 'https://react.dev/errors/418?args[]=Foo&args[]=Bar',
+    react_version: '19.0.0',
+}
+```
+
+`context.custom.react` keeps `componentStack`, `componentStackFrames` and `version`
+unchanged. Only `minifiedError` leaves it.
+
+### Why these choices
+
+**`flare.*` namespace.** Proposed by the backend. It already exists and is already
+the de facto internal namespace: `flare.language.name`, `flare.framework.name`,
+`flare.entry_point.type`. `context.*` is the display namespace. The split is
+convention, documented nowhere central, but consistent across the codebase.
+
+**One key holding an object, not a prefix of flat keys.** Every existing `flare.*`
+key is a flat dotted scalar, so this deviates. Justified: the backend gates on
+presence of the field to decide whether to decode, and an atomic key is either
+wholly present or wholly absent — no partial state to reason about. `args` is an
+array regardless, so a flat shape would not actually be flat. Nesting is safe on
+this path: `AttributeValue` is recursive (`packages/core/src/types.ts:3-5`) and the
+errors path serializes via `flatJsonStringify`, which despite its name does not
+flatten — it only decycles (`packages/core/src/util/flatJsonStringify.ts:4-6`).
+
+**Merge safety.** `assembleAttributes` (`packages/core/src/Flare.ts:495-548`) merges
+attribute sources with a _shallow_ spread. Core hand-writes a one-level deep merge
+for exactly one key, `context.custom` (`Flare.ts:521-538`), because both scope and
+integrations write to it. `flare.exception.react_minified_error` has a single
+producer — this package — so the shallow spread is correct and no deep-merge special
+case is needed. If a second producer ever writes this key, revisit.
+
+**snake_case interior.** This object is a backend-read wire contract, so it follows
+the backend-facing convention of the key it lives under, not the camelCase used by
+JS-facing payload interiors under `context.custom` (`componentStackFrames`). Only
+`react_version` is affected; `number`, `args` and `url` are single words. The
+`MinifiedReactError` type therefore needs no rename.
+
+**`react_version` bundled into the field.** The backend cannot decode `#418` from
+the number alone — it needs the React version to select the matching `codes.json`,
+since templates drift across majors. Bundling it makes the field self-sufficient:
+the backend reads one key, and the field never depends on a display value a consumer
+can strip. `context.custom.react.version` stays for UI display. The duplicated
+version string is the intended cost.
+
+## Components
+
+### 1. `types.ts`
+
+Remove `minifiedError` from `FlareReactContext`:
+
+```ts
+export type FlareReactContext = {
+    react: {
+        componentStack: string[];
+        componentStackFrames: ComponentStackFrame[];
+        version?: string;
+    };
+};
+```
+
+`MinifiedReactError` (`{ number, args, url }`) keeps its current shape and stays
+exported from `index.ts`, so existing type imports still compile.
+
+### 2. `buildReactContext.ts`
+
+Signature drops to `buildReactContext(rawStack: string)`. Drops the
+`parseMinifiedReactError` import — it no longer builds a field it does not own.
+
+```ts
+export function buildReactContext(rawStack: string): FlareReactContext {
+    return {
+        react: {
+            componentStack: formatComponentStack(rawStack),
+            componentStackFrames: parseComponentStack(rawStack),
+            version,
+        },
+    };
+}
+```
+
+### 3. `contextToAttributes.ts`
+
+```ts
+import { version } from 'react';
+
+export function contextToAttributes(context: FlareReactContext, minifiedError?: MinifiedReactError | null): Attributes {
+    return {
+        'context.custom': {
+            react: {
+                componentStack: context.react.componentStack as AttributeValue,
+                componentStackFrames: context.react.componentStackFrames as AttributeValue,
+                ...(context.react.version ? { version: context.react.version as AttributeValue } : {}),
+            },
+        },
+        ...(minifiedError
+            ? {
+                  'flare.exception.react_minified_error': {
+                      number: minifiedError.number,
+                      args: minifiedError.args,
+                      url: minifiedError.url,
+                      react_version: version,
+                  } as AttributeValue,
+              }
+            : {}),
+    };
+}
+```
+
+**`react_version` reads the `version` imported from `react`, NOT
+`context.react.version`.** This is load-bearing, not incidental. Reading it off the
+context would re-couple the internal field to a value a `beforeSubmit` hook can
+strip, which is the failure this design exists to prevent. Do not "simplify" it.
+
+When there is no minified error the key is absent entirely, not present-and-empty.
+
+### 4. Call sites
+
+`FlareErrorBoundary.componentDidCatch` and `flareReactErrorHandler` both already
+hold `error`, so nothing new is threaded through:
+
+```ts
+const context = buildReactContext(rawStack);
+
+const finalContext = beforeSubmit?.({ error, errorInfo, context }) ?? context;
+
+flare.reportSilently(error, contextToAttributes(finalContext, parseMinifiedReactError(error)));
+```
+
+## Data flow change
+
+Today the parse happens inside `buildReactContext`, _before_ `beforeSubmit`. Since
+`beforeSubmit` returns a **replacement** `FlareReactContext` and the call sites only
+fall back on an `undefined` return (`?? context`), a hook returning a fresh literal
+— a normal thing to do when scrubbing a component stack — silently drops
+`minifiedError` and silently breaks the backend decode.
+
+After this change the parse happens at the report call, _after_ `beforeSubmit`, on
+the original `error` object. The internal field cannot be dropped by a user hook,
+and `beforeSubmit` keeps full control of what it should control: the display context.
+
+No opt-out is added. Nobody has asked to suppress this field; YAGNI until they do.
+
+## Testing
+
+- `parseMinifiedReactError.test.ts` — untouched. Pure function, unchanged.
+- `buildReactContext.test.ts` — drop the two `minifiedError` tests and the `error`
+  argument. Version and component-stack tests stay.
+- `contextToAttributes.test.ts` — rework:
+    - minified error passed → `flare.exception.react_minified_error` with `number`,
+      `args`, `url` and a non-empty string `react_version`.
+    - not passed → key absent entirely.
+    - `context.custom.react` never carries `minifiedError` in either case.
+    - `react_version` is populated even when `context.react.version` is absent
+      (i.e. a `beforeSubmit` literal that omitted it) — this pins the decoupling.
+- `FlareErrorBoundary.test.tsx` and `flareReactErrorHandler.test.ts` — each has a
+  `describe('minified React errors')` block with two tests asserting against
+  `context.custom`; repoint both to the new key. Add one test per file: a
+  `beforeSubmit` returning a fresh context literal still yields
+  `flare.exception.react_minified_error` in the reported attributes. These are the
+  only tests that exercise the real hook-then-report path, so the unstrippability
+  property belongs here.
+- `e2e/specs/react-prod.spec.ts` — drives a genuine production `react-dom` invariant,
+  so it is the only test proving the field survives a real minified throw. Repoint
+  the `reactContextOf` helper from `attributes['context.custom'].react` to
+  `attributes['flare.exception.react_minified_error']`, and move the
+  `react.version` assertion onto the field's `react_version`.
+- `packages/react/README.md` — update the documented field location.
+
+## Release
+
+Lockstep minor: 2.6.0 -> 2.7.0 across `js`, `react`, `vue`, `svelte`, `webpack`,
+`vite`, `sveltekit`, `nextjs` (`scripts/release-all.mjs:41`).
+
+Removing an optional field from a public type is strictly breaking, and CLAUDE.md
+says breaking -> major. Treated as minor deliberately: the field is ~2 weeks old,
+optional, never had a backend consumer, and `MinifiedReactError` stays exported so
+type imports still compile. A major would drag seven packages with no changes of
+their own to 3.0.0 and trigger a `peerDependencies` audit across the integrations —
+disproportionate to one optional field. Call the relocation out in the release notes.
+
+## Risk
+
+The field name, interior casing and `react_version` are a cross-repo wire contract.
+The backend has not written the reader yet, so a rename now is free and a rename
+later is a coordinated release across two repos. Confirm the shape with the backend
+dev before shipping.
+
+## Out of scope
+
+- The backend `codes.json` lookup and interpolation.
+- Global `window.onerror` in `@flareapp/js` (unchanged from the 2026-06-08 design:
+  keeping React-specific regex out of the framework-agnostic core).
+- `vue` / `svelte` / `sveltekit` — no minified-error concept.
+- A general `flare.exception.*` convention or a shared `contextToAttributes` helper.
+  Four packages hand-write their own today; consolidating is not in service of this
+  change.

--- a/e2e/specs/react-prod.spec.ts
+++ b/e2e/specs/react-prod.spec.ts
@@ -7,19 +7,20 @@ import type { FakeFlareRecord } from '../fixtures/fake-flare';
 // where react-dom throws a genuine "Minified React error #NNN; visit
 // https://react.dev/errors/NNN ..." for an internal invariant.
 
-type ReactContext = {
-    version?: unknown;
-    minifiedError?: { number?: unknown; args?: unknown; url?: unknown };
+type MinifiedErrorField = {
+    number?: unknown;
+    args?: unknown;
+    url?: unknown;
+    react_version?: unknown;
 };
 
-const reactContextOf = (record: FakeFlareRecord): ReactContext | undefined => {
+const minifiedErrorOf = (record: FakeFlareRecord): MinifiedErrorField | undefined => {
     const body = record.bodyJson as { attributes?: Record<string, unknown> } | null;
-    const custom = body?.attributes?.['context.custom'] as { react?: ReactContext } | undefined;
-    return custom?.react;
+    return body?.attributes?.['flare.exception.react_minified_error'] as MinifiedErrorField | undefined;
 };
 
 test.describe('react playground (production build)', () => {
-    test('decodes a genuine minified React error into structured context', async ({ page, fakeFlare }) => {
+    test('decodes a genuine minified React error into the flare.exception field', async ({ page, fakeFlare }) => {
         await page.goto('/react-invariant');
         await page.waitForLoadState('networkidle');
 
@@ -27,11 +28,10 @@ test.describe('react playground (production build)', () => {
 
         const report = await fakeFlare.waitForReport({
             timeout: 10_000,
-            predicate: (record) => Boolean(reactContextOf(record)?.minifiedError),
+            predicate: (record) => Boolean(minifiedErrorOf(record)),
         });
 
-        const react = reactContextOf(report);
-        const minifiedError = react?.minifiedError;
+        const minifiedError = minifiedErrorOf(report);
 
         // The error originated from production react-dom, not an injected message:
         // a positive error number and the canonical react.dev errors URL.
@@ -40,9 +40,9 @@ test.describe('react playground (production build)', () => {
         expect(String(minifiedError?.url)).toMatch(/react\.dev\/errors\/\d+/);
         expect(Array.isArray(minifiedError?.args)).toBe(true);
 
-        // The running React version travels alongside so the backend can pick the
-        // matching error-code map.
-        expect(typeof react?.version).toBe('string');
-        expect(String(react?.version).length).toBeGreaterThan(0);
+        // The running React version travels inside the field so the backend can pick
+        // the matching error-code map.
+        expect(typeof minifiedError?.react_version).toBe('string');
+        expect(String(minifiedError?.react_version).length).toBeGreaterThan(0);
     });
 });

--- a/packages/react/README.md
+++ b/packages/react/README.md
@@ -44,22 +44,24 @@ flare.logger.info('Checkout started', { cartId: cart.id, total: cart.total });
 ## Minified production errors
 
 In production, React throws minified errors like `Minified React error #418; visit https://react.dev/errors/418?args[]=Foo`.
-The client parses these into structured fields and attaches them, along with the running React version, to the report
-context:
+The client parses these into a single self-contained field, `flare.exception.react_minified_error`, carrying the running
+React version alongside the parsed pieces:
 
 ```ts
-react: {
-    version: '19.0.0',
-    minifiedError: {
-        number: 418,
-        args: ['Foo', 'Bar'],
-        url: 'https://react.dev/errors/418?args[]=Foo&args[]=Bar',
-    },
+'flare.exception.react_minified_error': {
+    number: 418,
+    args: ['Foo', 'Bar'],
+    url: 'https://react.dev/errors/418?args[]=Foo&args[]=Bar',
+    react_version: '19.0.0',
 }
 ```
 
-Flare uses `react.minifiedError` and `react.version` on the backend to look up React's error-code map and surface the
-full, human-readable message. No error-code map is bundled into the client. Non-minified errors are reported unchanged.
+Flare reads this field on the backend to look up React's error-code map (keyed on `react_version`) and surface the full,
+human-readable message. It is a Flare-internal field, not part of the display context, so it is emitted only when an
+error actually parses as a minified React error and cannot be stripped by a `beforeSubmit` hook. No error-code map is
+bundled into the client. Non-minified errors are reported unchanged.
+
+`context.custom.react` continues to carry `componentStack`, `componentStackFrames` and `version` for display.
 
 ## Identifying users
 

--- a/packages/react/src/FlareErrorBoundary.ts
+++ b/packages/react/src/FlareErrorBoundary.ts
@@ -4,6 +4,7 @@ import { Component, ErrorInfo, type PropsWithChildren, type ReactNode } from 're
 import { buildReactContext } from './buildReactContext';
 import { contextToAttributes } from './contextToAttributes';
 import { tagReactFramework } from './identify';
+import { parseMinifiedReactError } from './parseMinifiedReactError';
 import { resolveFlare } from './resolveFlare';
 import { FlareReactContext } from './types';
 
@@ -58,7 +59,7 @@ export class FlareErrorBoundary extends Component<FlareErrorBoundaryProps, Flare
 
         const rawStack = errorInfo.componentStack ?? '';
 
-        const context = buildReactContext(rawStack, error);
+        const context = buildReactContext(rawStack);
 
         const finalContext =
             this.props.beforeSubmit?.({
@@ -69,9 +70,12 @@ export class FlareErrorBoundary extends Component<FlareErrorBoundaryProps, Flare
 
         this.setState({ componentStack: finalContext.react.componentStack });
 
+        // Parse the minified-error field from the ORIGINAL error, after beforeSubmit, so a hook that
+        // returns a fresh context literal cannot drop it. It is a Flare-internal decode field, not
+        // display context, so beforeSubmit has no say over it.
         // Swallow rejection from the report call. A network/transport failure in the error reporter
         // must not bubble up and cause a second render error inside the boundary itself.
-        this.flare.reportSilently(error, contextToAttributes(finalContext));
+        this.flare.reportSilently(error, contextToAttributes(finalContext, parseMinifiedReactError(error)));
 
         this.props.afterSubmit?.({
             error,

--- a/packages/react/src/FlareErrorBoundary.ts
+++ b/packages/react/src/FlareErrorBoundary.ts
@@ -70,11 +70,8 @@ export class FlareErrorBoundary extends Component<FlareErrorBoundaryProps, Flare
 
         this.setState({ componentStack: finalContext.react.componentStack });
 
-        // Parse the minified-error field from the ORIGINAL error, after beforeSubmit, so a hook that
-        // returns a fresh context literal cannot drop it. It is a Flare-internal decode field, not
-        // display context, so beforeSubmit has no say over it.
-        // Swallow rejection from the report call. A network/transport failure in the error reporter
-        // must not bubble up and cause a second render error inside the boundary itself.
+        // We build parse the minified react error after the beforeSubmit hook, because users are not allowed to mess with that data.
+        // It's an internal field of the protocol, and the backend needs it to parse the error message out of the minified error.
         this.flare.reportSilently(error, contextToAttributes(finalContext, parseMinifiedReactError(error)));
 
         this.props.afterSubmit?.({

--- a/packages/react/src/buildReactContext.ts
+++ b/packages/react/src/buildReactContext.ts
@@ -2,18 +2,14 @@ import { version } from 'react';
 
 import { formatComponentStack } from './formatComponentStack';
 import { parseComponentStack } from './parseComponentStack';
-import { parseMinifiedReactError } from './parseMinifiedReactError';
 import type { FlareReactContext } from './types';
 
-export function buildReactContext(rawStack: string, error: Error): FlareReactContext {
-    const minifiedError = parseMinifiedReactError(error);
-
+export function buildReactContext(rawStack: string): FlareReactContext {
     return {
         react: {
             componentStack: formatComponentStack(rawStack),
             componentStackFrames: parseComponentStack(rawStack),
             version,
-            ...(minifiedError ? { minifiedError } : {}),
         },
     };
 }

--- a/packages/react/src/contextToAttributes.ts
+++ b/packages/react/src/contextToAttributes.ts
@@ -12,10 +12,8 @@ export function contextToAttributes(context: FlareReactContext, minifiedError?: 
                 ...(context.react.version ? { version: context.react.version as AttributeValue } : {}),
             },
         },
-        // Flare-internal decode field, not display context. `react_version` is read from React's own
-        // `version` export, NOT context.react.version: reading it off the context would re-couple this
-        // field to a value a beforeSubmit hook can strip, which is the failure this design prevents.
-        // Do not "simplify" it back onto the context.
+        // We do not add to the custom context, but to the flare exception meta data because this is internal data and not something a user needs to see.
+        // The flare backend will parse this into a usable error message.
         ...(minifiedError
             ? {
                   'flare.exception.react_minified_error': {

--- a/packages/react/src/contextToAttributes.ts
+++ b/packages/react/src/contextToAttributes.ts
@@ -1,18 +1,30 @@
 import type { AttributeValue, Attributes } from '@flareapp/core';
+import { version } from 'react';
 
-import type { FlareReactContext } from './types';
+import type { FlareReactContext, MinifiedReactError } from './types';
 
-export function contextToAttributes(context: FlareReactContext): Attributes {
+export function contextToAttributes(context: FlareReactContext, minifiedError?: MinifiedReactError | null): Attributes {
     return {
         'context.custom': {
             react: {
                 componentStack: context.react.componentStack as AttributeValue,
                 componentStackFrames: context.react.componentStackFrames as AttributeValue,
                 ...(context.react.version ? { version: context.react.version as AttributeValue } : {}),
-                ...(context.react.minifiedError
-                    ? { minifiedError: context.react.minifiedError as AttributeValue }
-                    : {}),
             },
         },
+        // Flare-internal decode field, not display context. `react_version` is read from React's own
+        // `version` export, NOT context.react.version: reading it off the context would re-couple this
+        // field to a value a beforeSubmit hook can strip, which is the failure this design prevents.
+        // Do not "simplify" it back onto the context.
+        ...(minifiedError
+            ? {
+                  'flare.exception.react_minified_error': {
+                      number: minifiedError.number,
+                      args: minifiedError.args,
+                      url: minifiedError.url,
+                      react_version: version,
+                  } as AttributeValue,
+              }
+            : {}),
     };
 }

--- a/packages/react/src/flareReactErrorHandler.ts
+++ b/packages/react/src/flareReactErrorHandler.ts
@@ -4,6 +4,7 @@ import type { Flare } from '@flareapp/js/browser';
 import { buildReactContext } from './buildReactContext';
 import { contextToAttributes } from './contextToAttributes';
 import { tagReactFramework } from './identify';
+import { parseMinifiedReactError } from './parseMinifiedReactError';
 import { resolveFlare } from './resolveFlare';
 import { FlareReactContext } from './types';
 
@@ -37,7 +38,7 @@ export function flareReactErrorHandler(options?: FlareReactErrorHandlerOptions):
 
         const rawStack = errorInfo.componentStack ?? '';
 
-        const context = buildReactContext(rawStack, errorObject);
+        const context = buildReactContext(rawStack);
 
         const finalContext =
             options?.beforeSubmit?.({
@@ -46,8 +47,9 @@ export function flareReactErrorHandler(options?: FlareReactErrorHandlerOptions):
                 context,
             }) ?? context;
 
-        // See FlareErrorBoundary: rejection is swallowed so the reporter can't crash the host.
-        flare.reportSilently(errorObject, contextToAttributes(finalContext));
+        // See FlareErrorBoundary: parse the decode field from the original error after beforeSubmit so
+        // a fresh-literal hook can't drop it; rejection is swallowed so the reporter can't crash the host.
+        flare.reportSilently(errorObject, contextToAttributes(finalContext, parseMinifiedReactError(errorObject)));
 
         options?.afterSubmit?.({ error: errorObject, errorInfo, context: finalContext });
     };

--- a/packages/react/src/flareReactErrorHandler.ts
+++ b/packages/react/src/flareReactErrorHandler.ts
@@ -47,8 +47,8 @@ export function flareReactErrorHandler(options?: FlareReactErrorHandlerOptions):
                 context,
             }) ?? context;
 
-        // See FlareErrorBoundary: parse the decode field from the original error after beforeSubmit so
-        // a fresh-literal hook can't drop it; rejection is swallowed so the reporter can't crash the host.
+        // We build parse the minified react error after the beforeSubmit hook, because users are not allowed to mess with that data.
+        // It's an internal field of the protocol, and the backend needs it to parse the error message out of the minified error.
         flare.reportSilently(errorObject, contextToAttributes(finalContext, parseMinifiedReactError(errorObject)));
 
         options?.afterSubmit?.({ error: errorObject, errorInfo, context: finalContext });

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -16,6 +16,5 @@ export type FlareReactContext = {
         componentStack: string[];
         componentStackFrames: ComponentStackFrame[];
         version?: string;
-        minifiedError?: MinifiedReactError;
     };
 };

--- a/packages/react/tests/FlareErrorBoundary.test.tsx
+++ b/packages/react/tests/FlareErrorBoundary.test.tsx
@@ -548,7 +548,7 @@ describe('FlareErrorBoundary', () => {
     });
 
     describe('minified React errors', () => {
-        test('forwards minifiedError and version in the reported attributes', () => {
+        test('emits flare.exception.react_minified_error with react_version', () => {
             testError = new Error(
                 'Minified React error #418; visit https://react.dev/errors/418?args[]=Foo for the full message',
             );
@@ -560,17 +560,18 @@ describe('FlareErrorBoundary', () => {
             );
 
             const attributes = mockReport.mock.calls[0][1];
-            const react = (attributes['context.custom'] as any).react;
+            const field = (attributes as any)['flare.exception.react_minified_error'];
 
-            expect(react.minifiedError).toEqual({
-                number: 418,
-                args: ['Foo'],
-                url: 'https://react.dev/errors/418?args[]=Foo',
-            });
-            expect(typeof react.version).toBe('string');
+            expect(field.number).toBe(418);
+            expect(field.args).toEqual(['Foo']);
+            expect(field.url).toBe('https://react.dev/errors/418?args[]=Foo');
+            expect(typeof field.react_version).toBe('string');
+            expect(field.react_version.length).toBeGreaterThan(0);
+            // The decode field is not display context.
+            expect((attributes['context.custom'] as any).react).not.toHaveProperty('minifiedError');
         });
 
-        test('omits minifiedError for a plain error', () => {
+        test('omits the field for a plain error', () => {
             render(
                 <FlareErrorBoundary fallback={<div>Error</div>}>
                     <ThrowingComponent />
@@ -578,7 +579,37 @@ describe('FlareErrorBoundary', () => {
             );
 
             const attributes = mockReport.mock.calls[0][1];
+            expect(attributes).not.toHaveProperty('flare.exception.react_minified_error');
             expect((attributes['context.custom'] as any).react).not.toHaveProperty('minifiedError');
+        });
+
+        // The unstrippability property: a hook that returns a brand-new context object (a normal way
+        // to scrub a component stack) must NOT be able to drop the internal decode field, because it
+        // is parsed from the original error at report time, not carried inside the context.
+        test('still emits the field when beforeSubmit returns a fresh context literal that omits it', () => {
+            testError = new Error(
+                'Minified React error #418; visit https://react.dev/errors/418?args[]=Foo for the full message',
+            );
+
+            const beforeSubmit = vi.fn(({ context }: { context: FlareReactContext }) => ({
+                react: {
+                    componentStack: [],
+                    componentStackFrames: [],
+                    version: context.react.version,
+                },
+            }));
+
+            render(
+                <FlareErrorBoundary fallback={<div>Error</div>} beforeSubmit={beforeSubmit}>
+                    <ThrowingComponent />
+                </FlareErrorBoundary>,
+            );
+
+            const attributes = mockReport.mock.calls[0][1];
+            const field = (attributes as any)['flare.exception.react_minified_error'];
+
+            expect(field.number).toBe(418);
+            expect(typeof field.react_version).toBe('string');
         });
     });
 });

--- a/packages/react/tests/buildReactContext.test.ts
+++ b/packages/react/tests/buildReactContext.test.ts
@@ -7,37 +7,17 @@ const stack = '\n    at App (http://localhost:5173/src/App.tsx:5:3)\n';
 
 describe('buildReactContext', () => {
     test('includes the React version on every context', () => {
-        const context = buildReactContext(stack, new Error('plain error'));
+        const context = buildReactContext(stack);
 
         expect(context.react.version).toBe(reactVersion);
     });
 
     test('parses component stack into componentStack and componentStackFrames', () => {
-        const context = buildReactContext(stack, new Error('plain error'));
+        const context = buildReactContext(stack);
 
         expect(context.react.componentStack).toEqual(['at App (http://localhost:5173/src/App.tsx:5:3)']);
         expect(context.react.componentStackFrames).toEqual([
             { component: 'App', file: 'http://localhost:5173/src/App.tsx', line: 5, column: 3 },
         ]);
-    });
-
-    test('omits minifiedError for a plain error', () => {
-        const context = buildReactContext(stack, new Error('plain error'));
-
-        expect(context.react.minifiedError).toBeUndefined();
-    });
-
-    test('attaches minifiedError for a minified React error', () => {
-        const error = new Error(
-            'Minified React error #418; visit https://react.dev/errors/418?args[]=Foo for the full message',
-        );
-
-        const context = buildReactContext(stack, error);
-
-        expect(context.react.minifiedError).toEqual({
-            number: 418,
-            args: ['Foo'],
-            url: 'https://react.dev/errors/418?args[]=Foo',
-        });
     });
 });

--- a/packages/react/tests/contextToAttributes.test.ts
+++ b/packages/react/tests/contextToAttributes.test.ts
@@ -1,7 +1,8 @@
+import { version as reactVersion } from 'react';
 import { describe, expect, test } from 'vitest';
 
 import { contextToAttributes } from '../src/contextToAttributes';
-import { FlareReactContext } from '../src/types';
+import { FlareReactContext, MinifiedReactError } from '../src/types';
 
 describe('contextToAttributes', () => {
     test('wraps react context (with version) under context.custom', () => {
@@ -26,39 +27,6 @@ describe('contextToAttributes', () => {
         });
     });
 
-    test('forwards minifiedError when present', () => {
-        const context: FlareReactContext = {
-            react: {
-                componentStack: [],
-                componentStackFrames: [],
-                version: '19.0.0',
-                minifiedError: { number: 418, args: ['Foo'], url: 'https://react.dev/errors/418?args[]=Foo' },
-            },
-        };
-
-        const attributes = contextToAttributes(context);
-
-        expect((attributes['context.custom'] as any).react.minifiedError).toEqual({
-            number: 418,
-            args: ['Foo'],
-            url: 'https://react.dev/errors/418?args[]=Foo',
-        });
-    });
-
-    test('omits minifiedError when absent', () => {
-        const context: FlareReactContext = {
-            react: {
-                componentStack: [],
-                componentStackFrames: [],
-                version: '19.0.0',
-            },
-        };
-
-        const attributes = contextToAttributes(context);
-
-        expect((attributes['context.custom'] as any).react).not.toHaveProperty('minifiedError');
-    });
-
     test('omits version when a context has none (e.g. a beforeSubmit literal)', () => {
         const context: FlareReactContext = {
             react: {
@@ -69,6 +37,68 @@ describe('contextToAttributes', () => {
 
         const attributes = contextToAttributes(context);
 
+        expect((attributes['context.custom'] as any).react).not.toHaveProperty('version');
+    });
+
+    test('emits flare.exception.react_minified_error when a minified error is passed', () => {
+        const context: FlareReactContext = {
+            react: { componentStack: [], componentStackFrames: [], version: '19.0.0' },
+        };
+        const minifiedError: MinifiedReactError = {
+            number: 418,
+            args: ['Foo'],
+            url: 'https://react.dev/errors/418?args[]=Foo',
+        };
+
+        const attributes = contextToAttributes(context, minifiedError);
+        const field = attributes['flare.exception.react_minified_error'] as any;
+
+        expect(field.number).toBe(418);
+        expect(field.args).toEqual(['Foo']);
+        expect(field.url).toBe('https://react.dev/errors/418?args[]=Foo');
+        expect(typeof field.react_version).toBe('string');
+        expect(field.react_version.length).toBeGreaterThan(0);
+    });
+
+    test('omits the flare.exception.react_minified_error key entirely when no minified error is passed', () => {
+        const context: FlareReactContext = {
+            react: { componentStack: [], componentStackFrames: [], version: '19.0.0' },
+        };
+
+        const attributes = contextToAttributes(context);
+
+        expect(attributes).not.toHaveProperty('flare.exception.react_minified_error');
+    });
+
+    test('never carries minifiedError inside context.custom.react', () => {
+        const context: FlareReactContext = {
+            react: { componentStack: [], componentStackFrames: [], version: '19.0.0' },
+        };
+        const minifiedError: MinifiedReactError = {
+            number: 418,
+            args: ['Foo'],
+            url: 'https://react.dev/errors/418?args[]=Foo',
+        };
+
+        const withError = contextToAttributes(context, minifiedError);
+        const withoutError = contextToAttributes(context);
+
+        expect((withError['context.custom'] as any).react).not.toHaveProperty('minifiedError');
+        expect((withoutError['context.custom'] as any).react).not.toHaveProperty('minifiedError');
+    });
+
+    test('populates react_version even when the context carries no version', () => {
+        // A beforeSubmit hook that returns a fresh literal can drop context.react.version.
+        // react_version must NOT depend on it: it is read from React's own version export.
+        const context: FlareReactContext = {
+            react: { componentStack: [], componentStackFrames: [] },
+        };
+        const minifiedError: MinifiedReactError = { number: 418, args: [], url: null };
+
+        const attributes = contextToAttributes(context, minifiedError);
+        const field = attributes['flare.exception.react_minified_error'] as any;
+
+        expect(field.react_version).toBe(reactVersion);
         expect((attributes['context.custom'] as any).react).not.toHaveProperty('version');
     });
 });

--- a/packages/react/tests/flareReactErrorHandler.test.ts
+++ b/packages/react/tests/flareReactErrorHandler.test.ts
@@ -361,7 +361,7 @@ describe('flareReactErrorHandler', () => {
     });
 
     describe('minified React errors', () => {
-        test('forwards minifiedError and version in the reported attributes', () => {
+        test('emits flare.exception.react_minified_error with react_version', () => {
             const handler = flareReactErrorHandler();
             const error = new Error(
                 'Minified React error #418; visit https://react.dev/errors/418?args[]=Foo for the full message',
@@ -370,23 +370,50 @@ describe('flareReactErrorHandler', () => {
             handler(error, { componentStack: '    at App' });
 
             const attributes = mockReport.mock.calls[0][1];
-            const react = (attributes['context.custom'] as any).react;
+            const field = (attributes as any)['flare.exception.react_minified_error'];
 
-            expect(react.minifiedError).toEqual({
-                number: 418,
-                args: ['Foo'],
-                url: 'https://react.dev/errors/418?args[]=Foo',
-            });
-            expect(typeof react.version).toBe('string');
+            expect(field.number).toBe(418);
+            expect(field.args).toEqual(['Foo']);
+            expect(field.url).toBe('https://react.dev/errors/418?args[]=Foo');
+            expect(typeof field.react_version).toBe('string');
+            expect(field.react_version.length).toBeGreaterThan(0);
+            // The decode field is not display context.
+            expect((attributes['context.custom'] as any).react).not.toHaveProperty('minifiedError');
         });
 
-        test('omits minifiedError for a plain error', () => {
+        test('omits the field for a plain error', () => {
             const handler = flareReactErrorHandler();
 
             handler(new Error('plain error'), { componentStack: '    at App' });
 
             const attributes = mockReport.mock.calls[0][1];
+            expect(attributes).not.toHaveProperty('flare.exception.react_minified_error');
             expect((attributes['context.custom'] as any).react).not.toHaveProperty('minifiedError');
+        });
+
+        // See FlareErrorBoundary: a hook returning a fresh context literal must not be able to drop
+        // the internal decode field, since it is parsed from the original error at report time.
+        test('still emits the field when beforeSubmit returns a fresh context literal that omits it', () => {
+            const handler = flareReactErrorHandler({
+                beforeSubmit: ({ context }) => ({
+                    react: {
+                        componentStack: [],
+                        componentStackFrames: [],
+                        version: context.react.version,
+                    },
+                }),
+            });
+            const error = new Error(
+                'Minified React error #418; visit https://react.dev/errors/418?args[]=Foo for the full message',
+            );
+
+            handler(error, { componentStack: '    at App' });
+
+            const attributes = mockReport.mock.calls[0][1];
+            const field = (attributes as any)['flare.exception.react_minified_error'];
+
+            expect(field.number).toBe(418);
+            expect(typeof field.react_version).toBe('string');
         });
     });
 


### PR DESCRIPTION
Implements `docs/superpowers/specs/2026-07-17-react-minified-error-flare-field-design.md`.

## What and why

The decoded production React error used to be reported at `context.custom.react.minifiedError`, inside the user-visible display namespace. It is not display context: it is plumbing for a backend decode step. This moves it to a single Flare-internal field:

```
flare.exception.react_minified_error = { number, args, url, react_version }
```

emitted only when an error actually parses as a minified React error.

Two properties fall out of doing this correctly:

- **Unstrippable.** The field is now parsed at the report call, after `beforeSubmit`, from the original error, not carried inside `FlareReactContext`. A hook that returns a fresh context literal (a normal way to scrub a component stack) can no longer silently drop it.
- **`react_version` is decoupled.** It is read from React's own `version` export, not `context.react.version`, so a hook stripping the display version cannot break the backend's code-map lookup. This is marked load-bearing in the source, since it looks like collapsible duplication.

`context.custom.react` keeps `componentStack`, `componentStackFrames` and `version` for display. `MinifiedReactError` stays exported, so type imports still compile.

## Files

- `types.ts`, `buildReactContext.ts`, `contextToAttributes.ts`, `FlareErrorBoundary.ts`, `flareReactErrorHandler.ts` (Components 1-4 of the spec)
- Tests reworked to the new key, plus a new unstrippability test in each call-site suite
- `e2e/specs/react-prod.spec.ts` repointed to the new field
- `packages/react/README.md` updated

`parseMinifiedReactError.ts` is untouched.

## Verification

- `npm run typescript`, `npm run lint`, `npm run build`, `npm run test`: all pass
- `npm run test:e2e:prod`: passes. A genuine production react-dom minified invariant decodes into `flare.exception.react_minified_error` with a populated `react_version`.

## Reviewer note: versioning

Removing the optional `minifiedError` field from the exported `FlareReactContext` type is technically breaking. The spec deliberately ships this as a lockstep **minor** (2.6.0 -> 2.7.0), not major: the field is ~2 weeks old, optional, has no backend consumer yet, and `MinifiedReactError` stays exported. This contradicts the repo's usual "breaking -> major" rule, so it is a conscious exception to confirm. No version bumps are in this PR; the release is a separate step.